### PR TITLE
Update sass-loader webpack config to support .sass

### DIFF
--- a/bridgetown-core/lib/site_template/webpack.config.js
+++ b/bridgetown-core/lib/site_template/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
         }
       },
       {
-        test: /\.(sc|c)ss$/,
+        test: /\.(s[ac]|c)ss$/,
         use: [
           MiniCssExtractPlugin.loader,
           "css-loader",


### PR DESCRIPTION
I may be _completely_ crazy, but I like the indented form of sass and the `.sass` file extension.

This little tweak (ripped from the [sass-loader readme](https://github.com/webpack-contrib/sass-loader)) makes it so webpack supports both out of the box.