### PR TITLE
feat(tags): Adding a class_map tag

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -39,12 +39,12 @@ module Bridgetown
       end
 
       def render(context)
-        to_class_ary(@input, context).join(" ")
+        class_map(@input, context)
       end
 
       private
 
-      def to_class_ary(string, context)
+      def class_map(string, context)
         ary = []
 
         string.split(%r!,\s+!).each do |item|
@@ -67,7 +67,9 @@ module Bridgetown
           end
         end
 
-        ary
+        ary.join(" ")
+      rescue NoMethodError
+        "invalid-class-map"
       end
 
       def find_variable(context, variable)

--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -1,52 +1,75 @@
 # frozen_string_literal: true
-require 'json'
+require 'set'
 
 module Bridgetown
   module Tags
+
+
+    # A ClassMap class is meant to take a hash and append styles based on if the
+    # value is truthy or falsy
+    #
+    # @example
+    #   center-var = true
+    #   small-var = nil
+    #
+    #   # input
+    #   <div class="{% class_map has-centered-text: center-var, is-small: small-var %}">
+    #     Text
+    #   </div>
+    #
+    #   # output
+    #   <div class="has-centered-text">
+    #     Text
+    #   </div>
     class ClassMap < Liquid::Tag
+      # @see https://api.rubyonrails.org/classes/ActiveModel/Type/Boolean.html
+      FALSE_VALUES = [
+        nil, "nil", "NIL", false, 0, "0", :"0", "f", :f, "F", :F, "false",
+        :false, "FALSE", :FALSE
+      ].to_set.freeze
+
       # @param tag_name [String] The name to use for the tag
       # @param input [String] The input to the tag
-      # @param token [Hash] A hash of config tokens for Liquid.
+      # @param tokens [Hash] A hash of config tokens for Liquid.
       #
-      # @example
-      #   center-var = true
-      #   is-small = nil
-      #
-      #   # input
-      #   <div class="{% class_map has-centered-text: center-var, is-small: small-var %}">
-      #     Text
-      #   </div>
-      #
-      #   # output
-      #   <div class="has-centered-text">
-      #     Text
-      #   </div>
       #
       # @return [ClassMap] Returns a ClassMap object
       def initialize(tag_name, input, tokens)
         super
-
-        @hash = JSON.parse(input.strip.to_json)
+        @input = input
       end
 
       def render(context)
-        evaluate_variables(context)
-        @hash.map { |key, variable| key if variable }.compact.join(" ")
+        to_class_ary(@input, context).join(" ")
       end
 
       private
 
-      # @param context [Liquid::Context] The context to run the variable in
-      # @return [Hash] Returns a hash with updated variables
-      def evaluate_variables(context)
-        @hash.transform_values! do |value|
-          lookup = context
+      def to_class_ary(string, context)
+        ary = []
 
-          variable.split(".").each { |value| lookup = lookup[value] }
-
-          lookup || false
+        string.split(/,\s+/).each do |item|
+          kv_pair = item.split(/:\s+/)
+          klass = kv_pair[0]
+          variable = kv_pair[1]
+          variable = find_variable(context, variable)
+          ary.push(klass) unless FALSE_VALUES.include?(variable)
         end
+
+        ary
+      end
+
+      def find_variable(context, variable)
+        lookup = context
+
+        variable.split(".").each do |value|
+          lookup = lookup[value.strip]
+        end
+
+        lookup || nil
       end
     end
   end
 end
+
+Liquid::Template.register_tag("class_map", Bridgetown::Tags::ClassMap)

--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'json'
+
+module Bridgetown
+  module Tags
+    class ClassMap < Liquid::Tag
+      # @param tag_name [String] The name to use for the tag
+      # @param input [String] The input to the tag
+      # @param token [Hash] A hash of config tokens for Liquid.
+      #
+      # @example
+      #   center-var = true
+      #   is-small = nil
+      #
+      #   # input
+      #   <div class="{% class_map has-centered-text: center-var, is-small: small-var %}">
+      #     Text
+      #   </div>
+      #
+      #   # output
+      #   <div class="has-centered-text">
+      #     Text
+      #   </div>
+      #
+      # @return [ClassMap] Returns a ClassMap object
+      def initialize(tag_name, input, tokens)
+        super
+
+        @hash = JSON.parse(input.strip.to_json)
+      end
+
+      def render(context)
+        evaluate_variables(context)
+        @hash.map { |key, variable| key if variable }.compact.join(" ")
+      end
+
+      private
+
+      # @param context [Liquid::Context] The context to run the variable in
+      # @return [Hash] Returns a hash with updated variables
+      def evaluate_variables(context)
+        @hash.transform_values! do |value|
+          lookup = context
+
+          variable.split(".").each { |value| lookup = lookup[value] }
+
+          lookup || false
+        end
+      end
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-require 'set'
+
+require "set"
 
 module Bridgetown
   module Tags
-
-
     # A ClassMap class is meant to take a hash and append styles based on if the
     # value is truthy or falsy
     #
@@ -25,7 +24,7 @@ module Bridgetown
       # @see https://api.rubyonrails.org/classes/ActiveModel/Type/Boolean.html
       FALSE_VALUES = [
         nil, "nil", "NIL", false, 0, "0", :"0", "f", :f, "F", :F, "false",
-        :false, "FALSE", :FALSE
+        false, "FALSE", :FALSE,
       ].to_set.freeze
 
       # @param tag_name [String] The name to use for the tag
@@ -48,8 +47,8 @@ module Bridgetown
       def to_class_ary(string, context)
         ary = []
 
-        string.split(/,\s+/).each do |item|
-          kv_pair = item.split(/:\s+/)
+        string.split(%r!,\s+!).each do |item|
+          kv_pair = item.split(%r!:\s+!)
           klass = kv_pair[0]
           variable = kv_pair[1]
           variable = find_variable(context, variable)

--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -51,8 +51,20 @@ module Bridgetown
           kv_pair = item.split(%r!:\s+!)
           klass = kv_pair[0]
           variable = kv_pair[1]
+
+          # Check if a user wants the opposite of the variable
+          if variable[0] == "!"
+            check_opposite = true
+            variable.slice!(1..-1)
+          end
+
           variable = find_variable(context, variable)
-          ary.push(klass) unless FALSE_VALUES.include?(variable)
+
+          if check_opposite
+            ary.push(klass) if FALSE_VALUES.include?(variable)
+          else
+            ary.push(klass) unless FALSE_VALUES.include?(variable)
+          end
         end
 
         ary

--- a/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/class_map.rb
@@ -68,6 +68,8 @@ module Bridgetown
         end
 
         ary.join(" ")
+
+      # Gracefully handle if syntax is improper
       rescue NoMethodError
         "invalid-class-map"
       end

--- a/bridgetown-core/test/test_tags.rb
+++ b/bridgetown-core/test/test_tags.rb
@@ -718,4 +718,32 @@ class TestTags < BridgetownUnitTest
       end
     end
   end
+
+  context "class_map tag" do
+    context "renders without issues" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: Class Map parameters
+          ---
+
+          {% assign small = true %}
+          {% assign centered = "centered" %}
+          {% assign filled = nil %}
+          {% assign red-background = false %}
+
+          <button class="{% class_map is-small: small, has-text-center: centered, outlined: !filled, red-bg: red-background, nodef: notdefined %}">Button</button>
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "correctly output class names" do
+        assert_match "<button class=\"is-small has-text-center outlined\">Button</button>", @result
+      end
+    end
+  end
 end

--- a/bridgetown-core/test/test_tags.rb
+++ b/bridgetown-core/test/test_tags.rb
@@ -720,7 +720,7 @@ class TestTags < BridgetownUnitTest
   end
 
   context "class_map tag" do
-    context "renders without issues" do
+    context "renders without error" do
       setup do
         content = <<~CONTENT
           ---
@@ -732,7 +732,7 @@ class TestTags < BridgetownUnitTest
           {% assign filled = nil %}
           {% assign red-background = false %}
 
-          <button class="{% class_map is-small: small, has-text-center: centered, outlined: !filled, red-bg: red-background, nodef: notdefined %}">Button</button>
+          <button class="{% class_map   is-small: small,  has-text-center:   centered, outlined:  !filled, red-bg: red-background, nodef: notdefined %}">Button</button>
         CONTENT
         create_post(content,
                     "permalink"   => "pretty",
@@ -741,8 +741,35 @@ class TestTags < BridgetownUnitTest
                     "read_posts"  => true)
       end
 
-      should "correctly output class names" do
+      should "correctly output names" do
         assert_match "<button class=\"is-small has-text-center outlined\">Button</button>", @result
+      end
+    end
+
+    context "Returns an error if not properly formatted" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: Class Map parameters
+          ---
+
+          {% assign small = true %}
+          {% assign centered = "centered" %}
+          {% assign filled = nil %}
+          {% assign red-background = false %}
+
+          <button class="{% class_map is-small => small, has-text-center, centered, outlined: !filled, red-bg: red-background, nodef: notdefined %}">Button</button>
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "return an error due to improper formatting" do
+        refute_match "<button class=\"is-small has-text-center outlined\">Button</button>", @result
+        assert_match "<button class=\"invalid-class-map\">Button</button>", @result
       end
     end
   end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

Rough implementation, appears to pass normal use cases. Due to how this is implemented, only variables can be given as values. If the variable is false, nil, etc, it will not display in the output. Let me know if there's any questions.

## Summary

Adds a `{% class_map %}` tag as discussed in #86. 

Adds testing for the `class_map` tag
