### PR TITLE
Feat: webpack manifest errors

### DIFF
--- a/bridgetown-core/features/webpack_path_tag.feature
+++ b/bridgetown-core/features/webpack_path_tag.feature
@@ -101,6 +101,7 @@ Feature: WebpackPath Tag
     When I run bridgetown build
     Then the "output/index.html" file should not exist
     And I should see "WebpackAssetError" in the build output
+    And I should see "Liquid Exception" in the build output
 
   Scenario: Broken Webpack manifest (js)
     Given I have a _layouts directory
@@ -127,3 +128,4 @@ Feature: WebpackPath Tag
     When I run bridgetown build
     Then the "output/index.html" file should not exist
     And I should see "WebpackAssetError" in the build output
+    And I should see "Liquid Exception" in the build output

--- a/bridgetown-core/features/webpack_path_tag.feature
+++ b/bridgetown-core/features/webpack_path_tag.feature
@@ -75,3 +75,55 @@ Feature: WebpackPath Tag
     When I run bridgetown build
     Then the "output/index.html" file should not exist
     And I should see "Liquid Exception" in the build output
+
+  Scenario: Broken Webpack manifest (css)
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="{% webpack_path css %}" />
+      <script src="{% webpack_path js %}" defer></script>
+      </head>
+      <body>
+      {{ content }}
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    And I have a ".bridgetown-webpack" directory
+    And I have a ".bridgetown-webpack/manifest.json" file with content:
+    """
+    {
+      "main.js": "all.hashgoeshere.js"
+    }
+    """
+    When I run bridgetown build
+    Then the "output/index.html" file should not exist
+    And I should see "WebpackAssetError" in the build output
+
+  Scenario: Broken Webpack manifest (js)
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="{% webpack_path css %}" />
+      <script src="{% webpack_path js %}" defer></script>
+      </head>
+      <body>
+      {{ content }}
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    And I have a ".bridgetown-webpack" directory
+    And I have a ".bridgetown-webpack/manifest.json" file with content:
+    """
+    {
+      "main.css": "all.hashgoeshere.css"
+    }
+    """
+    When I run bridgetown build
+    Then the "output/index.html" file should not exist
+    And I should see "WebpackAssetError" in the build output

--- a/bridgetown-core/lib/bridgetown-core/errors.rb
+++ b/bridgetown-core/lib/bridgetown-core/errors.rb
@@ -16,5 +16,7 @@ module Bridgetown
     PostURLError                = Class.new(FatalException)
     InvalidURLError             = Class.new(FatalException)
     InvalidConfigurationError   = Class.new(FatalException)
+
+    WebpackAssetError           = Class.new(FatalException)
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -51,7 +51,7 @@ module Bridgetown
         if known_assets.include?(@asset_type)
           asset_path = manifest["main.#{@asset_type}"]
 
-          raise_webpack_asset_error(@asset_type) if asset_path.nil?
+          log_webpack_asset_error(@asset_type) if asset_path.nil?
 
           asset_path = asset_path.split("/").last
           return [frontend_path, @asset_type, asset_path].join("/")
@@ -61,19 +61,12 @@ module Bridgetown
         nil
       end
 
-      def raise_webpack_asset_error(asset_type)
-        stack_trace = caller.join("\n")
-        error_message = "
+      def log_webpack_asset_error(asset_type)
+        error_message = "\n\n
           There was an error parsing your #{asset_type} files.
           Please check your #{asset_type} for any errors.\n\n"
 
-        error = Errors::WebpackAssetError.new(error_message)
-
-        Bridgetown.logger.abort_with(error.class) do
-          Bridgetown.logger.info(error.message)
-          Bridgetown.logger.info(stack_trace + "\n\n")
-          error.message
-        end
+        Bridgetown.logger.warn(Errors::WebpackAssetError, error_message)
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -2,23 +2,41 @@
 
 module Bridgetown
   module Tags
+    # A helper class to help find the path to webpack asset inside of a webpack
+    # manifest file.
     class WebpackPath < Liquid::Tag
       include Bridgetown::Filters::URLFilters
 
-      def initialize(tag_name, asset_type, tokens)
+      class WebpackAssetError < RuntimeError
+      end
+
+      # @param tag_name [String] Name of the tag
+      # @param asset_type [String] The type of asset to parse (js, css)
+      # @param options [Hash] An options hash
+      # @return WebpackPath
+      # @see {https://www.rdoc.info/github/Shopify/liquid/Liquid/Tag#initialize-instance_method}
+      def initialize(tag_name, asset_type, options)
         super
 
         # js or css
         @asset_type = asset_type.strip
       end
 
+      # Render the contents of a webpack manifest file
+      # @param context [String] Root directory that contains the manifest file
+      #
+      # @return [String] Returns "MISSING_WEBPACK_MANIFEST" if the manifest
+      # file isnt found
+      # @return [nil] Returns nil if the asset isnt found
+      # @return [Array] Returns an array if rendered without issue
+      #
+      # @raise [WebpackAssetError] if unable to find css or js in the manifest
+      # file
       def render(context)
         @context = context
         site = context.registers[:site]
-
-        frontend_path = relative_url("_bridgetown/static")
-
         manifest_file = site.in_root_dir(".bridgetown-webpack", "manifest.json")
+
         if File.exist?(manifest_file)
           manifest = JSON.parse(File.read(manifest_file))
           if @asset_type == "js"
@@ -34,6 +52,36 @@ module Bridgetown
         else
           "MISSING_WEBPACK_MANIFEST"
         end
+        # parse_manifest_file(manifest_file)
+      end
+
+      private
+
+      def parse_manifest_file(manifest_file)
+        return "MISSING_WEBPACK_MANIFEST" unless File.exist?(manifest_file)
+
+        manifest = JSON.parse(File.read(manifest_file))
+        frontend_path = relative_url("_bridgetown/static")
+
+        known_assets = %w(js css)
+
+        if known_assets.include?(@asset_type)
+          asset_path = manifest["main.#{@asset_type}"]
+
+          raise_manifest_error(@asset_type) if asset_path.nil?
+
+          asset_path = asset_path.split("/").last
+          return [frontend_path, @asset_type, asset_path]
+        end
+
+        Bridgetown.logger.error("Unknown Webpack asset type", @asset_type)
+        nil
+      end
+
+      def raise_asset_error(asset_type)
+        error_message = "There was an error parsing your #{asset_type} files.
+                        Please check your #{asset_type} for any errors."
+        raise WebpackAssetError, error_message, caller
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -54,7 +54,7 @@ module Bridgetown
         if known_assets.include?(@asset_type)
           asset_path = manifest["main.#{@asset_type}"]
 
-          raise_asset_error(@asset_type) if asset_path.nil?
+          raise_webpack_asset_error(@asset_type) if asset_path.nil?
 
           asset_path = asset_path.split("/").last
           return [frontend_path, @asset_type, asset_path].join("/")
@@ -64,10 +64,17 @@ module Bridgetown
         nil
       end
 
-      def raise_asset_error(asset_type)
-        error_message = "There was an error parsing your #{asset_type} files.
-                        Please check your #{asset_type} for any errors."
-        raise WebpackAssetError, error_message, caller
+      def raise_webpack_asset_error(asset_type)
+          error_message = "There was an error parsing your #{asset_type} files.
+                          Please check your #{asset_type} for any errors.\n\n"
+
+          begin
+            raise WebpackAssetError, error_message
+          rescue => e
+            puts e.message
+            puts e.backtrace
+            Bridgetown.logger.abort_with(WebpackAssetError, error_message)
+          end
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -28,31 +28,17 @@ module Bridgetown
       # @return [String] Returns "MISSING_WEBPACK_MANIFEST" if the manifest
       # file isnt found
       # @return [nil] Returns nil if the asset isnt found
-      # @return [Array] Returns an array if rendered without issue
+      # @return [String] Returns the path to the asset if no issues parsing
       #
       # @raise [WebpackAssetError] if unable to find css or js in the manifest
       # file
       def render(context)
         @context = context
         site = context.registers[:site]
+
         manifest_file = site.in_root_dir(".bridgetown-webpack", "manifest.json")
 
-        if File.exist?(manifest_file)
-          manifest = JSON.parse(File.read(manifest_file))
-          if @asset_type == "js"
-            js_path = manifest["main.js"].split("/").last
-            [frontend_path, "js", js_path].join("/")
-          elsif @asset_type == "css"
-            css_path = manifest["main.css"].split("/").last
-            [frontend_path, "css", css_path].join("/")
-          else
-            Bridgetown.logger.error("Unknown Webpack asset type", @asset_type)
-            nil
-          end
-        else
-          "MISSING_WEBPACK_MANIFEST"
-        end
-        # parse_manifest_file(manifest_file)
+        parse_manifest_file(manifest_file)
       end
 
       private
@@ -68,10 +54,10 @@ module Bridgetown
         if known_assets.include?(@asset_type)
           asset_path = manifest["main.#{@asset_type}"]
 
-          raise_manifest_error(@asset_type) if asset_path.nil?
+          raise_asset_error(@asset_type) if asset_path.nil?
 
           asset_path = asset_path.split("/").last
-          return [frontend_path, @asset_type, asset_path]
+          return [frontend_path, @asset_type, asset_path].join("/")
         end
 
         Bridgetown.logger.error("Unknown Webpack asset type", @asset_type)

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -65,16 +65,15 @@ module Bridgetown
       end
 
       def raise_webpack_asset_error(asset_type)
-          error_message = "There was an error parsing your #{asset_type} files.
+        error_message = "There was an error parsing your #{asset_type} files.
                           Please check your #{asset_type} for any errors.\n\n"
 
-          begin
-            raise WebpackAssetError, error_message
-          rescue => e
-            puts e.message
-            puts e.backtrace
-            Bridgetown.logger.abort_with(WebpackAssetError, error_message)
-          end
+        begin
+          raise WebpackAssetError, error_message
+        rescue StandardError => e
+          Bridgetown.logger.info(e.backtrace.join("\n"))
+          Bridgetown.logger.abort_with(WebpackAssetError, error_message)
+        end
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -65,12 +65,14 @@ module Bridgetown
       end
 
       def raise_webpack_asset_error(asset_type)
-        error_message = "There was an error parsing your #{asset_type} files.
-                          Please check your #{asset_type} for any errors.\n\n"
+        error_message = "
+                There was an error parsing your #{asset_type} files.
+                Please check your #{asset_type} for any errors.\n\n"
 
         begin
           raise WebpackAssetError, error_message
         rescue StandardError => e
+          Bridgetown.logger.info(e.message)
           Bridgetown.logger.info(e.backtrace.join("\n"))
           Bridgetown.logger.abort_with(WebpackAssetError, error_message)
         end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -74,12 +74,6 @@ module Bridgetown
           Bridgetown.logger.info(stack_trace + "\n\n")
           error.message
         end
-
-        # Bridgetown.logger.abort_with(Errors::WebpackAssetError) do
-        #   Bridgetown.logger.warn(error_message)
-        #   Bridgetown.logger.info(stack_trace)
-        #   Bridgetown.logger.error(error_message)
-        # end
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/webpack_path.rb
@@ -62,9 +62,8 @@ module Bridgetown
       end
 
       def log_webpack_asset_error(asset_type)
-        error_message = "\n\n
-          There was an error parsing your #{asset_type} files.
-          Please check your #{asset_type} for any errors.\n\n"
+        error_message = "There was an error parsing your #{asset_type} files. \
+          Please check your #{asset_type} for any errors."
 
         Bridgetown.logger.warn(Errors::WebpackAssetError, error_message)
       end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This pull request provides better error handling for Webpack manifest file issues. Also adds YARD documentation for webpack_path.

I have added additional tests to the feature spec for `webpack_path` as well as tested locally.

Here is what the new error log looks like:

```bash
[Bridgetown]
[Bridgetown]           There was an error parsing your css files.
[Bridgetown]           Please check your css for any errors.
[Bridgetown]
[Bridgetown]
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/tags/webpack_path.rb:54:in `parse_manifest_file'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/tags/webpack_path.rb:38:in `render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/tag.rb:61:in `render_to_output_buffer'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:179:in `block in render_node'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:189:in `disable_tags'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:178:in `render_node'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:160:in `render_to_output_buffer'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:225:in `block in render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:262:in `with_profiling'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:224:in `render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:240:in `render_to_output_buffer'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/tags/render.rb:59:in `block in render_tag'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/tags/render.rb:68:in `render_tag'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/tags/render.rb:33:in `render_to_output_buffer'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:179:in `block in render_node'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/registers/disabled_tags.rb:14:in `disable'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:190:in `disable_tags'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:178:in `render_node'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/block_body.rb:160:in `render_to_output_buffer'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:225:in `block in render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:262:in `with_profiling'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:224:in `render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/liquid-render-tag-0.2.0/lib/liquid-render-tag/template.rb:236:in `render!'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:37:in `block (3 levels) in render!'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:51:in `measure_counts'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:36:in `block (2 levels) in render!'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:55:in `measure_bytes'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:35:in `block in render!'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:62:in `measure_time'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/liquid_renderer/file.rb:34:in `render!'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/renderer.rb:131:in `render_liquid'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/renderer.rb:209:in `render_layout'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/renderer.rb:178:in `place_in_layouts'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/renderer.rb:91:in `render_document'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/renderer.rb:66:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:66:in `render_regenerated'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:43:in `block (2 levels) in render_docs'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:42:in `each'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:42:in `block in render_docs'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:41:in `each_value'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:41:in `render_docs'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/renderable.rb:14:in `render'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/concerns/site/processable.rb:17:in `process'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/commands/build.rb:71:in `build_site'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/commands/build.rb:40:in `build'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `block in invoke_all'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `each'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `map'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `invoke_all'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/group.rb:232:in `dispatch'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:116:in `invoke'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/lib/bridgetown-core/commands/serve.rb:76:in `serve'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `block in invoke_all'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `each'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `map'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `invoke_all'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/group.rb:232:in `dispatch'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:116:in `invoke'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor.rb:40:in `block in register'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bridgetown-core-0.15.0/bin/bridgetown:22:in `<top (required)>'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/bin/bridgetown:23:in `load'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/bin/bridgetown:23:in `<top (required)>'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/bin/bundle:23:in `load'
[Bridgetown] /home/krog/.gem/ruby/2.6.3/bin/bundle:23:in `<main>'
[Bridgetown]
[Bridgetown]
[Bridgetown] Bridgetown::Errors::WebpackAssetError:  There was an error parsing your css files. Please check your css for any errors.
[Bridgetown]   Liquid Exception: exit in /home/krog/projects/ruby/mysite/src/_layouts/default.html
```

## Context

Fixes #93 
