### PR TITLE
Update pagination documentation

### DIFF
--- a/bridgetown-website/src/_docs/content/pagination.md
+++ b/bridgetown-website/src/_docs/content/pagination.md
@@ -23,7 +23,7 @@ To facilitate pagination on a page (like `index.html`, `blog.md`, etc.) then sim
 ``` yml
 ---
 layout: page
-pagination: 
+pagination:
   enabled: true
 ---
 ```
@@ -44,6 +44,14 @@ Normally the paginated documents are of a [Post](/docs/posts/) type, but to load
 pagination:
   enabled: true
   collection: tigers
+```
+
+By default, paginated documents will have 10 items per page. You can change this in your config by modifying the `per_page` key like so:
+
+```yml
+pagination:
+  enabled: true
+  per_page: 4
 ```
 
 ## Pagination Links


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

Update pagination documentation to include information on how to use the `per_page` key.

## Context

I do not currently see a place in the docs that we call out how to set the amount of paginated items per page. I had to go look in the source code, so this addition adds a little blurb about the `per_page` key to the pagination docs to make it easier to find.
