### PR TITLE
Move Webpack parsing to Utils, enable for ERB templates

### DIFF
--- a/bridgetown-core/features/webpack_path_tag.feature
+++ b/bridgetown-core/features/webpack_path_tag.feature
@@ -73,8 +73,8 @@ Feature: WebpackPath Tag
     }
     """
     When I run bridgetown build
-    Then the "output/index.html" file should not exist
-    And I should see "Liquid Exception" in the build output
+    Then the "output/index.html" file should exist
+    And I should see "Unknown Webpack asset type" in the build output
 
   Scenario: Broken Webpack manifest (css)
     Given I have a _layouts directory
@@ -99,9 +99,8 @@ Feature: WebpackPath Tag
     }
     """
     When I run bridgetown build
-    Then the "output/index.html" file should not exist
+    Then the "output/index.html" file should exist
     And I should see "WebpackAssetError" in the build output
-    And I should see "Liquid Exception" in the build output
 
   Scenario: Broken Webpack manifest (js)
     Given I have a _layouts directory
@@ -126,6 +125,35 @@ Feature: WebpackPath Tag
     }
     """
     When I run bridgetown build
-    Then the "output/index.html" file should not exist
+    Then the "output/index.html" file should exist
     And I should see "WebpackAssetError" in the build output
-    And I should see "Liquid Exception" in the build output
+
+  Scenario: Use Webpack manifest in an ERB layout
+    Given I have a _layouts directory
+    And I have a "_layouts/default.erb" file with content:
+      """
+      <html>
+      <head>
+      <link rel="stylesheet" href="<%= webpack_path :css %>" />
+      <script src="<%= webpack_path :js %>" defer></script>
+      </head>
+      <body>
+      Static: <%= relative_url "_bridgetown" %>
+      <%= yield %>
+      </body>
+      </html>
+      """
+    And I have an "index.html" page with layout "default" that contains "page content"
+    And I have a ".bridgetown-webpack" directory
+    And I have a ".bridgetown-webpack/manifest.json" file with content:
+    """
+    {
+      "main.js": "all.hashgoeshere.js",
+      "main.css": "all.hashgoeshere.css"
+    }
+    """
+    When I run bridgetown build
+    Then the "output/index.html" file should exist
+    And I should see "/_bridgetown/static/js/all.hashgoeshere.js" in "output/index.html"
+    And I should see "Static: /_bridgetown" in "output/index.html"
+    And I should not see "MISSING_WEBPACK_MANIFEST" in "output/index.html"

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -6,6 +6,19 @@ module Bridgetown
   class RubyTemplateView
     class Helpers
       include Bridgetown::Filters
+
+      Context = Struct.new(:registers)
+
+      def initialize(site)
+        @site = site
+
+        # duck typing for Liquid context
+        @context = Context.new({ site: @site })
+      end
+
+      def webpack_path(asset_type)
+        Bridgetown::Utils.parse_webpack_manifest_file(@site, asset_type.to_s)
+      end
     end
 
     attr_reader :layout, :page, :site, :content
@@ -43,7 +56,7 @@ module Bridgetown
     end
 
     def helpers
-      @helpers ||= Helpers.new
+      @helpers ||= Helpers.new(@site)
     end
 
     def method_missing(method, *args, &block)


### PR DESCRIPTION
Hey @ParamagicDev, I relocated the bulk of the code that parses the manifest to the Utils module so we can use it from ERB/etc. as well. I also changed the behavior so it doesn't actually trigger any runtime errors and always lets the site build…I think there must have been a communication mixup before and I thought that's how it was already working. Anyway, if you could give this a quick looksee before merge, I'd appreciate it!

(Also fixed an issue with using Liquid filters from ERB…had to add duck-typing for a `@context` ivar so the filters could access the current `site` object).