### PR TITLE
Fix for GitHub branch URLs in automations (0.15)

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/apply.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/apply.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 module Bridgetown
   module Commands
     class Apply < Thor::Group

--- a/bridgetown-core/lib/bridgetown-core/commands/apply.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/apply.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler"
-
 module Bridgetown
   module Commands
     class Apply < Thor::Group

--- a/bridgetown-core/lib/bridgetown-core/commands/apply.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/apply.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler'
+require "bundler"
 
 module Bridgetown
   module Commands

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -77,18 +77,22 @@ module Bridgetown
 
       private
 
+      def remote_file(arg)
+        if arg.end_with?(".rb")
+          arg.split("/").yield_self do |segments|
+            arg.sub!(%r!/#{segments.last}$!, "")
+            segments.last
+          end
+        else
+          "bridgetown.automation.rb"
+        end
+      end
+
       # TODO: option to download and confirm remote automation?
       def transform_automation_url(arg)
         return arg unless arg.start_with?("http")
 
-        remote_file = if arg.end_with?(".rb")
-                        arg.split("/").yield_self do |segments|
-                          arg.sub!(%r!/#{segments.last}$!, "")
-                          segments.last
-                        end
-                      else
-                        "bridgetown.automation.rb"
-                      end
+        remote_file = remote_file(arg)
 
         tree_regex = %r!https://github\.com/(?<path>.*/.*)/tree/(?<branch>.*)/?!
         match = tree_regex.match(arg)

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -90,10 +90,17 @@ module Bridgetown
                         "bridgetown.automation.rb"
                       end
 
+        tree_regex = %r!https://github\.com/(?<path>.*/.*)/tree/(?<branch>.*)/?!
+        match = tree_regex.match(arg)
+
         if arg.start_with?("https://gist.github.com")
           return arg.sub(
             "https://gist.github.com", "https://gist.githubusercontent.com"
           ) + "/raw/#{remote_file}"
+        elsif match
+          return arg.sub(
+            tree_regex, "https://raw.githubusercontent.com"
+          ) + "/#{match[:path]}/#{match[:branch]}/#{remote_file}"
         elsif arg.start_with?("https://github.com")
           return arg.sub(
             "https://github.com", "https://raw.githubusercontent.com"

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -88,6 +88,7 @@ module Bridgetown
         end
       end
 
+
       # TODO: option to download and confirm remote automation?
       def transform_automation_url(arg)
         return arg unless arg.start_with?("http")
@@ -95,7 +96,7 @@ module Bridgetown
         remote_file = determine_remote_filename(arg)
 
         github_regex = %r!https://github\.com!
-        github_tree_regex = %r!#{github_regex}/.*/.*/tree/.*)/?!
+        github_tree_regex = %r!#{github_regex}/.*/.*/tree/.*/?!
 
         github_match = github_regex.match(arg)
         github_tree_match = github_tree_regex.match(arg)
@@ -107,11 +108,13 @@ module Bridgetown
         elsif github_match
           new_url = arg.sub(github_regex, "https://raw.githubusercontent.com")
 
-          new_url += "/master/" unless github_tree_match
+          if github_tree_match
+            new_url = new_url.sub("/tree/", "/")
+          else
+            new_url += "/master"
+          end
 
-          new_url = new_url.sub(%r!/tree/!, "/")
-
-          return new_url + remote_file
+          return "#{new_url}/#{remote_file}"
         end
 
         arg + "/#{remote_file}"

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -95,10 +95,10 @@ module Bridgetown
         remote_file = determine_remote_filename(arg)
 
         github_regex = %r!https://github\.com!
-        github_branch_regex = %r!#{github_regex}/.*/.*/tree/(?<branch>.*)/?!
+        github_tree_regex = %r!#{github_regex}/.*/.*/tree/.*)/?!
 
         github_match = github_regex.match(arg)
-        github_branch_match = github_branch_regex.match(arg)
+        github_tree_match = github_tree_regex.match(arg)
 
         if arg.start_with?("https://gist.github.com")
           return arg.sub(
@@ -107,17 +107,11 @@ module Bridgetown
         elsif github_match
           new_url = arg.sub(github_regex, "https://raw.githubusercontent.com")
 
-          branch = "master"
+          new_url += "/master/" unless github_tree_match
 
-          if github_branch_match
-            branch = github_branch_match[:branch]
+          new_url = new_url.sub(%r!/tree/!, "/")
 
-            # Sub only affects the first match, so it wont affect directories
-            # named "tree"
-            new_url.sub(%r!/tree/!, "/")
-          end
-
-          return new_url + "/#{branch}/#{remote_file}"
+          return new_url + remote_file
         end
 
         arg + "/#{remote_file}"

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -96,7 +96,7 @@ module Bridgetown
         remote_file = determine_remote_filename(arg)
 
         github_regex = %r!https://github\.com!
-        github_tree_regex = %r!#{github_regex}/.*/.*/tree/.*/?!
+        github_tree_regex = %r!#{github_regex}/(?<repo>.*/.*)/tree/(?<path.*)/?!
 
         github_match = github_regex.match(arg)
         github_tree_match = github_tree_regex.match(arg)

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -88,7 +88,6 @@ module Bridgetown
         end
       end
 
-
       # TODO: option to download and confirm remote automation?
       def transform_automation_url(arg)
         return arg unless arg.start_with?("http")

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -96,7 +96,7 @@ module Bridgetown
         remote_file = determine_remote_filename(arg)
 
         github_regex = %r!https://github\.com!
-        github_tree_regex = %r!#{github_regex}/(?<repo>.*/.*)/tree/(?<path.*)/?!
+        github_tree_regex = %r!#{github_regex}/.*/.*/tree/.*/?!
 
         github_match = github_regex.match(arg)
         github_tree_match = github_tree_regex.match(arg)

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -91,7 +91,7 @@ class TestApplyCommand < BridgetownUnitTest
       assert_match %r!urltest.*?Works\!!, output
     end
 
-    should "transform GitHub repo URLs and not cause issues if users name or repo name is 'tree'" do
+    should "transform GitHub repo URLs and not cause issues if the repo name is 'tree'" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
       file = "https://github.com/bridgetown/tree/tree/my-tree/tree"
       output = capture_stdout do

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -58,7 +58,7 @@ class TestApplyCommand < BridgetownUnitTest
 
     should "transform GitHub repo URLs automatically" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
-      file = "https://github.com/bridgetownrb/tree/automation/bridgetown-automations"
+      file = "https://github.com/bridgetownrb/bridgetown-automations"
       output = capture_stdout do
         @cmd.invoke(:apply_automation, [file])
       end

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -58,11 +58,24 @@ class TestApplyCommand < BridgetownUnitTest
 
     should "transform GitHub repo URLs automatically" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
-      file = "https://github.com/bridgetownrb/bridgetown-automations"
+      file = "https://github.com/bridgetownrb/tree/automation/bridgetown-automations"
       output = capture_stdout do
         @cmd.invoke(:apply_automation, [file])
       end
       assert_match %r!apply.*?https://raw\.githubusercontent.com/bridgetownrb/bridgetown-automations/master/bridgetown\.automation\.rb!, output
+      assert_match %r!urltest.*?Works\!!, output
+    end
+
+    should "transform GitHub repo URLs and respect branches" do
+      allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
+      # file url includes */tree/<branch>/* for a regular github url
+      file = "https://github.com/bridgetownrb/bridgetown-automations/tree/my-tree"
+      output = capture_stdout do
+        @cmd.invoke(:apply_automation, [file])
+      end
+
+      # when pulling raw content, */tree/<branch>/* transforms to */<branch>/*
+      assert_match %r!apply.*?https://raw\.githubusercontent.com/bridgetownrb/bridgetown-automations/my-tree/bridgetown\.automation\.rb!, output
       assert_match %r!urltest.*?Works\!!, output
     end
 

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -91,6 +91,19 @@ class TestApplyCommand < BridgetownUnitTest
       assert_match %r!urltest.*?Works\!!, output
     end
 
+    should "transform GitHub repo URLs and not cause issues if users name or repo name is 'tree'" do
+      allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
+      file = "https://github.com/tree/bridgetown-automations/tree/my-tree/tree"
+      output = capture_stdout do
+        @cmd.invoke(:apply_automation, [file])
+      end
+
+      # when pulling raw content, */tree/<branch>/* transforms to */<branch>/*
+      assert_match %r!apply.*?https://raw\.githubusercontent.com/tree/bridgetown-automations/my-tree/tree/bridgetown\.automation\.rb!, output
+      assert_match %r!urltest.*?Works\!!, output
+    end
+
+
     should "transform Gist URLs automatically" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
       file = "https://gist.github.com/jaredcwhite/963d40acab5f21b42152536ad6847575"

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -79,6 +79,18 @@ class TestApplyCommand < BridgetownUnitTest
       assert_match %r!urltest.*?Works\!!, output
     end
 
+    should "transform GitHub repo URLs and preserve directories named 'tree'" do
+      allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
+      file = "https://github.com/bridgetownrb/bridgetown-automations/tree/my-tree/tree"
+      output = capture_stdout do
+        @cmd.invoke(:apply_automation, [file])
+      end
+
+      # when pulling raw content, */tree/<branch>/* transforms to */<branch>/*
+      assert_match %r!apply.*?https://raw\.githubusercontent.com/bridgetownrb/bridgetown-automations/my-tree/tree/bridgetown\.automation\.rb!, output
+      assert_match %r!urltest.*?Works\!!, output
+    end
+
     should "transform Gist URLs automatically" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
       file = "https://gist.github.com/jaredcwhite/963d40acab5f21b42152536ad6847575"

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -93,13 +93,13 @@ class TestApplyCommand < BridgetownUnitTest
 
     should "transform GitHub repo URLs and not cause issues if users name or repo name is 'tree'" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
-      file = "https://github.com/tree/bridgetown-automations/tree/my-tree/tree"
+      file = "https://github.com/bridgetown/tree/tree/my-tree/tree"
       output = capture_stdout do
         @cmd.invoke(:apply_automation, [file])
       end
 
       # when pulling raw content, */tree/<branch>/* transforms to */<branch>/*
-      assert_match %r!apply.*?https://raw\.githubusercontent.com/tree/bridgetown-automations/my-tree/tree/bridgetown\.automation\.rb!, output
+      assert_match %r!apply.*?https://raw\.githubusercontent.com/bridgetown/tree/my-tree/tree/bridgetown\.automation\.rb!, output
       assert_match %r!urltest.*?Works\!!, output
     end
 

--- a/bridgetown-core/test/test_apply_command.rb
+++ b/bridgetown-core/test/test_apply_command.rb
@@ -103,7 +103,6 @@ class TestApplyCommand < BridgetownUnitTest
       assert_match %r!urltest.*?Works\!!, output
     end
 
-
     should "transform Gist URLs automatically" do
       allow_any_instance_of(Bridgetown::Commands::Apply).to receive(:open).and_return(@template)
       file = "https://gist.github.com/jaredcwhite/963d40acab5f21b42152536ad6847575"


### PR DESCRIPTION
This is a 🐛 bug fix.

  - I've added tests (if it's a bug, feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)

## Summary

My pull request allow you to use a branch for the command "apply"

It transforms the Github url to one that allows the use of a branch

IE: 

`https://github.com/bridgetownrb/bridgetown/tree/automations`

turns to

`https://raw.githubusercontent.com/bridgetownrb/bridgetown/automations/bridgetown.automation.rb`

## Context

Fixes #65 
