### PR TITLE
Add a git init step to bridgetown new command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Lint/RaiseException:
   Enabled: true
 Lint/StructNewOverride:
   Enabled: true
+Lint/SuppressedException:
+  Exclude:
+    - bridgetown-core/lib/bridgetown-core/commands/new.rb
 Lint/UnreachableCode:
   Severity: error
 Lint/Void:

--- a/bridgetown-core/features/post_excerpts.feature
+++ b/bridgetown-core/features/post_excerpts.feature
@@ -108,7 +108,7 @@ Feature: Post excerpts
     Then I should get a zero exit status
     And I should not see "Kramdown warning" in the build output
     But I should see exactly "<p>Install Bridgetown</p>" in "output/just-text-excerpt.html"
-    And I should see "<p>Alpha <sup id=\"fnref:1\"><a href=\"#fn:1\" class=\"footnote\">1</a></sup></p>" in "output/text-and-footnote.html"
-    And I should see "<p>Omega sigma <a href=\"#fnref:1\" class=\"reversefootnote\">&#8617;</a></p>" in "output/text-and-footnote.html"
+    And I should see "<p>Alpha <sup id=\"fnref:1\" role=\"doc-noteref\"><a href=\"#fn:1\" class=\"footnote\">1</a></sup></p>" in "output/text-and-footnote.html"
+    And I should see "<p>Omega sigma <a href=\"#fnref:1\" class=\"reversefootnote\" role=\"doc-backlink\">&#8617;</a></p>" in "output/text-and-footnote.html"
     And I should see "<p>Read <a href=\"docs.bridgetown.com\">docs</a></p>" in "output/text-and-reference-link.html"
     And I should see "<p>Check out <a href=\"bridgetownrb.com\">bridgetown</a></p>" in "output/text-and-self-refencing-link.html"

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -151,15 +151,13 @@ module Bridgetown
         end
 
         def git_init(path)
-          begin
-            Dir.chdir(path) do
-              process, output = Bridgetown::Utils::Exec.run("git", "init")
-              output.to_s.each_line do |line|
-                Bridgetown.logger.info("Git:".green, line.strip) unless line.to_s.empty?
-              end
+          Dir.chdir(path) do
+            _process, output = Bridgetown::Utils::Exec.run("git", "init")
+            output.to_s.each_line do |line|
+              Bridgetown.logger.info("Git:".green, line.strip) unless line.to_s.empty?
             end
-          rescue SystemCallError
           end
+        rescue SystemCallError
         end
       end
     end

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -33,6 +33,8 @@ module Bridgetown
                       "try again with `--force` to proceed and overwrite any files."
           end
 
+          Bridgetown.logger.info("Creating:".green, new_site_path)
+
           create_site new_site_path
 
           after_install(new_site_path, args.join(" "), options)
@@ -121,7 +123,9 @@ module Bridgetown
             end
           end
 
-          Bridgetown.logger.info "Success! 🎉 Your new Bridgetown site was" \
+          git_init path
+
+          Bridgetown.logger.info "Success!".green, "🎉 Your new Bridgetown site was" \
                                   " generated in #{cli_path.cyan}."
           Bridgetown.logger.info "Execute cd #{cli_path.cyan} to get started."
           Bridgetown.logger.info "You'll probably also want to #{"yarn install".cyan}" \
@@ -143,6 +147,18 @@ module Bridgetown
             end
 
             raise SystemExit unless process.success?
+          end
+        end
+
+        def git_init(path)
+          begin
+            Dir.chdir(path) do
+              process, output = Bridgetown::Utils::Exec.run("git", "init")
+              output.to_s.each_line do |line|
+                Bridgetown.logger.info("Git:".green, line.strip) unless line.to_s.empty?
+              end
+            end
+          rescue SystemCallError
           end
         end
       end

--- a/bridgetown-core/lib/site_template/.gitignore
+++ b/bridgetown-core/lib/site_template/.gitignore
@@ -1,7 +1,35 @@
+# Bridgetown
 output
-node_modules
-.sass-cache
 .bridgetown-cache
 .bridgetown-metadata
 .bridgetown-webpack
+
+# Dependency folders
+node_modules
+bower_components
 vendor
+
+# Caches
+.sass-cache
+.npm
+.node_repl_history
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# dotenv environment variables file
+.env
+
+# Mac files
+.DS_Store
+
+# Yarn
+yarn-error.log
+yarn-debug.log*
+.pnp/
+.pnp.js
+# Yarn Integrity file
+.yarn-integrity


### PR DESCRIPTION
I'm surprised this wasn't already happening, so this PR adds a `git init` step after creating the new site folder. If the command fails (i.e. git isn't present on the system), it doesn't throw an error. Thanks to Rails' PR history for highlighting that potential gotcha. 😄

Fixes #16 