### PR TITLE
False value supported for no layouts

### DIFF
--- a/bridgetown-core/features/rendering.feature
+++ b/bridgetown-core/features/rendering.feature
@@ -99,6 +99,7 @@ Feature: Rendering
     Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
     And I have a _trials directory
     And I have a "_trials/no-layout.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
+    And I have a "_trials/false-layout.md" page with layout "false" that contains "Hi there, {{ site.author }}!"
     And I have a "_trials/test.md" page with layout "null" that contains "Hi there, {{ site.author }}!"
     And I have a none layout that contains "{{ content }}Welcome!"
     And I have a page layout that contains "{{ content }}Check this out!"
@@ -112,6 +113,7 @@ Feature: Rendering
     And the output directory should exist
     And I should not see "Welcome!" in "output/trials/no-layout.html"
     And I should not see "Check this out!" in "output/trials/no-layout.html"
+    And I should not see "Check this out!" in "output/trials/false-layout.html"
     But I should see "Check this out!" in "output/trials/test.html"
     And I should see "Hi there, John Doe!" in "output/index.html"
     And I should not see "Welcome!" in "output/index.html"

--- a/bridgetown-core/lib/bridgetown-core/concerns/layout_placeable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/layout_placeable.rb
@@ -11,7 +11,7 @@ module Bridgetown
     end
 
     def no_layout?
-      data["layout"] == "none"
+      data["layout"] == "none" || data["layout"] == false
     end
   end
 end

--- a/bridgetown-website/src/_docs/front-matter.md
+++ b/bridgetown-website/src/_docs/front-matter.md
@@ -82,10 +82,8 @@ front matter of a page or post.
             front matter defaults</a>.
           </li>
           <li>
-            Using <code>none</code> in a post/document will
-            produce a file without using a layout file regardless of front matter defaults.
-            Using <code>none</code> in a page will cause Bridgetown to attempt to
-            use a layout named "none".
+            Using <code>none</code> will produce a file without using a layout file
+            regardless of front matter defaults.
           </li>
         </ul>
       </td>

--- a/bridgetown-website/src/_docs/layouts.md
+++ b/bridgetown-website/src/_docs/layouts.md
@@ -57,9 +57,6 @@ You have full access to the front matter of the origin. In the
 example above, `page.title` comes from the page front matter.
 
 Next you need to specify what layout you're using in your page's front matter.
-You can also use
-[front matter defaults](/docs/configuration/front-matter-defaults/) to save you
-from having to set this on every page.
 
 ```markdown
 ---
@@ -95,6 +92,10 @@ The rendered output of this page is:
   </body>
 </html>
 ```
+
+You can also use
+[front matter defaults](/docs/configuration/front-matter-defaults/) to save you
+from having to set a layout for every page. Note that if you have defaults in place and you _don't_ want a certain page to render in a layout, you can specify `layout: none` in the page's front matter.
 
 ## Inheritance
 


### PR DESCRIPTION
Fixes #159 

Previously only `layout: none` would reliably switch off layout processing for a document even in the presence of front matter defaults. This PR allows `layout: false` as well.

- [x] Tests
- [x] Documentation