### PR TITLE
Support a _pages folder in the source tree

### DIFF
--- a/bridgetown-core/features/permalinks.feature
+++ b/bridgetown-core/features/permalinks.feature
@@ -142,3 +142,13 @@ Feature: Fancy permalinks
     And the output directory should exist
     And I should see "I am PHP" in "output/2016/i-am-php.php"
     And I should see "I am also PHP" in "output/i-am-also-php.php"
+
+  Scenario: Ensure putting pages in _pages doesn't add _pages to permalink
+    Given I have a _pages/test directory
+    And I have a "_pages/test/mypage.md" page that contains "I am a page!"
+    And I have a "_pages/anotherpage.md" page with permalink "/some/other/page" that contains "I am another page!"
+    When I run bridgetown build
+    Then I should get a zero exit status
+    And the output directory should exist
+    And I should see "I am a page!" in "output/test/mypage.html"
+    And I should see "I am another page!" in "output/some/other/page.html"

--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -311,6 +311,10 @@ module Bridgetown
         raise Bridgetown::Errors::InvalidConfigurationError,
               "'#{option}' should be set as an array, but was: #{self[option].inspect}."
       end
+
+      # add _pages to includes set
+      self[:include] << "_pages"
+
       self
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/page.rb
+++ b/bridgetown-core/lib/bridgetown-core/page.rb
@@ -121,10 +121,16 @@ module Bridgetown
     # desired placeholder replacements. For details see "url.rb"
     def url_placeholders
       {
-        path: @dir,
+        path: qualified_pages_path_for_url,
         basename: basename,
         output_ext: output_ext,
       }
+    end
+
+    # Strips _pages prefix off if needed for the url/destination generation
+    # @return [String]
+    def qualified_pages_path_for_url
+      @dir.sub(%r!^/_pages!, "")
     end
 
     # Extract information from the page filename.

--- a/bridgetown-core/test/test_entry_filter.rb
+++ b/bridgetown-core/test/test_entry_filter.rb
@@ -13,7 +13,7 @@ class TestEntryFilter < BridgetownUnitTest
                 .baz.markdow foo.markdown~ .htaccess _posts _pages ~$benbalter.docx)
 
       entries = EntryFilter.new(@site).filter(ent1)
-      assert_equal %w(foo.markdown bar.markdown baz.markdown .htaccess), entries
+      assert_equal %w(foo.markdown bar.markdown baz.markdown .htaccess _pages), entries
     end
 
     should "allow regexp filtering" do

--- a/bridgetown-website/src/_docs/pages.md
+++ b/bridgetown-website/src/_docs/pages.md
@@ -16,7 +16,7 @@ a homepage, an about page, and a contact page, here’s what the source folder
 and associated URLs might look like:
 
 ```
-.
+src
 ├── about.md    # => http://example.com/about.html
 ├── index.html    # => http://example.com/
 └── contact.html  # => http://example.com/contact.html
@@ -25,12 +25,24 @@ and associated URLs might look like:
 If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in your project's source will then exist in the `output` folder when your site builds. However, when a page has a *different* permalink set in the front matter, the subfolder at `output` changes accordingly.
 
 ```
-.
+src
 ├── about.md          # => http://example.com/about.html
 ├── documentation     # folder containing pages
 │   └── doc1.md       # => http://example.com/documentation/doc1.html
 ├── design            # folder containing pages
 │   └── draft.md      # => http://example.com/design/draft.html
+```
+
+You can also choose to place the pages folder tree within a top-level `src/_pages` folder to line up with `_posts`, `_data`, and any other collections you've configured.
+
+```
+src
+└── _pages
+    ├── about.md          # => http://example.com/about.html
+    ├── documentation     # folder containing pages
+    │   └── doc1.md       # => http://example.com/documentation/doc1.html
+    ├── design            # folder containing pages
+    │   └── draft.md      # => http://example.com/design/draft.html
 ```
 
 ## Changing the output URL
@@ -53,7 +65,13 @@ Front matter variables are available in Liquid via the `page` variable. For exam
 {% raw %}{{ page.my_number }}{% endraw %}
 ```
 
-Note that in order for Bridgetown to process any Liquid tags on your page, you must include front matter on it. The most minimal snippet of front matter you can include is:
+Or if you're using ERB template engine:
+
+```erb
+<%= page.data.my_number %>
+```
+
+Note that in order for Bridgetown to process pages through Liquid, ERB, etc., you must include front matter on it. The most minimal snippet of front matter you can include is:
 
 ```yaml
 ---

--- a/bridgetown-website/src/_docs/structure.md
+++ b/bridgetown-website/src/_docs/structure.md
@@ -102,7 +102,7 @@ The location of pages in your source folder structure will by default be mirrore
       </td>
       <td>
         <p>
-          Provided that the file has a <a href="/docs/front-matter/">front matter</a> section, it will be transformed by Bridgetown. You can create subfolders (and subfolders of subfolders) to organize your pages.
+          Provided that the file has a <a href="/docs/front-matter/">front matter</a> section, it will be transformed by Bridgetown. You can create subfolders (and subfolders of subfolders) to organize your pages. You can also locate pages within <code>_pages</code> to line up with <code>_posts</code>, <code>_data</code>, etc.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
Fixes #57

This was a surprisingly non-trivial change. I've seen some folks over on the Jekyll side create a collection called `pages` and use that, but getting the native page reader and final permalinks to support a `_pages` folder required a bit of tweaking. I'm on the fence if this should be the "default" pattern now (aka update the site template for `bridgetown new` to use a `_pages` folder), but at least it will be fully supported going forward.

- [x] Tests
- [x] Documentation