### PR TITLE
Add Faraday to default gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ end
 
 group :test do
   gem "cucumber", "~> 3.0"
-  gem "httpclient"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
   gem "memory_profiler"

--- a/bridgetown-core/bridgetown-core.gemspec
+++ b/bridgetown-core/bridgetown-core.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
+  s.add_runtime_dependency("faraday",               "~> 1.0")
   s.add_runtime_dependency("i18n",                  "~> 1.0")
   s.add_runtime_dependency("kramdown",              "~> 2.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -36,6 +36,7 @@ require "liquid"
 require "kramdown"
 require "colorator"
 require "i18n"
+require "faraday"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 

--- a/bridgetown-core/test/test_commands_serve.rb
+++ b/bridgetown-core/test/test_commands_serve.rb
@@ -3,7 +3,6 @@
 require "webrick"
 require "mercenary"
 require "helper"
-require "httpclient"
 require "openssl"
 require "tmpdir"
 

--- a/bridgetown-core/test/test_commands_serve_servlet.rb
+++ b/bridgetown-core/test/test_commands_serve_servlet.rb
@@ -2,42 +2,38 @@
 
 require "webrick"
 require "helper"
-require "net/http"
 
 class TestCommandsServeServlet < BridgetownUnitTest
   def get(path)
     TestWEBrick.mount_server do |_server, addr, port|
-      http = Net::HTTP.new(addr, port)
-      req = Net::HTTP::Get.new(path)
-
-      http.request(req) { |response| yield(response) }
+      yield Faraday.get("http://#{addr}:#{port}#{path}")
     end
   end
 
   context "with a directory and file with the same name" do
     should "find that file" do
       get("/bar/") do |response|
-        assert_equal("200", response.code)
+        assert_equal(200, response.status)
         assert_equal("Content of bar.html", response.body.strip)
       end
     end
 
     should "find file in directory" do
       get("/bar/baz") do |response|
-        assert_equal("200", response.code)
+        assert_equal(200, response.status)
         assert_equal("Content of baz.html", response.body.strip)
       end
     end
 
     should "return 404 for non-existing files" do
       get("/bar/missing") do |response|
-        assert_equal("404", response.code)
+        assert_equal(404, response.status)
       end
     end
 
     should "find xhtml file" do
       get("/bar/foo") do |response|
-        assert_equal("200", response.code)
+        assert_equal(200, response.status)
         assert_equal(
           '<html xmlns="http://www.w3.org/1999/xhtml">Content of foo.xhtml</html>',
           response.body.strip


### PR DESCRIPTION
Add Faraday to the default set of gems that get installed with Bridgetown. Now site builders and gem plugins can all expect a modern Ruby HTTP client with all the bells and whistles ready to go out of the box.

Closes #19 