### PR TITLE
First pass at Webpack manifest support for JS/CSS output bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # master
 
+# 0.10.1 / 2020-04-18
+
+Add `{% webpack_path [js|css] }` tag which pulls in the Webpack manifest and finds
+the hashed output bundles. Also works in concert with the Watcher so every time
+Webpack rebuilds the bundles, Bridgetown regenerates the site.
+
+[#6](https://github.com/bridgetownrb/bridgetown/pull/6)
+
 # 0.10.0 / 2020-04-17
 
 **Switch gears on _experimental_ component functionality.**

--- a/bridgetown-core/features/step_definitions.rb
+++ b/bridgetown-core/features/step_definitions.rb
@@ -107,7 +107,7 @@ end
 
 #
 
-Given(%r!^I have an? (.*) directory$!) do |dir|
+Given(%r!^I have an? \"?(.*?)\"? directory$!) do |dir|
   unless Paths.root_files.include?(dir)
     dir_in_src = File.join("src", dir)
     unless File.directory?(dir_in_src)

--- a/bridgetown-core/features/support/helpers.rb
+++ b/bridgetown-core/features/support/helpers.rb
@@ -18,7 +18,15 @@ class Paths
 
   def self.source_dir; SOURCE_DIR; end
 
-  def self.root_files; ["bridgetown.config.yml", "plugins", "frontend"]; end
+  def self.root_files
+    [
+      ".bridgetown-webpack",
+      ".bridgetown-webpack/manifest.json",
+      "bridgetown.config.yml",
+      "plugins",
+      "frontend"
+    ]
+  end
 end
 
 #

--- a/bridgetown-core/features/webpack_path_tag.feature
+++ b/bridgetown-core/features/webpack_path_tag.feature
@@ -1,0 +1,77 @@
+Feature: WebpackPath Tag
+  As a web developer who likes managing frontend assets with Webpack
+  I want to be able to easily link JS and CSS output bundles using manifest.json
+  So browsers don't use cached, out-of-date bundles
+
+  Scenario: Use Webpack manifest
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="{% webpack_path css %}" />
+      <script src="{% webpack_path js %}" defer></script>
+      </head>
+      <body>
+      {{ content }}
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    And I have a ".bridgetown-webpack" directory
+    And I have a ".bridgetown-webpack/manifest.json" file with content:
+    """
+    {
+      "main.js": "all.hashgoeshere.js",
+      "main.css": "all.hashgoeshere.css"
+    }
+    """
+    When I run bridgetown build
+    Then the "output/index.html" file should exist
+    And I should see "/_bridgetown/static/js/all.hashgoeshere.js" in "output/index.html"
+    And I should not see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+
+  Scenario: Missing Webpack manifest
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="{% webpack_path css %}" />
+      <script src="{% webpack_path js %}" defer></script>
+      </head>
+      <body>
+      {{ content }}
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    When I run bridgetown build
+    Then the "output/index.html" file should exist
+    And I should see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+
+  Scenario: Missing Webpack manifest
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="{% webpack_path bad %}" />
+      </head>
+      <body>
+      {{ content }}
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    And I have a ".bridgetown-webpack" directory
+    And I have a ".bridgetown-webpack/manifest.json" file with content:
+    """
+    {
+      "main.js": "all.hashgoeshere.js",
+      "main.css": "all.hashgoeshere.css"
+    }
+    """
+    When I run bridgetown build
+    Then the "output/index.html" file should not exist
+    And I should see "Liquid Exception" in the build output

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Tags
+    class WebpackPath < Liquid::Tag
+      include Bridgetown::Filters::URLFilters
+
+      class << self
+        def tag_name
+          name.split("::").last.downcase
+        end
+      end
+
+      def initialize(tag_name, asset_type, tokens)
+        super
+
+        # js or css
+        @asset_type = asset_type.strip
+      end
+
+      def render(context)
+        @context = context
+        site = context.registers[:site]
+
+        frontend_path = relative_url("_bridgetown/static")
+
+        manifest_file = site.in_root_dir(".bridgetown-webpack", "manifest.json")
+        if File.exist?(manifest_file)
+          manifest = JSON.parse(File.read(manifest_file))
+          if @asset_type == "js"
+            js_path = manifest["main.js"].split("/").last
+            [frontend_path, "js", js_path].join("/")
+          elsif @asset_type == "css"
+            css_path = manifest["main.css"].split("/").last
+            [frontend_path, "css", css_path].join("/")
+          else
+            Bridgtown.logger.error("Unknown Webpack asset type", @asset_type)
+            nil
+          end
+        else
+          "MISSING_WEBPACK_MANIFEST"
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag(Bridgetown::Tags::WebpackPath.tag_name, Bridgetown::Tags::WebpackPath)

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -5,12 +5,6 @@ module Bridgetown
     class WebpackPath < Liquid::Tag
       include Bridgetown::Filters::URLFilters
 
-      class << self
-        def tag_name
-          name.split("::").last.downcase
-        end
-      end
-
       def initialize(tag_name, asset_type, tokens)
         super
 
@@ -34,7 +28,7 @@ module Bridgetown
             css_path = manifest["main.css"].split("/").last
             [frontend_path, "css", css_path].join("/")
           else
-            Bridgtown.logger.error("Unknown Webpack asset type", @asset_type)
+            Bridgetown.logger.error("Unknown Webpack asset type", @asset_type)
             nil
           end
         else
@@ -45,4 +39,4 @@ module Bridgetown
   end
 end
 
-Liquid::Template.register_tag(Bridgetown::Tags::WebpackPath.tag_name, Bridgetown::Tags::WebpackPath)
+Liquid::Template.register_tag("webpack_path", Bridgetown::Tags::WebpackPath)

--- a/bridgetown-core/lib/bridgetown-core/version.rb
+++ b/bridgetown-core/lib/bridgetown-core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bridgetown
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/bridgetown-core/lib/bridgetown-core/watcher.rb
+++ b/bridgetown-core/lib/bridgetown-core/watcher.rb
@@ -37,8 +37,11 @@ module Bridgetown
     private
 
     def build_listener(site, options)
+      webpack_path = site.in_root_dir(".bridgetown-webpack")
+      FileUtils.mkdir(webpack_path) unless Dir.exist?(webpack_path)
       Listen.to(
         options["source"],
+        site.in_root_dir(".bridgetown-webpack"),
         ignore: listen_ignore_paths(options),
         force_polling: options["force_polling"],
         &listen_handler(site)
@@ -54,7 +57,7 @@ module Bridgetown
         Bridgetown.logger.info "Regenerating…"
         Bridgetown.logger.info "", "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
 
-        c.each { |path| Bridgetown.logger.info "", path["#{site.source}/".length..-1] }
+        c.each { |path| Bridgetown.logger.info "", path["#{site.root_dir}/".length..-1] }
         process(site, t)
       end
     end

--- a/bridgetown-core/lib/site_template/.gitignore
+++ b/bridgetown-core/lib/site_template/.gitignore
@@ -3,4 +3,5 @@ node_modules
 .sass-cache
 .bridgetown-cache
 .bridgetown-metadata
+.bridgetown-webpack
 vendor

--- a/bridgetown-core/lib/site_template/package.json
+++ b/bridgetown-core/lib/site_template/package.json
@@ -19,6 +19,7 @@
     "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
     "webpack": "^4.42.1",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "webpack-manifest-plugin": "^2.2.0"
   }
 }

--- a/bridgetown-core/lib/site_template/src/_includes/head.html
+++ b/bridgetown-core/lib/site_template/src/_includes/head.html
@@ -5,5 +5,5 @@
 
 <meta name="description" content="{{ site.metadata.description }}" />
 
-<link rel="stylesheet" href="{% webpackpath css %}" />
-<script src="{% webpackpath js %}" defer></script>
+<link rel="stylesheet" href="{% webpack_path css %}" />
+<script src="{% webpack_path js %}" defer></script>

--- a/bridgetown-core/lib/site_template/src/_includes/head.html
+++ b/bridgetown-core/lib/site_template/src/_includes/head.html
@@ -5,5 +5,5 @@
 
 <meta name="description" content="{{ site.metadata.description }}" />
 
-<link rel="stylesheet" href="/_bridgetown/static/css/all.css{% if bridgetown.environment == 'development' %}?{{ site.time | date: '%I%M%s' }}{% endif %}" />
-<script src="/_bridgetown/static/js/all.js{% if bridgetown.environment == 'development' %}?{{ site.time | date: '%I%M%s' }}{% endif %}"></script>
+<link rel="stylesheet" href="{% webpackpath css %}" />
+<script src="{% webpackpath js %}" defer></script>

--- a/bridgetown-core/lib/site_template/webpack.config.js
+++ b/bridgetown-core/lib/site_template/webpack.config.js
@@ -1,19 +1,30 @@
-const path = require('path');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require("path")
+const MiniCssExtractPlugin = require("mini-css-extract-plugin")
+const ManifestPlugin = require("webpack-manifest-plugin")
 
 module.exports = {
-  entry: './frontend/javascript/index.js',
+  entry: "./frontend/javascript/index.js",
   devtool: "source-map",
+  // Set some or all of these to true if you want more verbose logging:
+  stats: {
+    modules: false,
+    builtAt: false,
+    timings: false,
+    children: false
+  },
   output: {
-    path: path.resolve(__dirname, 'output', '_bridgetown', 'static', 'js'),
-    filename: 'all.js'
+    path: path.resolve(__dirname, "output", "_bridgetown", "static", "js"),
+    filename: "all.[contenthash].js"
   },
   resolve: {
-    extensions: ['.js']
+    extensions: [".js"]
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "../css/all.css",
+      filename: "../css/all.[contenthash].css",
+    }),
+    new ManifestPlugin({
+      fileName: path.resolve(__dirname, ".bridgetown-webpack", "manifest.json")
     })
   ],
   module: {
@@ -21,13 +32,13 @@ module.exports = {
       {
         test: /\.js/,
         use: {
-          loader: 'babel-loader',
+          loader: "babel-loader",
           options: {
             presets: [
-              '@babel/preset-env'
+              "@babel/preset-env"
             ],
             plugins: [
-              '@babel/plugin-proposal-class-properties'
+              "@babel/plugin-proposal-class-properties"
             ]
           }
         }
@@ -36,12 +47,12 @@ module.exports = {
         test: /\.(sc|c)ss$/,
         use: [
           MiniCssExtractPlugin.loader,
-          'css-loader',
+          "css-loader",
           {
-            loader: 'sass-loader',
+            loader: "sass-loader",
             options: {
               sassOptions: {
-                includePaths: [path.resolve(__dirname, 'src/_includes')]
+                includePaths: [path.resolve(__dirname, "src/_includes")]
               }
             }
           }
@@ -49,12 +60,12 @@ module.exports = {
       },
       {
         test: /\.woff2?$|\.ttf$|\.eot$|\.svg$/,
-        loader: 'file-loader',
+        loader: "file-loader",
         options: {
-          outputPath: '../fonts',
-          publicPath: '../fonts'
+          outputPath: "../fonts",
+          publicPath: "../fonts"
         },
       }
     ]
   }
-};
+}

--- a/bridgetown-website/.gitignore
+++ b/bridgetown-website/.gitignore
@@ -3,4 +3,5 @@ node_modules
 .sass-cache
 .bridgetown-cache
 .bridgetown-metadata
+.bridgetown-webpack
 vendor

--- a/bridgetown-website/frontend/fonts/inter.css
+++ b/bridgetown-website/frontend/fonts/inter.css
@@ -1,3 +1,6 @@
+/* Commenting out the weights we're not using: */
+
+/*
 @font-face {
   font-family: 'Inter';
   font-style:  normal;
@@ -48,6 +51,7 @@
   src: url("inter-web/Inter-LightItalic.woff2?v=3.12") format("woff2"),
        url("inter-web/Inter-LightItalic.woff?v=3.12") format("woff");
 }
+*/
 
 @font-face {
   font-family: 'Inter';
@@ -83,6 +87,7 @@
        url("inter-web/Inter-MediumItalic.woff?v=3.12") format("woff");
 }
 
+/*
 @font-face {
   font-family: 'Inter';
   font-style:  normal;
@@ -99,6 +104,7 @@
   src: url("inter-web/Inter-SemiBoldItalic.woff2?v=3.12") format("woff2"),
        url("inter-web/Inter-SemiBoldItalic.woff?v=3.12") format("woff");
 }
+*/
 
 @font-face {
   font-family: 'Inter';
@@ -117,6 +123,7 @@
        url("inter-web/Inter-BoldItalic.woff?v=3.12") format("woff");
 }
 
+/*
 @font-face {
   font-family: 'Inter';
   font-style:  normal;
@@ -133,6 +140,7 @@
   src: url("inter-web/Inter-ExtraBoldItalic.woff2?v=3.12") format("woff2"),
        url("inter-web/Inter-ExtraBoldItalic.woff?v=3.12") format("woff");
 }
+*/
 
 @font-face {
   font-family: 'Inter';
@@ -160,6 +168,7 @@ Usage:
     html { font-family: 'Inter var', sans-serif; }
   }
 */
+/*
 @font-face {
   font-family: 'Inter var';
   font-weight: 100 900;
@@ -176,7 +185,7 @@ Usage:
   font-named-instance: 'Italic';
   src: url("inter-web/Inter-italic.var.woff2?v=3.12") format("woff2");
 }
-
+*/
 
 /* --------------------------------------------------------------------------
 [EXPERIMENTAL] Multi-axis, single variable font.
@@ -191,6 +200,7 @@ explicitly, e.g.
   .italic { font-variation-settings: "slnt" 10deg }
 
 */
+/*
 @font-face {
   font-family: 'Inter var experimental';
   font-weight: 100 900;
@@ -198,3 +208,4 @@ explicitly, e.g.
   font-style: oblique 0deg 10deg;
   src: url("inter-web/Inter.var.woff2?v=3.12") format("woff2");
 }
+*/

--- a/bridgetown-website/frontend/javascript/index.js
+++ b/bridgetown-website/frontend/javascript/index.js
@@ -54,4 +54,3 @@ document.addEventListener('DOMContentLoaded', () => {
   swup.preloadPage('/about/')
   swup.preloadPage('/blog/') */
 })
-//console.info("Bridgetown is loaded!")

--- a/bridgetown-website/package.json
+++ b/bridgetown-website/package.json
@@ -19,7 +19,8 @@
     "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
     "webpack": "^4.42.1",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "webpack-manifest-plugin": "^2.2.0"
   },
   "dependencies": {
     "@swup/body-class-plugin": "^1.0.2",

--- a/bridgetown-website/src/_includes/head.html
+++ b/bridgetown-website/src/_includes/head.html
@@ -9,10 +9,10 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 
-<link rel="preload" href="/_bridgetown/static/css/all.css" as="style" />
+<link rel="preload" href="{% webpackpath css %}" as="style" />
 <link rel="prefetch" href="/docs/" />
 <link rel="prefetch" href="/docs/jamstack/" />
 <link rel="prefetch" href="/about/" />
 
-<link rel="stylesheet" href="/_bridgetown/static/css/all.css{% if bridgetown.environment == 'development' %}?{{ site.time | date: '%I%M%s' }}{% endif %}" />
-<script src="/_bridgetown/static/js/all.js{% if bridgetown.environment == 'development' %}?{{ site.time | date: '%I%M%s' }}{% endif %}" defer></script>
+<link rel="stylesheet" href="{% webpackpath css %}" />
+<script src="{% webpackpath js %}" defer></script>

--- a/bridgetown-website/src/_includes/head.html
+++ b/bridgetown-website/src/_includes/head.html
@@ -9,10 +9,10 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 
-<link rel="preload" href="{% webpackpath css %}" as="style" />
+<link rel="preload" href="{% webpack_path css %}" as="style" />
 <link rel="prefetch" href="/docs/" />
 <link rel="prefetch" href="/docs/jamstack/" />
 <link rel="prefetch" href="/about/" />
 
-<link rel="stylesheet" href="{% webpackpath css %}" />
-<script src="{% webpackpath js %}" defer></script>
+<link rel="stylesheet" href="{% webpack_path css %}" />
+<script src="{% webpack_path js %}" defer></script>

--- a/bridgetown-website/webpack.config.js
+++ b/bridgetown-website/webpack.config.js
@@ -1,19 +1,30 @@
-const path = require('path');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require("path")
+const MiniCssExtractPlugin = require("mini-css-extract-plugin")
+const ManifestPlugin = require("webpack-manifest-plugin")
 
 module.exports = {
-  entry: './frontend/javascript/index.js',
+  entry: "./frontend/javascript/index.js",
   devtool: "source-map",
+  // Set some or all of these to true if you want more verbose logging:
+  stats: {
+    modules: false,
+    builtAt: false,
+    timings: false,
+    children: false
+  },
   output: {
-    path: path.resolve(__dirname, 'output', '_bridgetown', 'static', 'js'),
-    filename: 'all.js'
+    path: path.resolve(__dirname, "output", "_bridgetown", "static", "js"),
+    filename: "all.[contenthash].js"
   },
   resolve: {
-    extensions: ['.js']
+    extensions: [".js"]
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "../css/all.css",
+      filename: "../css/all.[contenthash].css",
+    }),
+    new ManifestPlugin({
+      fileName: path.resolve(__dirname, ".bridgetown-webpack", "manifest.json")
     })
   ],
   module: {
@@ -21,13 +32,13 @@ module.exports = {
       {
         test: /\.js/,
         use: {
-          loader: 'babel-loader',
+          loader: "babel-loader",
           options: {
             presets: [
-              '@babel/preset-env'
+              "@babel/preset-env"
             ],
             plugins: [
-              '@babel/plugin-proposal-class-properties'
+              "@babel/plugin-proposal-class-properties"
             ]
           }
         }
@@ -36,12 +47,12 @@ module.exports = {
         test: /\.(sc|c)ss$/,
         use: [
           MiniCssExtractPlugin.loader,
-          'css-loader',
+          "css-loader",
           {
-            loader: 'sass-loader',
+            loader: "sass-loader",
             options: {
               sassOptions: {
-                includePaths: [path.resolve(__dirname, 'src/_includes')]
+                includePaths: [path.resolve(__dirname, "src/_includes")]
               }
             }
           }
@@ -49,12 +60,12 @@ module.exports = {
       },
       {
         test: /\.woff2?$|\.ttf$|\.eot$|\.svg$/,
-        loader: 'file-loader',
+        loader: "file-loader",
         options: {
-          outputPath: '../fonts',
-          publicPath: '../fonts'
+          outputPath: "../fonts",
+          publicPath: "../fonts"
         },
       }
     ]
   }
-};
+}

--- a/bridgetown-website/yarn.lock
+++ b/bridgetown-website/yarn.lock
@@ -1747,7 +1747,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1907,6 +1907,32 @@ error-ex@^1.2.0:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
+  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.5"
+    is-regex "^1.0.5"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.1"
+    string.prototype.trimright "^2.1.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2154,6 +2180,15 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -2322,7 +2357,7 @@ globule@^1.0.0:
     lodash "~4.17.12"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -2352,7 +2387,7 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbols@^1.0.0:
+has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -2392,6 +2427,13 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -2577,6 +2619,11 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-callable@^1.1.4, is-callable@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
+  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2590,6 +2637,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2676,10 +2728,24 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-regex@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+  dependencies:
+    has "^1.0.3"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2786,6 +2852,13 @@ json5@^2.1.2:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2906,7 +2979,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15, lodash@~4.17.12:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15, lodash@~4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3339,7 +3412,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -3360,6 +3438,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.entries@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
+  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -4396,6 +4484,40 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string.prototype.trimend@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+string.prototype.trimleft@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
+  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    string.prototype.trimstart "^1.0.0"
+
+string.prototype.trimright@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
+  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    string.prototype.trimend "^1.0.0"
+
+string.prototype.trimstart@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
 string_decoder@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -4672,6 +4794,11 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -4786,6 +4913,16 @@ webpack-cli@^3.3.11:
     supports-color "6.1.0"
     v8-compile-cache "2.0.3"
     yargs "13.2.4"
+
+webpack-manifest-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16"
+  integrity sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    object.entries "^1.1.0"
+    tapable "^1.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"


### PR DESCRIPTION
This PR adds new Liquid tags for use in the HTML head to load the hashed output files from the Webpack bundler. So now you can simply add:

```html
<link rel="stylesheet" href="{% webpack_path css %}" />
<script src="{% webpack_path js %}" defer></script>
```

And the tag will open the manifest saved in `.bridgetown-webpack/manifest.json` and locate the proper hashed asset (aka `/_bridgetown/static/css/all.1e4140d3a350deac0198.css`).