### PR TITLE
add bundler cache to the build GH action to improve test speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,22 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Build and test with Rake
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes locally (run `script/cibuild` to verify this)

## Summary

Adds caching for bundled gems to improve test speed on subsequent runs for [GitHub Actions](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows)

I noticed that you are not running the tests or linters for pull requests except on master. I didn't add this in because it would be super quick to add and I figured there may be a reason but I have found [this](https://github.com/gitcoinco/code_fund_ads/blob/master/.github/workflows/standardrb.yml#L3) setup to be ideal as sometimes people will merge stuff into their own branches and tests would not run if they were not pointing at master. 

## Context

N/A