### PR TITLE
feat: Lazy loading iframes & adding title attribute to them

### DIFF
--- a/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
+++ b/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
@@ -14,7 +14,7 @@ It's time to unveil some of those initiatives today with the release of Bridgeto
 Before we get into the meat of the release, there's a brand-new overview video you can watch to learn more about Bridgetown!
 
 <figure class="image is-16by9 mx-0">
-  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
 </figure>
 
 This is the first video in an ongoing series, so keep an eye out for future installments.

--- a/bridgetown-website/src/index.md
+++ b/bridgetown-website/src/index.md
@@ -26,7 +26,7 @@ Built upon proven open source technology, **Bridgetown** is a _fast_, _scalable_
 {: .has-text-centered .has-text-danger .mt-10}
 
 <figure class="image is-16by9 mx-0">
-  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" title="Introduction to Bridgetown / Ruby-powered Static Site Generator"></iframe>
 </figure>
 
 

--- a/bridgetown-website/src/index.md
+++ b/bridgetown-website/src/index.md
@@ -26,7 +26,7 @@ Built upon proven open source technology, **Bridgetown** is a _fast_, _scalable_
 {: .has-text-centered .has-text-danger .mt-10}
 
 <figure class="image is-16by9 mx-0">
-  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe class="has-ratio" width="560" height="315" src="https://www.youtube-nocookie.com/embed/gSij_P3iaIE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
 </figure>
 
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This add the [`loading="lazy"`](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#Images_and_iframes) method to the iframes, which means the browser won't load the iframe until the viewport is close to showing that iframe. It also adds a `title` attribute to improve accessibility.

## Context

I measured via https://web.dev/measure/ 

**Current Lighthouse**

![image](https://user-images.githubusercontent.com/325384/88216980-c8b7da00-cc55-11ea-8583-1e1023faaaab.png)

**Review App Lighthouse**

![image](https://user-images.githubusercontent.com/325384/88217490-880c9080-cc56-11ea-80f2-cb81ae856865.png)


As you can see it's a minor improvement, though hard to know if it's just lighthouse hitting a different URL & caching differently (The SEO change is due to the review apps being no-index).

**What's happening?**

![image](https://user-images.githubusercontent.com/325384/88240267-848cff80-cc7e-11ea-8a45-5070034b0336.png)

If you look kind of close at the network order, it's loading the YouTube iFrame after the page has loaded (after the fonts).

## Related Tickets

https://github.com/bridgetownrb/bridgetown/issues/103
