### PR TITLE
Add Dokku installation instructions to the guides section in the website

### DIFF
--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -51,3 +51,55 @@ For a simple method of deployment, you can simply transfer the contents of your 
 Rsync is similar to scp except it can be faster as it will only send changed
 parts of files as opposed to the entire file. You can learn more about using
 rsync in the [Digital Ocean tutorial](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories-on-a-vps).
+
+### dokku
+
+[Dokku](http://dokku.viewdocs.io/dokku) is great if you either want Heroku-style
+deployments on a budget or you want more control over your server stack.
+Deploying to Dokku is ridiculously easy, but as always, there are a few settings
+required to make everything run smoothly.
+
+This guide assumes you've got a fully-functioning Dokku server up and running
+and created an app we'll conveniently call `bridgetown`.
+
+First, add the following environment variables to your app on the server:
+
+```shell
+$ dokku config:set bridgetown BRIDGETOWN_ENV=production NGINX_ROOT=output
+```
+
+Next, create a file called `.buildpacks` at the root of your local project with
+the following contents to tell Dokku about the app's requirements:
+
+```
+https://github.com/heroku/heroku-buildpack-ruby
+https://github.com/heroku/heroku-buildpack-nodejs
+https://github.com/dokku/buildpack-nginx
+```
+
+Also, create an empty file called `.static` in the same location. This file will
+tell dokku to run the app as a static website using Nginx.
+
+Finally, add the following line to the `scripts` section in your package.json:
+
+```js
+{
+  // ...
+  "scripts": {
+    // ...
+    "heroku-postbuild": "yarn deploy",
+    // ...
+  },
+  // ...
+}
+```
+
+The nodejs buildpack will automatically run `yarn heroku-postbuild` at the right
+time during the deployment process, so there is nothing left to do. You can now
+safely deploy your application:
+
+```shell
+$ git push dokku
+```
+
+... and watch your site being built on the server.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
This PR adds instructions to the deployment section in the guides on how to configure your Bridgetown project to deploy it to a Dokku server. The same instructions may work as well on Heroku, but I haven't tested it.

The guide is a bit longer than the rest of the instructions on that page and I wasn't sure if it needed a separate page or not. Please let me know if I need to change the wording/writing style or put it in a separate page.