### PR TITLE
Add titleize Liquid filter

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -63,6 +63,16 @@ module Bridgetown
       Utils.slugify(input, mode: mode)
     end
 
+    # Titleize a slug or identifier string.
+    #
+    # input - The string to titleize.
+    #
+    # Returns a transformed string with spaces and capitalized words.
+    # See Utils.titleize_slug for more detail.
+    def titleize(input)
+      Utils.titleize_slug(input)
+    end
+
     # XML escape a string for use. Replaces any special characters with
     # appropriate HTML entity replacements.
     #

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -20,7 +20,7 @@ module Bridgetown
 
     # Takes a slug and turns it into a simple title.
     def titleize_slug(slug)
-      slug.split("-").map!(&:capitalize).join(" ")
+      slug.gsub(%r![_ ]!, "-").split("-").map!(&:capitalize).join(" ")
     end
 
     # Non-destructive version of deep_merge_hashes! See that method.

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -1240,6 +1240,12 @@ class TestFilters < BridgetownUnitTest
       end
     end
 
+    context "titleize filter" do
+      should "return a titliezed string" do
+        assert_equal "Q Bert Says Howdy There", @filter.titleize("q-bert_says howdy there")
+      end
+    end
+
     context "push filter" do
       should "return a new array with the element pushed to the end" do
         assert_equal %w(hi there bernie), @filter.push(%w(hi there), "bernie")

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -202,7 +202,7 @@
 #
 
 - name: Slugify
-  description: Convert a string into a lowercase URL "slug". See below for options.
+  description: Convert a string into a lowercase URL "slug". <a href="http://localhost:4000/docs/liquid/filters/#options-for-the-slugify-filter">See below for options</a>.
   examples:
     - input: '{{ "The _config.yml file" | slugify }}'
       output: "the-config-yml-file"

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -22,7 +22,7 @@
     your site is hosted at a subpath rather than the root of the domain.
   examples:
     - input: '{{ "/assets/image.jpg" | relative_url }}'
-      output: '/my-baseurl/assets/image.jpg'
+      output: "/my-baseurl/assets/image.jpg"
 
 #
 
@@ -30,57 +30,57 @@
   description: Prepend the <code>url</code> and <code>baseurl</code> value to the input.
   examples:
     - input: '{{ "/assets/image.jpg" | absolute_url }}'
-      output: 'http://example.com/my-baseurl/assets/image.jpg'
+      output: "http://example.com/my-baseurl/assets/image.jpg"
 
 #
 
 - name: Date to XML Schema
   description: Convert a Date into XML Schema (ISO 8601) format.
   examples:
-    - input: '{{ site.time | date_to_xmlschema }}'
-      output: '2008-11-07T13:07:54-08:00'
+    - input: "{{ site.time | date_to_xmlschema }}"
+      output: "2008-11-07T13:07:54-08:00"
 
 #
 
 - name: Date to RFC-822 Format
   description: Convert a Date into the RFC-822 format used for RSS feeds.
   examples:
-    - input: '{{ site.time | date_to_rfc822 }}'
-      output: 'Mon, 07 Nov 2008 13:07:54 -0800'
+    - input: "{{ site.time | date_to_rfc822 }}"
+      output: "Mon, 07 Nov 2008 13:07:54 -0800"
 
 #
 
 - name: Date to String
   description: Convert a date to short format.
   examples:
-    - input: '{{ site.time | date_to_string }}'
-      output: '07 Nov 2008'
+    - input: "{{ site.time | date_to_string }}"
+      output: "07 Nov 2008"
 
 #
 
 - name: Date to String in ordinal US style
-  description: 'Format a date to ordinal, US, short format.'
+  description: "Format a date to ordinal, US, short format."
   version_badge: 3.8.0
   examples:
     - input: '{{ site.time | date_to_string: "ordinal", "US" }}'
-      output: 'Nov 7th, 2008'
+      output: "Nov 7th, 2008"
 
 #
 
 - name: Date to Long String
   description: Format a date to long format.
   examples:
-    - input: '{{ site.time | date_to_long_string }}'
-      output: '07 November 2008'
+    - input: "{{ site.time | date_to_long_string }}"
+      output: "07 November 2008"
 
 #
 
 - name: Date to Long String in ordinal UK style
-  description: 'Format a date to ordinal, UK, long format.'
+  description: "Format a date to ordinal, UK, long format."
   version_badge: 3.8.0
   examples:
     - input: '{{ site.time | date_to_long_string: "ordinal" }}'
-      output: '7th November 2008'
+      output: "7th November 2008"
 
 #
 
@@ -137,7 +137,7 @@
 - name: XML Escape
   description: Escape some text for use in XML.
   examples:
-    - input: '{{ page.content | xml_escape }}'
+    - input: "{{ page.content | xml_escape }}"
       output:
 
 #
@@ -149,7 +149,7 @@
     replaces a space with a plus <code>+</code> sign.
   examples:
     - input: '{{ "foo, bar; baz?" | cgi_escape }}'
-      output: 'foo%2C+bar%3B+baz%3F'
+      output: "foo%2C+bar%3B+baz%3F"
 
 #
 
@@ -161,14 +161,14 @@
     will not be escaped.
   examples:
     - input: '{{ "http://foo.com/?q=foo, \bar?" | uri_escape }}'
-      output: 'http://foo.com/?q=foo,%20%5Cbar?'
+      output: "http://foo.com/?q=foo,%20%5Cbar?"
 
 #
 
 - name: Number of Words
   description: Count the number of words in some text.
   examples:
-    - input: '{{ page.content | number_of_words }}'
+    - input: "{{ page.content | number_of_words }}"
       output: 1337
 
 #
@@ -178,17 +178,17 @@
     Convert an array into a sentence. Useful for listing tags.
     Optional argument for connector.
   examples:
-    - input: '{{ page.tags | array_to_sentence_string }}'
-      output: 'foo, bar, and baz'
+    - input: "{{ page.tags | array_to_sentence_string }}"
+      output: "foo, bar, and baz"
     - input: '{{ page.tags | array_to_sentence_string: "or" }}'
-      output: 'foo, bar, or baz'
+      output: "foo, bar, or baz"
 
 #
 
 - name: Markdownify
   description: Convert a Markdown-formatted string into HTML.
   examples:
-    - input: '{{ page.excerpt | markdownify }}'
+    - input: "{{ page.excerpt | markdownify }}"
       output:
 
 #
@@ -196,7 +196,7 @@
 - name: Smartify
   description: 'Convert "quotes" into &ldquo;smart quotes.&rdquo;'
   examples:
-    - input: '{{ page.title | smartify }}'
+    - input: "{{ page.title | smartify }}"
       output:
 
 #
@@ -205,20 +205,32 @@
   description: Convert a string into a lowercase URL "slug". See below for options.
   examples:
     - input: '{{ "The _config.yml file" | slugify }}'
-      output: 'the-config-yml-file'
+      output: "the-config-yml-file"
     - input: '{{ "The _config.yml file" | slugify: "pretty" }}'
-      output: 'the-_config.yml-file'
+      output: "the-_config.yml-file"
     - input: '{{ "The _cönfig.yml file" | slugify: "ascii" }}'
-      output: 'the-c-nfig-yml-file'
+      output: "the-c-nfig-yml-file"
     - input: '{{ "The cönfig.yml file" | slugify: "latin" }}'
-      output: 'the-config-yml-file'
+      output: "the-config-yml-file"
+
+#
+
+- name: Titleize
+  description: Transform a lowercase string, slug, or identifier string into a capitalized title.
+  examples:
+    - input: '{{ "to-kill-a-mockingbird" | titleize }}'
+      output: "To Kill A Mockingbird"
+    - input: '{{ "as_easy_as_123" | titleize }}'
+      output: "As Easy As 123"
+    - input: '{{ "working hard or hardly working" | titleize }}'
+      output: "Working Hard Or Hardly Working"
 
 #
 
 - name: Data To JSON
   description: Convert Hash or Array to JSON.
   examples:
-    - input: '{{ site.data.projects | jsonify }}'
+    - input: "{{ site.data.projects | jsonify }}"
       output:
 
 #
@@ -237,7 +249,7 @@
     1.&nbsp;property name
     2.&nbsp;nils order (<em>first</em> or <em>last</em>).
   examples:
-    - input: '{{ page.tags | sort }}'
+    - input: "{{ page.tags | sort }}"
       output:
     - input: '{{ site.posts | sort: "author" }}'
       output:
@@ -247,11 +259,11 @@
 #
 
 - name: Sample
-  description: 'Pick a random value from an array. Optionally, pick multiple values.'
+  description: "Pick a random value from an array. Optionally, pick multiple values."
   examples:
-    - input: '{{ site.pages | sample }}'
+    - input: "{{ site.pages | sample }}"
       output:
-    - input: '{{ site.pages | sample: 2 }}'
+    - input: "{{ site.pages | sample: 2 }}"
       output:
 
 #
@@ -259,7 +271,7 @@
 - name: To Integer
   description: Convert a string or boolean to integer.
   examples:
-    - input: '{{ some_var | to_integer }}'
+    - input: "{{ some_var | to_integer }}"
       output:
 
 #
@@ -272,9 +284,9 @@
   examples:
     - input: '{{ page.tags | push: "Spokane" }}'
       output: '["Seattle", "Tacoma", "Spokane"]'
-    - input: '{{ page.tags | pop }}'
+    - input: "{{ page.tags | pop }}"
       output: '["Seattle"]'
-    - input: '{{ page.tags | shift }}'
+    - input: "{{ page.tags | shift }}"
       output: '["Tacoma"]'
     - input: '{{ page.tags | unshift: "Olympia" }}'
       output: '["Olympia", "Seattle", "Tacoma"]'
@@ -284,5 +296,5 @@
 - name: Inspect
   description: Convert an object into its String representation for debugging.
   examples:
-    - input: '{{ some_var | inspect }}'
+    - input: "{{ some_var | inspect }}"
       output:


### PR DESCRIPTION
Like the docs say: a Liquid filter to transform a lowercase string, slug, or identifier string into a capitalized title. Uses the already present `Utils.titleize_slug` method.

input: `{{ "to-kill-a-mockingbird" | titleize }}`
output: `To Kill A Mockingbird`
