### PR TITLE
add a posts page to the new site template

### DIFF
--- a/bridgetown-core/lib/site_template/src/_includes/navbar.html
+++ b/bridgetown-core/lib/site_template/src/_includes/navbar.html
@@ -1,4 +1,5 @@
 <nav>
   <a href="/">Home</a>
   <a href="/about">About</a>
+  <a href="/posts">Posts</a>
 </nav>

--- a/bridgetown-core/lib/site_template/src/posts.md
+++ b/bridgetown-core/lib/site_template/src/posts.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Posts
+permalink: /posts/
+---
+
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
+If you have a lot of posts, you may want to consider adding [pagination](https://www.bridgetownrb.com/docs/content/pagination)!


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
        __I did some looking and I did not find where you were testing this. It is totally possible, if not probable, that I just missed it so would appreciate you pointing me in that direction if I did indeed just overlook it :smile:__
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
       __I did some looking and I do not see it documented what get's generated from the build command__
- [x] The test suite passes locally (run `script/cibuild` to verify this)


## Summary

When generating a new bridgetown site, it is not immediately clear how to get to your posts. I attempted a few ways to navigate there, but since I do not have prior experience with Jekyll, I was a little lost. This commit adds a posts page so that feature newbies, like myself, can quickly see their posts, and not have to try and spend time figuring it out.

## Context

Not related to any currently open issues, but may help prevent some from coming down in the future from people who get immediately frustrated and don't take the time to investigate. 