### PR TITLE
Adding rel="noopener" to external links

### DIFF
--- a/bridgetown-website/src/_components/shared/footer.liquid
+++ b/bridgetown-website/src/_components/shared/footer.liquid
@@ -18,7 +18,7 @@
         <div class="mt-6 is-size-7">
           Source code licensed <a href="https://opensource.org/licenses/mit-license.php" target="_blank" rel="noopener">MIT</a>
           <br>
-          Website content licensed <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">CC BY-NC-SA 4.0</a>
+          Website content licensed <a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA 4.0</a>
         </div>
 
       </div>

--- a/bridgetown-website/src/_components/shared/footer.liquid
+++ b/bridgetown-website/src/_components/shared/footer.liquid
@@ -10,15 +10,15 @@
 
         <div>
           Version: <strong>v{{ bridgetown.version }}</strong> (codename “<strong>{{ bridgetown.code_name }}</strong>”)<br/>
-          Monthly GitHub Commits: <strong><a href="https://github.com/{{ metadata.github }}/graphs/commit-activity">{{ github_participation }}</a></strong><br/>
-          Follow Us: <strong><a href="https://twitter.com/{{ metadata.twitter }}">@{{ metadata.twitter }}</strong></a><br/>
+          Monthly GitHub Commits: <strong><a href="https://github.com/{{ metadata.github }}/graphs/commit-activity" rel="noopener">{{ github_participation }}</a></strong><br/>
+          Follow Us: <strong><a href="https://twitter.com/{{ metadata.twitter }}" rel="noopener">@{{ metadata.twitter }}</strong></a><br/>
           Read About Our <strong><a href="/about/">History &amp; Roadmap</a></strong>
         </div>
 
         <div class="mt-6 is-size-7">
-          Source code licensed <a href="https://opensource.org/licenses/mit-license.php" target="_blank">MIT</a>
+          Source code licensed <a href="https://opensource.org/licenses/mit-license.php" target="_blank" rel="noopener">MIT</a>
           <br>
-          Website content licensed <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA 4.0</a>
+          Website content licensed <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">CC BY-NC-SA 4.0</a>
         </div>
 
       </div>
@@ -28,15 +28,15 @@
         </h4>
 
         <div class="mt-6">
-          <a href="https://github.com/{{ metadata.github }}/issues">Browse Issues</a><br/>
-          <a href="https://github.com/{{ metadata.github }}/pulls">Submit a Pull Request</a><br/>
-          <a href="https://github.com/{{ metadata.github }}/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
+          <a href="https://github.com/{{ metadata.github }}/issues" rel="noopener">Browse Issues</a><br/>
+          <a href="https://github.com/{{ metadata.github }}/pulls" rel="noopener">Submit a Pull Request</a><br/>
+          <a href="https://github.com/{{ metadata.github }}/blob/main/CODE_OF_CONDUCT.md" rel="noopener">Code of Conduct</a>
         </div>
 
         <div class="mt-6">
-          <a href="https://community.bridgetownrb.com">Community Forum</a><br/>
-          <a href="https://jamstack.org/slack">Jamstack Slack (#bridgetown)</a><br/>
-          <a href="https://discord.gg/V56yUWR">Discord Chat</a>
+          <a href="https://community.bridgetownrb.com" rel="noopener">Community Forum</a><br/>
+          <a href="https://jamstack.org/slack" rel="noopener">Jamstack Slack (#bridgetown)</a><br/>
+          <a href="https://discord.gg/V56yUWR" rel="noopener">Discord Chat</a>
         </div>
       </div>
       <div class="column is-3">
@@ -45,7 +45,7 @@
         </h4>
 
         <div class="mt-6">
-          <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fbridgetownrb.com&via=bridgetownrb&text=Check%20out%20this%20awesome%20new%20static%20site%20generator%20built%20in%20Ruby%21&hashtags=SpinUpBridgetown%2CJamstack" class="button is-info">
+          <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fbridgetownrb.com&via=bridgetownrb&text=Check%20out%20this%20awesome%20new%20static%20site%20generator%20built%20in%20Ruby%21&hashtags=SpinUpBridgetown%2CJamstack" class="button is-info" rel="noopener">
             <span class="icon"> <i class="fa fa-twitter is-size-5"></i> </span>
             <span class="has-text-weight-bold">Tweet</span>
           </a>

--- a/bridgetown-website/src/_components/shared/navbar.liquid
+++ b/bridgetown-website/src/_components/shared/navbar.liquid
@@ -40,18 +40,18 @@
         <div class="navbar-item search-item">
           {% render "bridgetown_quick_search/search", placeholder: "Search", input_class: "input" %}
         </div>
-        <a class="navbar-item" href="https://github.com/{{ metadata.github }}" target="_blank">
+        <a class="navbar-item" href="https://github.com/{{ metadata.github }}" target="_blank" rel="noopener">
           <button class="button is-info is-small">
             <span class="icon"> <i class="fa fa-github is-size-6"></i> </span>
             <span class="has-text-weight-bold">Star</span>
           </button>
         </a>
 
-        <a class="navbar-item is-hidden-desktop-only" href="https://github.com/bridgetownrb/bridgetown/issues/new?assignees=&labels=bug&template=bug_report.md&title=" target="_blank">
+        <a class="navbar-item is-hidden-desktop-only" href="https://github.com/bridgetownrb/bridgetown/issues/new?assignees=&labels=bug&template=bug_report.md&title=" target="_blank" rel="noopener">
           <span class="icon"><i class="fa fa-exclamation-circle is-size-6"></i></span>
           <span class="is-hidden-tablet">Report Issue</span>
         </a>
-        <a class="navbar-item is-hidden-desktop-only" href="https://twitter.com/{{ metadata.twitter }}" target="_blank">
+        <a class="navbar-item is-hidden-desktop-only" href="https://twitter.com/{{ metadata.twitter }}" target="_blank" rel="noopener">
           <span class="icon"><i class="fa fa-twitter is-size-6"></i></span>
           <span class="is-hidden-tablet">Twitter</span>
         </a>

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -157,7 +157,7 @@
   description: >-
     Percent encodes any special characters in a URI.
     URI escape normally replaces a space with <code>%20</code>.
-    <a href="https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters">Reserved characters</a>
+    <a href="https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters" rel="noopener">Reserved characters</a>
     will not be escaped.
   examples:
     - input: '{{ "http://foo.com/?q=foo, \bar?" | uri_escape }}'
@@ -202,7 +202,7 @@
 #
 
 - name: Slugify
-  description: Convert a string into a lowercase URL "slug". <a href="http://localhost:4000/docs/liquid/filters/#options-for-the-slugify-filter">See below for options</a>.
+  description: Convert a string into a lowercase URL "slug". <a href="http://localhost:4000/docs/liquid/filters/#options-for-the-slugify-filter" rel="noopener">See below for options</a>.
   examples:
     - input: '{{ "The _config.yml file" | slugify }}'
       output: "the-config-yml-file"

--- a/bridgetown-website/src/_data/bridgetown_variables.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables.yml
@@ -146,7 +146,7 @@ page:
       If the page being processed is a Post, this contains a list of up to ten related Posts.
       By default, these are the ten most recent posts. For high quality but slow to compute
       results, run the <code>bridgetown</code> command with the <code>--lsi</code>
-      (<a href="https://en.wikipedia.org/wiki/Latent_semantic_analysis#Latent_semantic_indexing">latent semantic indexing</a>)
+      (<a href="https://en.wikipedia.org/wiki/Latent_semantic_analysis#Latent_semantic_indexing" rel="noopener">latent semantic indexing</a>)
       option.
 
 paginator:

--- a/bridgetown-website/src/_docs/components.md
+++ b/bridgetown-website/src/_docs/components.md
@@ -127,7 +127,7 @@ Now we can render that component and fill in the `logo`, `items_start`, and `ite
     <div class="navbar-item search-item">
       {% render "bridgetown_quick_search/search", placeholder: "Search", input_class: "input" %}
     </div>
-    <a class="navbar-item is-hidden-desktop-only" href="https://twitter.com/{{ metadata.twitter }}" target="_blank">
+    <a class="navbar-item is-hidden-desktop-only" href="https://twitter.com/{{ metadata.twitter }}" target="_blank" rel="noopener">
       <span class="icon"><i class="fa fa-twitter is-size-6"></i></span>
       <span class="is-hidden-tablet">Twitter</span>
     </a>

--- a/bridgetown-website/src/_docs/configuration/incremental-regeneration.md
+++ b/bridgetown-website/src/_docs/configuration/incremental-regeneration.md
@@ -34,6 +34,6 @@ configuration file.
   <p>
     While incremental regeneration will work for the most common cases, it will
     not work correctly in every scenario. Please report any problems not listed above by
-    <a href="https://github.com/bridgetownrb/bridgetown/issues/new">opening an issue on GitHub</a>.
+    <a href="https://github.com/bridgetownrb/bridgetown/issues/new" rel="noopener">opening an issue on GitHub</a>.
   </p>
 </div>

--- a/bridgetown-website/src/_docs/configuration/options.md
+++ b/bridgetown-website/src/_docs/configuration/options.md
@@ -107,9 +107,9 @@ class="flag">flags</code> (specified on the command-line) that control them.
             Set the time zone for site generation. This sets the <code>TZ</code>
             environment variable, which Ruby uses to handle time and date
             creation and manipulation. Any entry from the
-            <a href="https://en.wikipedia.org/wiki/Tz_database">IANA Time Zone
+            <a href="https://en.wikipedia.org/wiki/Tz_database" rel="noopener">IANA Time Zone
             Database</a> is valid, e.g. <code>America/New_York</code>. A list of all
-            available values can be found <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
+            available values can be found <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones" rel="noopener">
             here</a>. When serving on a local machine, the default time zone is set by your operating system. But when served on a remote host/server, the default time zone depends on the server's setting or location.
         </p>
       </td>
@@ -222,7 +222,7 @@ a staging area and copy files from there to your web server.
       <td>
         <p class="name"><strong>LSI</strong></p>
         <p class="description">Produce an index for related posts. Requires the
-          <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin.</p>
+          <a href="http://www.classifier-reborn.com/" rel="noopener">classifier-reborn</a> plugin.</p>
       </td>
       <td class="has-text-centered">
         <p><code class="option">lsi: BOOL</code></p>

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -146,9 +146,9 @@ author: dave
 ---
 
 {% assign author = site.data.people[page.author] %}
-<a rel="author"
+<a rel="author noopener"
   href="https://twitter.com/{{ author.twitter }}"
-  title="{{ author.name }}" rel="noopener">
+  title="{{ author.name }}">
     {{ author.name }}
 </a>
 ```

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -66,7 +66,7 @@ You can now render the list of members in a template:
 <ul>
 {% for member in site.data.members %}
   <li>
-    <a href="https://github.com/{{ member.github }}">
+    <a href="https://github.com/{{ member.github }}" rel="noopener">
       {{ member.name }}
     </a>
   </li>
@@ -114,7 +114,7 @@ file name:
 {% for org_hash in site.data.orgs %}
 {% assign org = org_hash[1] %}
   <li>
-    <a href="https://github.com/{{ org.username }}">
+    <a href="https://github.com/{{ org.username }}" rel="noopener">
       {{ org.name }}
     </a>
     ({{ org.members | size }} members)
@@ -148,7 +148,7 @@ author: dave
 {% assign author = site.data.people[page.author] %}
 <a rel="author"
   href="https://twitter.com/{{ author.twitter }}"
-  title="{{ author.name }}">
+  title="{{ author.name }}" rel="noopener">
     {{ author.name }}
 </a>
 ```

--- a/bridgetown-website/src/_docs/front-matter.md
+++ b/bridgetown-website/src/_docs/front-matter.md
@@ -172,7 +172,7 @@ For documents in the `posts` collection, these variables are available out-of-th
           use that to filter posts in various ways or use the "slugified" version of the
           category name to adjust the permalink for a post. Categories (plural key) can be
           specified as a <a
-          href="https://en.wikipedia.org/wiki/YAML#Basic_components">YAML list</a> or a
+          href="https://en.wikipedia.org/wiki/YAML#Basic_components" rel="noopener">YAML list</a> or a
           space-separated string.
         </p>
       </td>
@@ -184,9 +184,9 @@ For documents in the `posts` collection, these variables are available out-of-th
       <td>
         <p>
           Similar to categories, one or multiple tags can be added to a post as a flexible
-          method of building a lightweight content <a href="https://en.wikipedia.org/wiki/Taxonomy">taxonomy</a>.
+          method of building a lightweight content <a href="https://en.wikipedia.org/wiki/Taxonomy" rel="noopener">taxonomy</a>.
           As with categories, tags can be specified as a <a
-          href="https://en.wikipedia.org/wiki/YAML#Basic_components">YAML list</a> or a
+          href="https://en.wikipedia.org/wiki/YAML#Basic_components" rel="noopener">YAML list</a> or a
           space-separated string.
         </p>
       </td>

--- a/bridgetown-website/src/authors/author.html
+++ b/bridgetown-website/src/authors/author.html
@@ -18,9 +18,9 @@ prototype:
         Connect with
         {{ author.name }}
         on the
-        <a href="{{ author.website }}" class="has-text-weight-bold">Web</a>
+        <a href="{{ author.website }}" class="has-text-weight-bold" rel="noopener">Web</a>
         or
-        <a class="has-text-weight-bold" href="https://twitter.com/{{ author.twitter }}">Twitter</a>
+        <a class="has-text-weight-bold" href="https://twitter.com/{{ author.twitter }}" rel="noopener">Twitter</a>
       </p>
 
       {% for post in paginator.documents %}

--- a/bridgetown-website/src/plugins.html
+++ b/bridgetown-website/src/plugins.html
@@ -37,7 +37,7 @@ plugins: !ruby/string:Rb |
 
       {% for plugin in page.plugins %}
         <div class="box px-8 py-8 mb-10">
-          <a href="{{ plugin.html_url }}">
+          <a href="{{ plugin.html_url }}" rel="noopener">
             <h2 class="mb-8 title is-3 has-text-info">
               {{ plugin.name }}
               {% if plugin.gem_version %}
@@ -52,7 +52,7 @@ plugins: !ruby/string:Rb |
         
           <div class="mt-8 author">
             <img src="{{ plugin.owner.avatar_url }}" alt="{{ plugin.owner.login }}" class="avatar" />
-            <a href="{{ plugin.owner.html_url }}" class="has-text-weight-bold">{{ plugin.owner.login }}</a>
+            <a href="{{ plugin.owner.html_url }}" class="has-text-weight-bold" rel="noopener">{{ plugin.owner.login }}</a>
           </div>
         </div>
       {% endfor %}


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

https://github.com/bridgetownrb/bridgetown/pull/109 Pulled from here. This adds `rel="noopener"` to external HTTP links. It's one of the quick wins to help improve the lighthouse score.

![image](https://user-images.githubusercontent.com/325384/88315480-42130380-cd0e-11ea-8870-e8fd1d58fca5.png)

This solves the "Links to cross-origin destinations are unsafe" best practice. 

When I run https://web.dev/measure/ against the review app, that suggestion is now gone :)

## Context

https://github.com/bridgetownrb/bridgetown/issues/103
