### PR TITLE
Reducing animation for users who prefer reduced motion

### DIFF
--- a/bridgetown-website/frontend/javascript/index.js
+++ b/bridgetown-website/frontend/javascript/index.js
@@ -52,19 +52,21 @@ document.addEventListener('DOMContentLoaded', () => {
     containers = [mainEl, "#topnav"]
   }
 
-  const swup = new Swup({
-    containers: containers,
-    plugins: [
-      new SwupSlideTheme({mainElement: mainEl}),
-      new SwupBodyClassPlugin(),
-      new SwupScrollPlugin({animateScroll: false})
-    ],
-    
-  })
+  if(!window.matchMedia('(prefers-reduced-motion)')) {
+    const swup = new Swup({
+      containers: containers,
+      plugins: [
+        new SwupSlideTheme({mainElement: mainEl}),
+        new SwupBodyClassPlugin(),
+        new SwupScrollPlugin({animateScroll: false})
+      ],
 
-  swup.on('contentReplaced', function() {
-    addHeadingAnchors()
-  })
+    })
+
+    swup.on('contentReplaced', function() {
+      addHeadingAnchors()
+    })
+  }
 
   addHeadingAnchors()
 })

--- a/bridgetown-website/frontend/javascript/index.js
+++ b/bridgetown-website/frontend/javascript/index.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     containers = [mainEl, "#topnav"]
   }
 
-  if(!window.matchMedia('(prefers-reduced-motion)')) {
+  if(!window.matchMedia('(prefers-reduced-motion)').matches) {
     const swup = new Swup({
       containers: containers,
       plugins: [

--- a/bridgetown-website/frontend/styles/content.scss
+++ b/bridgetown-website/frontend/styles/content.scss
@@ -2,8 +2,10 @@
 // override theme speeds
 .swup-transition-main {
   transition: opacity 0.2s, transform 0.3s;
+}
 
-  @media screen and (prefers-reduced-motion: reduce) {
+@media screen and (prefers-reduced-motion: reduce) {
+  .swup-transition-main {
     transition-property: none;
   }
 }

--- a/bridgetown-website/frontend/styles/content.scss
+++ b/bridgetown-website/frontend/styles/content.scss
@@ -4,7 +4,7 @@
   transition: opacity 0.2s, transform 0.3s;
 
   @media screen and (prefers-reduced-motion: reduce) {
-    transition: opacity 0s, transform 0s;
+    transition-property: none;
   }
 }
 

--- a/bridgetown-website/frontend/styles/content.scss
+++ b/bridgetown-website/frontend/styles/content.scss
@@ -2,6 +2,10 @@
 // override theme speeds
 .swup-transition-main {
   transition: opacity 0.2s, transform 0.3s;
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    transition: opacity 0s, transform 0s;
+  }
 }
 
 html.is-animating {

--- a/bridgetown-website/frontend/styles/content.scss
+++ b/bridgetown-website/frontend/styles/content.scss
@@ -4,12 +4,6 @@
   transition: opacity 0.2s, transform 0.3s;
 }
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .swup-transition-main {
-    transition-property: none;
-  }
-}
-
 html.is-animating {
   .swup-transition-main {
     transform: translate3d(0, -20px, 0);


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The animations when navigating between pages on [the documentation](https://www.bridgetownrb.com/docs/core-concepts) are giving me a headache.

![image](https://user-images.githubusercontent.com/325384/86243272-fe5d2c00-bb9d-11ea-950c-fca2eb1d6159.png)

I have reduced motion enabled so expect less animation. This removes the animation for users who have "Reduce Motion" checked.

## Context

I've not opened an issue, I created a PR to experiment with solution & get feedback.
