### PR TITLE
Honor the configured site encoding when loading Liquid components

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/liquid_renderer.rb
+++ b/bridgetown-core/lib/bridgetown-core/liquid_renderer.rb
@@ -17,6 +17,7 @@ module Bridgetown
       Liquid::Template.file_system = LiquidRenderer::FileSystem.new(
         @site.components_load_paths, "%s.liquid"
       )
+      Liquid::Template.file_system.site = site
 
       Liquid::Template.error_mode = @site.config["liquid"]["error_mode"].to_sym
       reset

--- a/bridgetown-core/lib/bridgetown-core/liquid_renderer/file_system.rb
+++ b/bridgetown-core/lib/bridgetown-core/liquid_renderer/file_system.rb
@@ -3,6 +3,8 @@
 module Bridgetown
   class LiquidRenderer
     class FileSystem < Liquid::LocalFileSystem
+      attr_accessor :site
+
       def read_template_file(template_path)
         load_paths = root
         found_paths = []
@@ -29,7 +31,7 @@ module Bridgetown
         raise Liquid::FileSystemError, "No such template '#{template_path}'" if found_paths.empty?
 
         # Last path in the list wins
-        ::File.read(found_paths.last)
+        ::File.read(found_paths.last, site.file_read_opts)
       end
     end
   end


### PR DESCRIPTION
I ran across a `US-ASCII` encoding bug when using a remote SSH session that was incorrectly configured (aka not indicating a `UTF-8` shell) in conjunction with Bridgetown's new support for Liquid's `render` tag. It was preventing the site from building.

This resolves that error.