### PR TITLE
Site documents array should exclude static files

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -2,7 +2,10 @@
 
 module Bridgetown
   class Collection
-    attr_reader :site, :label, :metadata
+    # @return [Bridgetown::Site]
+    attr_reader :site
+
+    attr_reader :label, :metadata
     attr_writer :docs
 
     # Create a new Collection.
@@ -65,6 +68,7 @@ module Bridgetown
           read_static_file(file_path, full_path)
         end
       end
+      site.static_files.concat(files)
       sort_docs!
     end
 

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
@@ -181,7 +181,7 @@ module Bridgetown
     # Get all pages and documents (posts and collection items) in a single array.
     #
     # @return [Array]
-    def all_documents
+    def contents
       pages + documents
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
@@ -123,7 +123,7 @@ module Bridgetown
     end
 
     # An array of collection names.
-    # @return [Array<Collection>] an array of collection names from the configuration,
+    # @return [Array<String>] an array of collection names from the configuration,
     #   or an empty array if the +config+["collections"] key is not set.
     # @raise ArgumentError Raise an error if +config+["collections"] is not
     #   an Array or a Hash
@@ -141,17 +141,18 @@ module Bridgetown
     end
 
     # Get all documents.
-    # @return [Array<String>] an array of documents from the configuration
+    # @return [Array<Bridgetown::Document>] an array of documents from the
+    # configuration
     def documents
       collections.each_with_object(Set.new) do |(_, collection), set|
-        set.merge(collection.docs).merge(collection.files)
+        set.merge(collection.docs)
       end.to_a
     end
 
     # Get the documents to be written
     #
-    # @return [Array<String, File>] an Array of Documents which should be written and
-    #   that +respond_to :write?+
+    # @return [Array<Bridgetown::Document>] an array of documents which should be
+    # written and that +respond_to :write?+
     # @see #documents
     # @see Collection
     def docs_to_write
@@ -165,6 +166,23 @@ module Bridgetown
     # @see Collection
     def posts
       collections["posts"] ||= Collection.new(self, "posts")
+    end
+
+    # Get the static files to be written
+    #
+    # @return [Array<Bridgetown::StaticFile>] an array of files which should be
+    # written and that +respond_to :write?+
+    # @see #static_files
+    # @see StaticFile
+    def static_files_to_write
+      static_files.select(&:write?)
+    end
+
+    # Get all pages and documents (posts and collection items) in a single array.
+    #
+    # @return [Array]
+    def all_documents
+      pages + documents
     end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
@@ -20,7 +20,8 @@ module Bridgetown
       Bridgetown::Hooks.trigger :site, :post_write, self
     end
 
-    # Yields the pages from {#pages}, {#static_files}, and {#docs_to_write}.
+    # Yields the pages from {#pages}, {#static_files_to_write}, and
+    # {#docs_to_write}.
     #
     # @yieldparam item [Document, Page, StaticFile] Yields a
     # {#Bridgetown::Page}, {#Bridgetown::StaticFile}, or
@@ -29,13 +30,13 @@ module Bridgetown
     # @return [void]
     #
     # @see #pages
-    # @see #static_files
+    # @see #static_files_to_write
     # @see #docs_to_write
     # @see Page
     # @see StaticFile
     # @see Document
     def each_site_file
-      %w(pages static_files docs_to_write).each do |type|
+      %w(pages static_files_to_write docs_to_write).each do |type|
         send(type).each do |item|
           yield item
         end

--- a/bridgetown-core/lib/bridgetown-core/drops/site_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/site_drop.rb
@@ -50,6 +50,10 @@ module Bridgetown
         @documents ||= @obj.documents
       end
 
+      def contents
+        @contents ||= @obj.contents
+      end
+
       def metadata
         @site_metadata ||= @obj.data["site_metadata"]
       end

--- a/bridgetown-core/lib/bridgetown-core/reader.rb
+++ b/bridgetown-core/lib/bridgetown-core/reader.rb
@@ -76,10 +76,7 @@ module Bridgetown
     def retrieve_posts(dir)
       return if outside_configured_directory?(dir)
 
-      post_reader.read_posts(dir).tap do |entries|
-        site.posts.docs.concat(entries.select { |entry| entry.is_a?(Document) })
-        site.posts.files.concat(entries.select { |entry| entry.is_a?(StaticFile) })
-      end
+      post_reader.read_posts(dir)
     end
 
     # Recursively traverse directories with the read_directories function.

--- a/bridgetown-core/lib/bridgetown-core/site.rb
+++ b/bridgetown-core/lib/bridgetown-core/site.rb
@@ -15,8 +15,18 @@ module Bridgetown
     attr_reader   :root_dir, :source, :dest, :cache_dir, :config,
                   :regenerator, :liquid_renderer, :components_load_paths,
                   :includes_load_paths
-    attr_accessor :layouts, :pages, :static_files,
-                  :exclude, :include, :lsi, :highlighter, :permalink_style,
+
+    # All files not pages/documents or structured data in the source folder
+    # @return [Array<Bridgetown::StaticFile>]
+    attr_accessor :static_files
+
+    # @return [Array<Bridgetown::Layout>]
+    attr_accessor :layouts
+
+    # @return [Array<Bridgetown::Page>]
+    attr_accessor :pages
+
+    attr_accessor :exclude, :include, :lsi, :highlighter, :permalink_style,
                   :time, :future, :unpublished, :limit_posts,
                   :keep_files, :baseurl, :data, :file_read_opts,
                   :plugin_manager, :converters, :generators, :reader

--- a/bridgetown-core/test/test_document.rb
+++ b/bridgetown-core/test/test_document.rb
@@ -514,8 +514,8 @@ class TestDocument < BridgetownUnitTest
       assert @document.write?
     end
 
-    should "be in the list of docs_to_write" do
-      assert @site.docs_to_write.include?(@document)
+    should "be in the list of static_files_to_write" do
+      assert @site.static_files_to_write.include?(@document)
     end
 
     should "be output in the correct place" do

--- a/bridgetown-core/test/test_site.rb
+++ b/bridgetown-core/test/test_site.rb
@@ -102,6 +102,13 @@ class TestSite < BridgetownUnitTest
       assert before_time <= @site.time
     end
 
+    should "provide access to all content" do
+      clear_dest
+      @site.process
+
+      assert_equal @site.documents.length + @site.pages.length, @site.contents.length
+    end
+
     should "write only modified static files" do
       clear_dest
       StaticFile.reset_cache

--- a/bridgetown-core/test/test_site.rb
+++ b/bridgetown-core/test/test_site.rb
@@ -12,10 +12,7 @@ class TestSite < BridgetownUnitTest
   end
 
   def read_posts
-    PostReader.new(@site).read_posts("").tap do |entries|
-      @site.posts.docs.concat(entries.select { |entry| entry.is_a?(Document) })
-      @site.posts.files.concat(entries.select { |entry| entry.is_a?(StaticFile) })
-    end
+    PostReader.new(@site).read_posts("")
     posts = Dir[source_dir("_posts", "**", "*")]
     posts.delete_if do |post|
       File.directory?(post) && post !~ Document::DATE_FILENAME_MATCHER

--- a/bridgetown-website/src/_data/bridgetown_variables.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables.yml
@@ -25,6 +25,9 @@ site:
   - name: site.time
     description: >-
       The current time (when you run the <code>bridgetown</code> command).
+  - name: site.contents
+    description: >-
+      A combined list of all Pages and Documents (from posts and other collections).
   - name: site.pages
     description: >-
       A list of all Pages.


### PR DESCRIPTION
In researching a fix for #161, I discovered that static files loaded within a collection would be added to the `site.documents` array! Furthermore, they *wouldn't* be added to the `site.static_files` array. I don't know about you, but to me that seems exactly backwards from what you would expect. 🤪

So this PR fixes that — and in addition, there is now a `site.contents` array which includes _all_ pages and documents in the site. Every single one. So no more having to concatenate `site.pages` and `site.documents`, or loop through each separately…unless you really want to.