### PR TITLE
Adding netlify.toml to add caching headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,37 @@
+[build]
+  base = "bridgetown-website/"
+  command = "yarn deploy"
+  publish = "output"
+
+[build.processing]
+  skip_processing = false
+[build.processing.css]
+  bundle = false
+  minify = false
+[build.processing.js]
+  bundle = false
+  minify = false
+[build.processing.html]
+  pretty_urls = true
+[build.processing.images]
+  compress = true
+
+[[headers]]
+  for = "*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=15552000; includeSubDomains"
+    Referrer-Policy = "no-referrer-when-downgrade"
+    Cache-Control = "public, max-age=604800, s-max-age=604800"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Link = [
+      "</apple-touch-icon.png>; rel=prefetch; as=image",
+      "<https://www.youtube-nocookie.com/embed/gSij_P3iaIE>; rel=preload"
+    ]
+
+[[headers]]
+  for = "/*.(png|jpg|js|css|svg|woff|ttf|eot|ico)"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, s-max-age=31536000"


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

https://github.com/bridgetownrb/bridgetown/pull/109 Pulled from here. Originally I thought it could be neat to add lots of [Early Hints headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103), but I think it's better to keep the changes small & easy to review :)

This adds caching headers served files. 


## Context

https://github.com/bridgetownrb/bridgetown/issues/103