### PR TITLE
First pass at implementing site locales and translations

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Site::Localizable
+    def locale
+      if @locale
+        @locale
+      else
+        @locale = ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
+        I18n.load_path << Dir[in_source_dir("_locales") + "/*.yml"]
+        I18n.available_locales = config[:available_locales]
+        I18n.default_locale = @locale
+      end
+    end
+
+    def locale=(new_locale)
+      I18n.locale = @locale = new_locale.to_sym
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -52,6 +52,8 @@ module Bridgetown
       "show_dir_listing"     => false,
 
       # Output Configuration
+      "available_locales"    => ["en"],
+      "default_locale"       => "en",
       "permalink"            => "date",
       "timezone"             => nil, # use the local timezone
 

--- a/bridgetown-core/lib/bridgetown-core/drops/site_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/site_drop.rb
@@ -8,7 +8,7 @@ module Bridgetown
       mutable false
 
       def_delegator  :@obj, :data
-      def_delegators :@obj, :time, :pages, :static_files, :tags, :categories
+      def_delegators :@obj, :locale, :time, :pages, :static_files, :tags, :categories
 
       private def_delegator :@obj, :config, :fallback_data
 

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -20,6 +20,10 @@ module Bridgetown
       def webpack_path(asset_type)
         Bridgetown::Utils.parse_webpack_manifest_file(@site, asset_type.to_s)
       end
+
+      def t(*args)
+        I18n.send :t, *args
+      end
     end
 
     attr_reader :layout, :page, :site, :content

--- a/bridgetown-core/lib/bridgetown-core/site.rb
+++ b/bridgetown-core/lib/bridgetown-core/site.rb
@@ -7,6 +7,7 @@ module Bridgetown
     include Configurable
     include Content
     include Extensible
+    include Localizable
     include Processable
     include Renderable
     include Writable
@@ -25,6 +26,7 @@ module Bridgetown
     # config - A Hash containing site configuration details.
     def initialize(config)
       self.config = config
+      locale
 
       @plugin_manager  = PluginManager.new(self)
       @cleaner         = Cleaner.new(self)

--- a/bridgetown-core/lib/bridgetown-core/tags/t.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/t.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Tags
+    class TranslationTag < Liquid::Tag
+      def render(_context)
+        key = @markup.strip
+        I18n.t(key)
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("t", Bridgetown::Tags::TranslationTag)


### PR DESCRIPTION
Partially addresses #49 

This PR adds two new concepts to Bridgetown:

* Available locales. You can now add an `available_locales` key to your config to list one or more locales (en, fr, zh, etc.) OOTB it's "en". Bridgetown will configure the I18n gem with those locales and to look for YAML files in `src/_locales`, so you can add translation files just like you would in a Rails app.
* Current locale. A site always has a current locale, configured either by the `BRIDGETOWN_LOCALE` environment variable if present or the `default_locale` config key. You can access this value in templates via `site.locale`, and in Ruby code (plugins, etc.) you can switch the current site locale via `site.locale = :de`.

It also adds a `t` helper for ERB/etc. templates and a `t` Liquid tag. The Liquid tag is currently very basic so it doesn't support default values, interpolation, etc. The ERB/etc. helper just aliases `I18n.t` so you get the full power of that method.

I think this is a good start to adding multilingual site support. Theoretically, just this functionality could let you write a script to build a site multiple times, each with a different `BRIDGETOWN_LOCALE` env var and destination folder, and then you'd get multiple sites that have different translations for the same URLs that you could host on `en.domain.com`, `fr.domain.com`, etc.

I suspect many people though (including myself) want the `domain.com/foo`, `domain.com/fr/foo`, `domain.com/zh/foo` approach, so that would still require additional work in another PR(s) so that all languages are processed through a single build process.