### PR TITLE
Obfuscate link filter

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -120,6 +120,20 @@ module Bridgetown
       Addressable::URI.normalize_component(input)
     end
 
+    # Obfuscate an email, telephone number etc.
+    #
+    # @param input[String] the String containing the contact information (email, phone etc.)
+    # @param prefix[String] the URL scheme to prefix (default "mailto")
+    # @return [String] a link that is unreadable for bots but will be recovered on focus or mouseover
+    def obfuscate_link(input, prefix="mailto")
+      output = "<a href=\"obfuscated\" "
+      output += "style=\"unicode-bidi: bidi-override; direction: rtl\" "
+      output += "onfocus=\"this.href = '#{prefix}:#{input}'\" "
+      output += "onmouseover=\"this.href = '#{prefix}:#{input}'\">"
+      output += "<script type=\"text/javascript\">document.write(\"#{input}\".split('').reverse().join('').replace('(', ')').replace(')', '('));</script></a>"
+      output
+    end
+
     # Replace any whitespace in the input string with a single space
     #
     # input - The String on which to operate.

--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -124,13 +124,16 @@ module Bridgetown
     #
     # @param input[String] the String containing the contact information (email, phone etc.)
     # @param prefix[String] the URL scheme to prefix (default "mailto")
-    # @return [String] a link that is unreadable for bots but will be recovered on focus or mouseover
-    def obfuscate_link(input, prefix="mailto")
+    # @return [String] a link unreadable for bots but will be recovered on focus or mouseover
+    def obfuscate_link(input, prefix = "mailto")
       output = "<a href=\"obfuscated\" "
       output += "style=\"unicode-bidi: bidi-override; direction: rtl\" "
       output += "onfocus=\"this.href = '#{prefix}:#{input}'\" "
       output += "onmouseover=\"this.href = '#{prefix}:#{input}'\">"
-      output += "<script type=\"text/javascript\">document.write(\"#{input}\".split('').reverse().join('').replace('(', ')').replace(')', '('));</script></a>"
+      output += "<script type=\"text/javascript\">"
+      output += "document.write(\"#{input}\".split('').reverse().join('')"
+      output += ".replace('(', ')').replace(')', '('));"
+      output += "</script></a>"
       output
     end
 

--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -126,15 +126,13 @@ module Bridgetown
     # @param prefix[String] the URL scheme to prefix (default "mailto")
     # @return [String] a link unreadable for bots but will be recovered on focus or mouseover
     def obfuscate_link(input, prefix = "mailto")
-      output = "<a href=\"obfuscated\" "
-      output += "style=\"unicode-bidi: bidi-override; direction: rtl\" "
-      output += "onfocus=\"this.href = '#{prefix}:#{input}'\" "
-      output += "onmouseover=\"this.href = '#{prefix}:#{input}'\">"
-      output += "<script type=\"text/javascript\">"
-      output += "document.write(\"#{input}\".split('').reverse().join('')"
-      output += ".replace('(', ')').replace(')', '('));"
-      output += "</script></a>"
-      output
+      link = "<a href=\"#{prefix}:#{input}\">#{input}</a>"
+      script = "<script type=\"text/javascript\">document.currentScript.insertAdjacentHTML("
+      script += "beforebegin', '#{rot47(link)}'.replace(/[!-~]/g,"
+      script += "function(c){{var j=c.charCodeAt(0);if((j>=33)&&(j<=126)){"
+      script += "return String.fromCharCode(33+((j+ 14)%94));}"
+      script += "else{return String.fromCharCode(j);}}}));</script>"
+      script
     end
 
     # Replace any whitespace in the input string with a single space
@@ -341,6 +339,11 @@ module Bridgetown
     end
 
     private
+
+    # Perform a rot47 rotation for obfuscation
+    def rot47(input)
+      input.tr "!-~", "P-~!-O"
+    end
 
     # Sort the input Enumerable by the given property.
     # If the property doesn't exist, return the sort order respective of

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -395,6 +395,27 @@ class TestFilters < BridgetownUnitTest
       )
     end
 
+    should "obfuscate email addresses" do
+      assert_match(
+        %r{<a href=\"obfuscated\".*this\.href = 'mailto:},
+        @filter.obfuscate_link("test@example.com")
+      )
+    end
+
+    should "obfuscate phone numbers" do
+      assert_match(
+        %r{<a href=\"obfuscated\".*this\.href = 'tel:},
+        @filter.obfuscate_link("+1 234 567", "tel:")
+      )
+    end
+
+    should "obfuscate sms targets" do
+      assert_match(
+        %r{<a href=\"obfuscated\".*this\.href = 'sms:},
+        @filter.obfuscate_link("&body=Hello", "sms:")
+      )
+    end
+
     context "absolute_url filter" do
       should "produce an absolute URL from a page URL" do
         page_url = "/about/my_favorite_page/"

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -397,22 +397,22 @@ class TestFilters < BridgetownUnitTest
 
     should "obfuscate email addresses" do
       assert_match(
-        %r!<a href=\"obfuscated\".*this\.href = 'mailto:!,
+        %r!>2:=E@iE6DEo6I2>A=6]4@>!,
         @filter.obfuscate_link("test@example.com")
       )
     end
 
     should "obfuscate phone numbers" do
       assert_match(
-        %r!<a href=\"obfuscated\".*this\.href = 'tel:!,
-        @filter.obfuscate_link("+1 234 567", "tel:")
+        %r!E6=iZ` abc def!,
+        @filter.obfuscate_link("+1 234 567", "tel")
       )
     end
 
     should "obfuscate sms targets" do
       assert_match(
-        %r!<a href=\"obfuscated\".*this\.href = 'sms:!,
-        @filter.obfuscate_link("&body=Hello", "sms:")
+        %r!D>DiU3@5Jlw6==@!,
+        @filter.obfuscate_link("&body=Hello", "sms")
       )
     end
 

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -397,21 +397,21 @@ class TestFilters < BridgetownUnitTest
 
     should "obfuscate email addresses" do
       assert_match(
-        %r{<a href=\"obfuscated\".*this\.href = 'mailto:},
+        %r!<a href=\"obfuscated\".*this\.href = 'mailto:!,
         @filter.obfuscate_link("test@example.com")
       )
     end
 
     should "obfuscate phone numbers" do
       assert_match(
-        %r{<a href=\"obfuscated\".*this\.href = 'tel:},
+        %r!<a href=\"obfuscated\".*this\.href = 'tel:!,
         @filter.obfuscate_link("+1 234 567", "tel:")
       )
     end
 
     should "obfuscate sms targets" do
       assert_match(
-        %r{<a href=\"obfuscated\".*this\.href = 'sms:},
+        %r!<a href=\"obfuscated\".*this\.href = 'sms:!,
         @filter.obfuscate_link("&body=Hello", "sms:")
       )
     end

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -168,12 +168,11 @@
 - name: Obfuscate Link
   description: >-
     Obfuscate emails, telephone numbers etc.
-    The link text is replaced by a reversed text on which the reading direction has also be reversed (thus it appears correct).
-    The link href is populated with the original target on focus or mouseover.
+    The link text is replaced by a ciphered string (using the ROT47 algorithm, so numbers are
+    included). On page load, this cipher is reversed, so the string is readable again.
     Takes an optional argument to specify the URI scheme prefix (default "mailto")
   examples:
     - input: '{{ "+1 234 567" | obfuscate_link:"tel" }}'
-      output: '<a href="obfuscated" ...></a>'
 
 #
 

--- a/bridgetown-website/src/_data/bridgetown_filters.yml
+++ b/bridgetown-website/src/_data/bridgetown_filters.yml
@@ -165,6 +165,18 @@
 
 #
 
+- name: Obfuscate Link
+  description: >-
+    Obfuscate emails, telephone numbers etc.
+    The link text is replaced by a reversed text on which the reading direction has also be reversed (thus it appears correct).
+    The link href is populated with the original target on focus or mouseover.
+    Takes an optional argument to specify the URI scheme prefix (default "mailto")
+  examples:
+    - input: '{{ "+1 234 567" | obfuscate_link:"tel" }}'
+      output: '<a href="obfuscated" ...></a>'
+
+#
+
 - name: Number of Words
   description: Count the number of words in some text.
   examples:


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This PR introduces a simple `obfuscate_link` filter to prevent bots from sending emails etc.

The implementation takes the simplest path possible, reversing the link text and using CSS reading-direction style attributes to display it correctly.

The link href is replaced by `obfuscated` and the original target is restored on mouseover or focus (touch friendly). 


## Context

Closes #166 
