### PR TITLE
build: add matrix testing for Ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,11 @@ jobs:
     strategy:
       matrix:
         ruby_version: [2.5.x, 2.6.x, 2.7.x, head, debug]
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@master
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.46
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby 2.6
+      - uses: actions/checkout@master
+      - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
-      - uses: actions/cache@v1
+          ruby-version: ${{ matrix.ruby_version }}
+      - uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
+        ruby_version: [2.5.x, 2.6.x, 2.7.x, head, debug]
     steps:
       - uses: actions/checkout@master
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.46
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - uses: actions/cache@v2
@@ -26,9 +26,11 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
-      - name: Build and test with Rake
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+      - name: Install Bundler
+        run: gem install bundler
+      - name: Configure vendor path
+        run: bundle config path vendor/bundle
+      - name: Bundle Install
+        run: bundle install --jobs 4 --retry 3
+      - name: Test with Rake
+        run: bundle exec rake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.8, 2.6.6, 2.7.1, ruby-head, debug]
+        ruby_version: [2.5.8, 2.6.6, 2.7.2]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.8, 2.6.6, 2.7.1, head, debug]
+        ruby_version: [2.5.8, 2.6.6, 2.7.1, ruby-head, debug]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.x, 2.6.x, 2.7.x, head, debug]
+        ruby_version: [2.5.8, 2.6.6, 2.7.1, head, debug]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This is a 🙋 feature or enhancement. 

## Summary

I hit an issue on Ruby 3 (that I will open in a sec), and was hoping that GitHub may provide access to use it but I see not. I am going to try a few other things but I think some matrix testing would help make sure that people on lower ruby versions aren't affected in changes.

## Context

1min
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
