### PR TITLE
Adding loading="lazy" to images near footer

### DIFF
--- a/bridgetown-website/src/_components/content/news_item.liquid
+++ b/bridgetown-website/src/_components/content/news_item.liquid
@@ -9,7 +9,7 @@
 
   <div class="mt-8 author p-author">
     {% assign author = authors[post.author] %}
-    <img src="{{ author.avatar }}" alt="{{ author.name }}" class="avatar u-photo" />
+    <img src="{{ author.avatar }}" alt="{{ author.name }}" class="avatar u-photo" loading="lazy" />
     <a href="/authors/{{ post.author }}/" class="has-text-weight-bold u-url p-name">{{ author.name }}</a>
     on {{ post.date | date: "%B %-d, %Y" }}
   </div>

--- a/bridgetown-website/src/_components/shared/footer.liquid
+++ b/bridgetown-website/src/_components/shared/footer.liquid
@@ -66,7 +66,7 @@
 
     <p class="mt-12 has-text-centered">
       <strong style="opacity:.7">we</strong>
-      <img src="/images/ruby.svg" alt="Ruby" style="height: 1.5rem;vertical-align:middle;margin: 0 0.5rem" />
+      <img src="/images/ruby.svg" alt="Ruby" style="height: 1.5rem;vertical-align:middle;margin: 0 0.5rem" loading="lazy" />
       <strong style="opacity:.7">ruby</strong>
     </p>
   </div>

--- a/bridgetown-website/src/plugins.html
+++ b/bridgetown-website/src/plugins.html
@@ -51,7 +51,7 @@ plugins: !ruby/string:Rb |
           </div>
         
           <div class="mt-8 author">
-            <img src="{{ plugin.owner.avatar_url }}" alt="{{ plugin.owner.login }}" class="avatar" />
+            <img src="{{ plugin.owner.avatar_url }}" alt="{{ plugin.owner.login }}" class="avatar" loading="lazy" />
             <a href="{{ plugin.owner.html_url }}" class="has-text-weight-bold">{{ plugin.owner.login }}</a>
           </div>
         </div>

--- a/bridgetown-website/test/test_blog.rb
+++ b/bridgetown-website/test/test_blog.rb
@@ -12,7 +12,7 @@ class TestBlog < Minitest::Test
     should "show authors" do
       assert_select ".box .author img" do |imgs|
         assert_dom_equal imgs.last.to_html,
-                         '<img src="/images/jared-white-avatar.jpg" alt="Jared White" class="avatar u-photo">'
+                         '<img src="/images/jared-white-avatar.jpg" alt="Jared White" class="avatar u-photo" loading="lazy">'
       end
     end
 


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

This lazy loads of images which are not in the initial viewport of the homepage. It's the same approach I used on the iFrame & it looks super effective on https://web.dev/measure/

Only catch with this PR is you can see the images loading in if you scroll fast enough.

## Context

Continuing on from https://github.com/bridgetownrb/bridgetown/pull/108 which was inspired by https://github.com/bridgetownrb/bridgetown/issues/103
