### PR TITLE
Process data cascade for folder-based frontmatter defaults

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -68,6 +68,7 @@ module Bridgetown
   autoload :Cache,               "bridgetown-core/cache"
   autoload :CollectionReader,    "bridgetown-core/readers/collection_reader"
   autoload :DataReader,          "bridgetown-core/readers/data_reader"
+  autoload :DefaultsReader,      "bridgetown-core/readers/defaults_reader"
   autoload :LayoutReader,        "bridgetown-core/readers/layout_reader"
   autoload :PostReader,          "bridgetown-core/readers/post_reader"
   autoload :PageReader,          "bridgetown-core/readers/page_reader"

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
@@ -37,6 +37,10 @@ module Bridgetown
       @config
     end
 
+    def defaults_reader
+      @defaults_reader ||= DefaultsReader.new(self)
+    end
+
     # Returns the current instance of {FrontmatterDefaults} or
     # creates a new instance {FrontmatterDefaults} if it doesn't already exist.
     #

--- a/bridgetown-core/lib/bridgetown-core/reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/reader.rb
@@ -13,6 +13,7 @@ module Bridgetown
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
     def read
+      @site.defaults_reader.read
       @site.layouts = LayoutReader.new(site).read
       read_directories
       read_included_excludes

--- a/bridgetown-core/lib/bridgetown-core/readers/collection_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/collection_reader.rb
@@ -5,6 +5,7 @@ module Bridgetown
     SPECIAL_COLLECTIONS = %w(posts data).freeze
 
     attr_reader :site, :content
+
     def initialize(site)
       @site = site
       @content = {}

--- a/bridgetown-core/lib/bridgetown-core/readers/data_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/data_reader.rb
@@ -3,6 +3,7 @@
 module Bridgetown
   class DataReader
     attr_reader :site, :content
+
     def initialize(site)
       @site = site
       @content = ActiveSupport::HashWithIndifferentAccess.new

--- a/bridgetown-core/lib/bridgetown-core/readers/defaults_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/defaults_reader.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  class DefaultsReader
+    attr_reader :site, :path_defaults
+
+    def initialize(site)
+      @site = site
+      @path_defaults = ActiveSupport::HashWithIndifferentAccess.new
+    end
+
+    def read
+      entries = Dir.chdir(site.in_source_dir) do
+        Dir["**/_defaults.{yaml,yml,json}"]
+      end
+
+      entries.each do |entry|
+        path = @site.in_source_dir(entry)
+        @path_defaults[File.dirname(path) + File::SEPARATOR] = SafeYAML.load_file(path)
+      end
+
+      @path_defaults
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/readers/defaults_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/defaults_reader.rb
@@ -10,7 +10,9 @@ module Bridgetown
     end
 
     def read
-      entries = Dir.chdir(site.in_source_dir) do
+      return unless File.directory?(site.source)
+
+      entries = Dir.chdir(site.source) do
         Dir["**/_defaults.{yaml,yml,json}"]
       end
 

--- a/bridgetown-core/lib/bridgetown-core/readers/layout_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/layout_reader.rb
@@ -3,6 +3,7 @@
 module Bridgetown
   class LayoutReader
     attr_reader :site
+
     def initialize(site)
       @site = site
       @layouts = {}

--- a/bridgetown-core/lib/bridgetown-core/readers/page_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/page_reader.rb
@@ -3,6 +3,7 @@
 module Bridgetown
   class PageReader
     attr_reader :site, :dir, :unfiltered_content
+
     def initialize(site, dir)
       @site = site
       @dir = dir

--- a/bridgetown-core/lib/bridgetown-core/readers/post_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/post_reader.rb
@@ -3,6 +3,7 @@
 module Bridgetown
   class PostReader
     attr_reader :site, :unfiltered_content
+
     def initialize(site)
       @site = site
     end

--- a/bridgetown-core/lib/bridgetown-core/readers/static_file_reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/readers/static_file_reader.rb
@@ -3,6 +3,7 @@
 module Bridgetown
   class StaticFileReader
     attr_reader :site, :dir, :unfiltered_content
+
     def initialize(site, dir)
       @site = site
       @dir = dir

--- a/bridgetown-core/test/source/src/_posts/_defaults.yml
+++ b/bridgetown-core/test/source/src/_posts/_defaults.yml
@@ -1,0 +1,1 @@
+ruby3: groovy

--- a/bridgetown-core/test/source/src/_posts/es/_defaults.yml
+++ b/bridgetown-core/test/source/src/_posts/es/_defaults.yml
@@ -1,0 +1,1 @@
+ruby3: trippin

--- a/bridgetown-core/test/source/src/_posts/es/further/2020-09-10-further-nested.md
+++ b/bridgetown-core/test/source/src/_posts/es/further/2020-09-10-further-nested.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Further Nested
+---
+
+url: {{ page.url }}
+date: {{ page.date }}
+id: {{ page.id }}

--- a/bridgetown-core/test/test_defaults_reader.rb
+++ b/bridgetown-core/test/test_defaults_reader.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDefaultsReader < BridgetownUnitTest
+  def setup
+    @reader = DefaultsReader.new(fixture_site)
+    @reader.read
+  end
+
+  context "default files" do
+    should "be loaded" do
+      assert_equal "groovy", @reader.path_defaults[fixture_site.source + "/_posts/"][:ruby3]
+      assert_equal "trippin", @reader.path_defaults[fixture_site.source + "/_posts/es/"][:ruby3]
+    end
+  end
+end

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -657,6 +657,7 @@ class TestFilters < BridgetownUnitTest
           "categories"    => [
             "publish_test",
           ],
+          "ruby3"         => "groovy",
           "layout"        => "default",
           "title"         => "Publish",
           "category"      => "publish_test",

--- a/bridgetown-core/test/test_front_matter_defaults.rb
+++ b/bridgetown-core/test/test_front_matter_defaults.rb
@@ -222,4 +222,19 @@ class TestFrontMatterDefaults < BridgetownUnitTest
       assert(@site.posts.find { |page| page.data["date"] == date })
     end
   end
+
+  context "A site with front matter data cascade" do
+    setup do
+      @site = fixture_site
+      @site.process
+    end
+
+    should "have a post with a value from the defaults file" do
+      assert(@site.posts.find { |page| page.data[:title] == "Post with Permalink" }.data[:ruby3] == "groovy")
+    end
+
+    should "have an overridden value in a subtree" do
+      assert(@site.posts.find { |page| page.data[:title] == "Further Nested" }.data[:ruby3] == "trippin")
+    end
+  end
 end

--- a/bridgetown-core/test/test_generated_site.rb
+++ b/bridgetown-core/test/test_generated_site.rb
@@ -16,7 +16,7 @@ class TestGeneratedSite < BridgetownUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 60, @site.posts.size
+      assert_equal 61, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/bridgetown-core/test/test_site.rb
+++ b/bridgetown-core/test/test_site.rb
@@ -53,7 +53,7 @@ class TestSite < BridgetownUnitTest
   context "creating sites" do
     setup do
       @site = Site.new(site_configuration)
-      @num_invalid_posts = 5
+      @num_invalid_posts = 7
     end
 
     teardown do

--- a/bridgetown-website/bridgetown.config.yml
+++ b/bridgetown-website/bridgetown.config.yml
@@ -14,25 +14,6 @@ collections:
     name: Documentation
     foo: bar
 
-defaults:
-  - scope:
-      path: ""
-    values:
-      image: /images/bridgetown-logo-twitter-card.jpg
-  - scope:
-      path: _docs
-    values:
-      layout: docs
-  - scope:
-      path: _posts
-    values:
-      layout: post
-      category: news
-  - scope:
-      path: _posts/drafts
-    values:
-      published: false
-
 pagination:
   enabled: true
 

--- a/bridgetown-website/src/_defaults.yml
+++ b/bridgetown-website/src/_defaults.yml
@@ -1,1 +1,1 @@
-image: /images/bridgetown-logo-twitter-cardddd.jpg
+image: /images/bridgetown-logo-twitter-card.jpg

--- a/bridgetown-website/src/_defaults.yml
+++ b/bridgetown-website/src/_defaults.yml
@@ -1,0 +1,1 @@
+image: /images/bridgetown-logo-twitter-cardddd.jpg

--- a/bridgetown-website/src/_docs/_defaults.yml
+++ b/bridgetown-website/src/_docs/_defaults.yml
@@ -1,0 +1,1 @@
+layout: docs

--- a/bridgetown-website/src/_posts/_defaults.yml
+++ b/bridgetown-website/src/_posts/_defaults.yml
@@ -1,0 +1,2 @@
+layout: post
+category: news

--- a/bridgetown-website/src/_posts/drafts/_defaults.yml
+++ b/bridgetown-website/src/_posts/drafts/_defaults.yml
@@ -1,0 +1,1 @@
+published: false


### PR DESCRIPTION
Related to #50 

This PR provides the ability to put a `_defaults.yml/yaml/json` file(s) anywhere in the source tree, which will then cause a "data cascade" — aka pages/documents will pull their front matter defaults from one or more defaults files in the tree with subfolders potentially overriding values from their parents.

While this isn't a 100% replacement for the previous defaults config syntax, as you can see here with the changes made to the Bridgetown website, it very well can be a wholesale replacement.

Still needs documentation/tests.