### PR TITLE
Replace 'insert_svg' with 'bridgetown-inline-svg' plugin on website

### DIFF
--- a/bridgetown-website/Gemfile
+++ b/bridgetown-website/Gemfile
@@ -5,9 +5,12 @@ gem 'bridgetown-builder', path: '../bridgetown-builder'
 gem 'bridgetown-paginate', path: '../bridgetown-paginate'
 gem 'bridgetown', path: '../bridgetown'
 
-gem "bridgetown-seo-tag", "3.0.5", :group => :bridgetown_plugins
-gem "bridgetown-feed", "~> 1.0", :group => :bridgetown_plugins
-gem "bridgetown-quick-search", "~> 1.0.3", group: :bridgetown_plugins
+group :bridgetown_plugins do
+  gem "bridgetown-seo-tag", "3.0.5"
+  gem "bridgetown-feed", "~> 1.0"
+  gem "bridgetown-quick-search", "~> 1.0.3"
+  gem "bridgetown-inline-svg", "~> 1.1"
+end
 
 group :test, optional: true do
   gem "nokogiri"

--- a/bridgetown-website/bridgetown.config.yml
+++ b/bridgetown-website/bridgetown.config.yml
@@ -39,3 +39,6 @@ pagination:
 # Environment-specific settings
 development:
   unpublished: true
+
+svg:
+  optimize: true

--- a/bridgetown-website/plugins/builders/tags.rb
+++ b/bridgetown-website/plugins/builders/tags.rb
@@ -10,13 +10,5 @@ class TagsBuilder < SiteBuilder
         {:toc}
       TAG
     end
-
-    liquid_tag "insert_svg" do |filename|
-      svg_path = File.join site.source, "images", filename.gsub("../", "")
-      svg_lines = File.readlines(svg_path).map(&:strip).select do |line|
-        line unless line.start_with?("<!", "<?xml")
-      end
-      svg_lines.join
-    end
   end
 end

--- a/bridgetown-website/src/_components/shared/footer.liquid
+++ b/bridgetown-website/src/_components/shared/footer.liquid
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="columns">
       <div class="column is-5">
-        <div class="bridgetown-logo">{% insert_svg Bridgetown-Logo.svg %}</div>
+        <div class="bridgetown-logo">{% svg images/Bridgetown-Logo.svg %}</div>
 
         <h4>
           <strong>Bridgetown</strong> is a Ruby-powered static site generator.
@@ -65,8 +65,8 @@
     </div>
 
     <p class="mt-12 has-text-centered">
-      <strong style="opacity:.7">we</strong> 
-      <img src="/images/ruby.svg" alt="Ruby" style="height: 1.5rem;vertical-align:middle;margin: 0 0.5rem" /> 
+      <strong style="opacity:.7">we</strong>
+      <img src="/images/ruby.svg" alt="Ruby" style="height: 1.5rem;vertical-align:middle;margin: 0 0.5rem" />
       <strong style="opacity:.7">ruby</strong>
     </p>
   </div>

--- a/bridgetown-website/src/_components/shared/navbar.liquid
+++ b/bridgetown-website/src/_components/shared/navbar.liquid
@@ -17,7 +17,7 @@
   <div class="container">
     <div class="navbar-brand">
       <a class="navbar-item {{ home_active }}" href="/">
-        <span class="bridgetown-logo">{% insert_svg Bridgetown-Logo.svg %}</span>
+        <span class="bridgetown-logo">{% svg images/Bridgetown-Logo.svg %}</span>
         {% if is_beta != "" %}<span class="tag is-warning">Beta</span>{% endif %}
         <h1 class="title is-5">Bridgetown</h1>
       </a>

--- a/bridgetown-website/src/_layouts/home.html
+++ b/bridgetown-website/src/_layouts/home.html
@@ -9,7 +9,7 @@ layout: default
     </div>
   {% endif %}
   {% rendercontent "shared/box" %}
-    <div class="bridgetown-logo">{% insert_svg Bridgetown-Logo.svg %}</div>
+    <div class="bridgetown-logo">{% svg images/Bridgetown-Logo.svg %}</div>
 
     <h1 class="mt-3 mb-10 title has-text-centered has-text-brown">Bridgetown</h1>
 

--- a/bridgetown-website/src/inverse_logo.html
+++ b/bridgetown-website/src/inverse_logo.html
@@ -7,7 +7,7 @@ exclude_from_search: true
   <div class="columns is-centered">
     <div class="column is-three-quarters" id="swup">
       <div style="width:1000px; height: 563px; border-radius: 0" class="box px-8 py-8 has-background-primary">
-        <div style="margin-top: 0.7rem; max-width: 750px;" class="bridgetown-logo inverse">{% insert_svg Bridgetown-Logo.svg %}</div>
+        <div style="margin-top: 0.7rem; max-width: 750px;" class="bridgetown-logo inverse">{% svg images/Bridgetown-Logo.svg %}</div>
 
         <h1 style="font-size: 4.3rem" class="mt-3 mb-8 title has-text-centered has-text-white">Bridgetown</h1>
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement.


## Summary

- Adds the [bridgetown-inline-svg](https://github.com/andrewmcodes/bridgetown-inline-svg) plugin for easier handling and inline of SVG assets on the website.
- Removes `insert_svg` tag that was created to handle this previously

## Context

@jaredcwhite mentioned he wanted to do this so I decided to save him the work! 💪 