### PR TITLE
Fix the "add_yarn_for_gem" action

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -68,12 +68,20 @@ module Bridgetown
     # If that exact package hasn't been installed, execute yarn add
     #
     # Returns nothing.
-    def self.install_yarn_dependencies(required_gems)
+    def self.install_yarn_dependencies(required_gems, single_gemname = nil)
       return unless File.exist?("package.json")
 
       package_json = JSON.parse(File.read("package.json"))
 
-      required_gems.each do |loaded_gem|
+      gems_to_search = if single_gemname
+                         required_gems.select do |loaded_gem|
+                           loaded_gem.to_spec&.name == single_gemname.to_s
+                         end
+                       else
+                         required_gems
+                       end
+
+      gems_to_search.each do |loaded_gem|
         yarn_dependency = find_yarn_dependency(loaded_gem)
         next unless add_yarn_dependency?(yarn_dependency, package_json)
 


### PR DESCRIPTION
This gets the action working again so you can do this in an automation:

```ruby
add_bridgetown_plugin :bulmatown
add_yarn_for_gem :bulmatown
```

I'd add tests but almost everything else in this flow is already tested and this part is very specific to gem specifications so it'd require mocking the gem specs…so will hold off for the time being.