### PR TITLE
Add reading_time filter/helper

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -138,6 +138,14 @@ module Bridgetown
       input.split.length
     end
 
+    # Calculates the average reading time of the supplied content.
+    # @param input [String] the String of content to analyze.
+    # @return [Float] the number of minutes required to read the content.
+    def reading_time(input, round_to = 0)
+      wpm = @context.registers[:site].config[:reading_time_wpm] || 250
+      (number_of_words(input).to_f / wpm).ceil(round_to)
+    end
+
     # Join an array of things into a string by separating with commas and the
     # word "and" for the last one.
     #

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -167,6 +167,17 @@ class TestFilters < BridgetownUnitTest
       assert_equal 7, @filter.number_of_words("These aren't the droids you're looking for.")
     end
 
+    should "reading_time filter" do
+      assert_equal 3, @filter.reading_time("word " * 551)
+
+      new_wpm_filter = make_filter_mock(
+        "reading_time_wpm" => 300
+      )
+
+      assert_equal 2, new_wpm_filter.reading_time("word " * 551)
+      assert_equal 1.84, new_wpm_filter.reading_time("word " * 551, 2)
+    end
+
     context "normalize_whitespace filter" do
       should "replace newlines with a space" do
         assert_equal "a b", @filter.normalize_whitespace("a\nb")

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -173,6 +173,15 @@
 
 #
 
+- name: Reading Time
+  description: Returns the average number of minutes to read the supplied content. Based on 250 WPM but that can be changed using the <code>reading_time_wpm</code> configuration variable. You can also pass an argument to specify which decimal point to round to (defaults to 0 for no decimals).
+  examples:
+    - input: "{{ page.content | reading_time }} minutes"
+      output: "4 minutes"
+    - input: "{{ page.content | reading_time: 1 }} minutes"
+      output: "3.2 minutes"
+#
+
 - name: Array to Sentence
   description: >-
     Convert an array into a sentence. Useful for listing tags.


### PR DESCRIPTION
Close #129.

I thought about making the filter output a word like "minute" or "minutes" along with the number, but then you run into issues like localization or capitalization or whatever, so I figured just outputting a number is good enough. Let the template handle additional wording.

- [x] Tests
- [x] Documentation