### PR TITLE
Convert ERB and Beyond docs to ERB and use capture helper for liquid_render

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,9 +59,8 @@ Lint/Void:
   Exclude:
     - bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
 Metrics/AbcSize:
-  Max: 21
+  Max: 24
   Exclude:
-    - bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
     - bridgetown-core/lib/bridgetown-core/commands/build.rb
     - bridgetown-core/lib/bridgetown-core/commands/new.rb
     - bridgetown-core/lib/bridgetown-core/commands/console.rb

--- a/bridgetown-builder/.rubocop.yml
+++ b/bridgetown-builder/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
 
 Metrics/AbcSize:
   Exclude:
-    - lib/bridgetown-builder/dsl/*
+    - lib/bridgetown-builder/dsl/generators.rb
 Metrics/MethodLength:
   Exclude:
     - lib/bridgetown-builder/dsl/*

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
@@ -20,8 +20,6 @@ class Bridgetown::Site
       print_stats if config["profile"]
     end
 
-    # rubocop:disable Metrics/AbcSize
-
     # Reset all in-memory data and content.
     # @return [void]
     def reset
@@ -48,8 +46,6 @@ class Bridgetown::Site
       Bridgetown::Cache.clear_if_config_changed config
       Bridgetown::Hooks.trigger :site, :after_reset, self
     end
-
-    # rubocop:enable Metrics/AbcSize
 
     # Read data from disk and load it into internal memory.
     # @return [void]

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -38,8 +38,8 @@ module Bridgetown
       site.site_payload.site
     end
 
-    def liquid_render(component, options = {})
-      options[:_block_content] = yield if block_given?
+    def liquid_render(component, options = {}, &block)
+      options[:_block_content] = capture(&block) if block && respond_to?(:capture)
       render_statement = _render_statement(component, options)
 
       template = site.liquid_renderer.file(

--- a/bridgetown-core/lib/bridgetown-core/tags/render_content.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/render_content.rb
@@ -3,7 +3,7 @@
 module Bridgetown
   module Tags
     class BlockRenderTag < Liquid::Block
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
       def render(context)
         context.stack({}) do
           # unindent the incoming text
@@ -37,7 +37,7 @@ module Bridgetown
             .render_tag(context, +"")
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/bridgetown-paginate/.rubocop.yml
+++ b/bridgetown-paginate/.rubocop.yml
@@ -12,13 +12,6 @@ Bridgetown/NoPutsAllowed:
 Layout/CommentIndentation:
   Exclude:
     - lib/bridgetown-paginate/defaults.rb
-Metrics/AbcSize:
-  Exclude:
-    - lib/bridgetown-paginate/pagination_generator.rb
-    - lib/bridgetown-paginate/pagination_indexer.rb
-    - lib/bridgetown-paginate/pagination_model.rb
-    - lib/bridgetown-paginate/pagination_page.rb
-    - lib/bridgetown-paginate/paginator.rb
 Metrics/BlockNesting:
   Exclude:
     - lib/bridgetown-paginate/pagination_model.rb

--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_generator.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_generator.rb
@@ -27,7 +27,7 @@ module Bridgetown
       # site - The Site.
       #
       # Returns nothing.
-      def generate(site)
+      def generate(site) # rubocop:todo Metrics/AbcSize
         # Retrieve and merge the pagination configuration from the site yml file
         default_config = Bridgetown::Utils.deep_merge_hashes(
           DEFAULT,

--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_indexer.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_indexer.rb
@@ -17,7 +17,7 @@ module Bridgetown
       # Create a hash index for all documents based on a key in the
       # document.data table
       #
-      def self.index_documents_by(all_documents, index_key)
+      def self.index_documents_by(all_documents, index_key) # rubocop:todo Metrics/AbcSize
         return nil if all_documents.nil?
         return all_documents if index_key.nil?
 

--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_model.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_model.rb
@@ -30,7 +30,7 @@ module Bridgetown
       end
 
       # rubocop:disable Metrics/BlockLength
-      def run(default_config, templates, site_title)
+      def run(default_config, templates, site_title) # rubocop:todo Metrics/AbcSize
         if templates.size.to_i <= 0
           @logging_lambda.call "is enabled in the config, but no paginated pages found." \
             " Add 'pagination:\\n  enabled: true' to the front-matter of a page.", "warn"
@@ -142,7 +142,7 @@ module Bridgetown
       end
 
       # rubocop:disable Layout/LineLength
-      def _debug_print_config_info(config, page_path)
+      def _debug_print_config_info(config, page_path) # rubocop:todo Metrics/AbcSize
         r = 20
         f = "Pagination: ".rjust(20)
         # Debug print the config
@@ -185,6 +185,7 @@ module Bridgetown
       # template - The index.html Page that requires pagination.
       # config - The configuration settings that should be used
       #
+      # rubocop:todo Metrics/AbcSize
       def paginate(template, config, site_title, documents_payload)
         # By default paginate on all posts in the site
         using_posts = documents_payload[:posts]
@@ -446,6 +447,7 @@ module Bridgetown
           end
         end
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_page.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_page.rb
@@ -11,6 +11,7 @@ module Bridgetown
     # not read from disk
     #
     class PaginationPage < Bridgetown::Page
+      # rubocop:todo Metrics/AbcSize
       def initialize(page_to_copy, cur_page_nr, total_pages, index_pageandext, template_ext)
         @site = page_to_copy.site
         @base = ""
@@ -44,6 +45,7 @@ module Bridgetown
 
         Bridgetown::Hooks.trigger :pages, :post_init, self
       end
+      # rubocop:enable Metrics/AbcSize
 
       # rubocop:disable Naming/AccessorMethodName
       def set_url(url_value)

--- a/bridgetown-paginate/lib/bridgetown-paginate/paginator.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/paginator.rb
@@ -13,7 +13,7 @@ module Bridgetown
 
       # Initialize a new Paginator.
       #
-      def initialize(
+      def initialize( # rubocop:todo Metrics/AbcSize
         config_per_page,
         first_index_page_url,
         paginated_page_url,

--- a/bridgetown-website/plugins/builders/tags.rb
+++ b/bridgetown-website/plugins/builders/tags.rb
@@ -2,13 +2,16 @@
 
 class TagsBuilder < SiteBuilder
   def build
-    liquid_tag "toc" do
-      <<~TAG
-        ## Table of Contents
-        {:.no_toc}
-        * …
-        {:toc}
-      TAG
-    end
+    liquid_tag "toc", :toc_template
+    helper "toc", :toc_template
+  end
+
+  def toc_template(attributes=nil, tag=nil)
+    <<~TAG
+      ## Table of Contents
+      {:.no_toc}
+      * …
+      {:toc}
+    TAG
   end
 end

--- a/bridgetown-website/src/_docs/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/erb-and-beyond.md
@@ -93,7 +93,7 @@ You can also pass variables to partials using either a `locals` hash or as keywo
 
 Starting in Bridgetown 0.18, you can even render Ruby objects directly! This opens the door to a fully-featured view component architecture for ERB and other Ruby-based template languages in Bridgetown, and we will have more to announce on that front going forward.
 
-Bridgetown automatically loads `.rb` files you add to the `src/_components` folder, so that's likely where you'll want to save your component class definitions. It also load components from plugins which provide a `components` source manifest. Bridgetown's component loader is based on [Zeitwerk](https://github.com/fxn/zeitwerk), so you'll need to make sure you class names and namespaces line up with your component folder hierarchy.
+Bridgetown automatically loads `.rb` files you add to the `src/_components` folder, so that's likely where you'll want to save your component class definitions. It also load components from plugins which provide a `components` source manifest. Bridgetown's component loader is based on [Zeitwerk](https://github.com/fxn/zeitwerk){:rel="noopener"}, so you'll need to make sure you class names and namespaces line up with your component folder hierarchy.
 
 To create a Ruby component, all you have to do is define a `render_in` method which accepts a single `view_context` argument as well as optional block. Whatever string value you return from the method will be inserted into the template. For example:
 

--- a/bridgetown-website/src/_docs/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/erb-and-beyond.md
@@ -3,6 +3,7 @@ title: ERB and Beyond
 order: 19
 top_section: Templates
 category: erb
+template_engine: erb
 ---
 
 Bridgetown's primary template language is [**Liquid**](/docs/liquid), due to historical reasons (its heritage coming from Jekyll) and well as Liquid's simple syntax and safe execution context making it ideal for designer-led template creation.
@@ -11,7 +12,7 @@ However, Bridgetown's implementation language, Ruby, has a rich history of promo
 
 So, starting with Bridgetown 0.16, you can now add ERB-based templates and pages (and partials too) to your site. In additional, there are plugins you can easily install for Haml and Slim as well. Under the hood, Bridgetown uses the [Tilt gem](https://github.com/rtomayko/tilt) to load and process these Ruby templates.
 
-{% toc %}
+<%= toc %>
 
 ## Usage
 
@@ -22,40 +23,50 @@ Simply define a page/document with an `.erb` extension, rather than `.html`. You
 title: I'm a page!
 ---
 
-<h1><%= page.data[:title] %></h1>
+<h1><%%= page.data[:title] %></h1>
 
-<p>Welcome to <%= Bridgetown.name.to_s %>!</p>
+<p>Welcome to <%%= Bridgetown.name.to_s %>!</p>
 
-<footer>Authored by <%= site.data[:authors].first[:name] %></footer>
+<footer>Authored by <%%= site.data[:authors].first[:name] %></footer>
 ```
 
 Front matter is accessible via the `data` method on pages, posts, layouts, and other documents. Site config values are accessible via the `site.config` method, and loaded data files via `site.data` as you would expect.
 
 In addition to `site`, you can also access the `site_drop` object which will provide similar access to various data and config values similar to the `site` variable in Liquid.
 
+If you need to escape an ERB tag (to use it in a code sample for example), use two percent signs:
+
+~~~md
+Here's my **Markdown** file.
+
+```erb
+And my <%%%= "ERB code sample" %>
+```
+~~~
+
 ## Dot Access Hashes
 
 Instead of traditional Ruby hash key access, you can use "dot access" instead for a more familar look (coming from Liquid templates, or perhaps ActiveRecord objects in Rails). For example:
 
 ```eruby
-<%= post.data.title %>
+<%%= post.data.title %>
 
-<%= page.data.author %>
+<%%= page.data.author %>
 
-<%= site.data.authors.lakshmi.twitter.handle %>
+<%%= site.data.authors.lakshmi.twitter.handle %>
 
-<% # You can freely mix hash access and dot access: %>
+<%% # You can freely mix hash access and dot access: %>
 
-<%= site.data.authors[page.data.author].github %>
+<%%= site.data.authors[page.data.author].github %>
 ```
 
 ## Partials
 
-To include a partial in your ERB template, add a `_partials` folder to your source folder, and save a partial starting with `_` in the filename. Then you can reference it using the `<%= render "filename" %>` helper (or use the `partial` alias if you're more comfortable with that). For example, if we were to move the footer above into a partial:
+To include a partial in your ERB template, add a `_partials` folder to your source folder, and save a partial starting with `_` in the filename. Then you can reference it using the `<%%= render "filename" %>` helper (or use the `partial` alias if you're more comfortable with that). For example, if we were to move the footer above into a partial:
 
 ```eruby
 <!-- src/_partials/_author_footer.erb -->
-<footer>Authored by <%= site.data[:authors].first[:name] %></footer>
+<footer>Authored by <%%= site.data[:authors].first[:name] %></footer>
 ```
 
 ```eruby
@@ -63,19 +74,19 @@ To include a partial in your ERB template, add a `_partials` folder to your sour
 title: I'm a page!
 ---
 
-<h1><%= page.data[:title] %></h1>
+<h1><%%= page.data[:title] %></h1>
 
-<p>Welcome to <%= Bridgetown.name %>!</p>
+<p>Welcome to <%%= Bridgetown.name %>!</p>
 
-<%= render "author_footer" %>
+<%%= render "author_footer" %>
 ```
 
 You can also pass variables to partials using either a `locals` hash or as keyword arguments:
 
 ```eruby
-<%= render "some/partial", key: "value", another_key: 123 %>
+<%%= render "some/partial", key: "value", another_key: 123 %>
 
-<%= render "some/partial", locals: { key: "value", another_key: 123 } %>
+<%%= render "some/partial", locals: { key: "value", another_key: 123 } %>
 ```
 
 ## Rendering Ruby Components
@@ -95,7 +106,7 @@ end
 ```
 
 ```eruby
-<%= render MyComponent.new %>
+<%%= render MyComponent.new %>
 
   output: Hello from MyComponent!
 ```
@@ -120,7 +131,7 @@ end
 ```
 
 ```eruby
-<%= render FieldComponent.new(type: "email", name: "email_address", label: "Email Address") %>
+<%%= render FieldComponent.new(type: "email", name: "email_address", label: "Email Address") %>
 
   output:
   <field-component>
@@ -129,9 +140,9 @@ end
   </field-component>
 ```
 
-{% rendercontent "docs/note", type: "warning", extra_margin: true %}
+<%= liquid_render "docs/note", type: "warning", extra_margin: true do %>
 Bear in mind that Ruby components aren't accessible from Liquid templates. So if you need a component which can be used in either templating system, consider writing a Liquid component (see below).
-{% endrendercontent %}
+<% end %>
 
 ## Liquid Filters, Tags, and Components
 
@@ -139,7 +150,7 @@ Bridgetown includes access to some helpful [Liquid filters](/docs/liquid/filters
 
 ```eruby
 <!-- July 9th, 2020 -->
-<%= date_to_string site.time, "ordinal" %>
+<%%= date_to_string site.time, "ordinal" %>
 ```
 
 These helpers are actually methods of the `helper` object which is an instance of `Bridgetown::RubyTemplateView::Helpers`.
@@ -151,16 +162,14 @@ In addition to using Liquid helpers, you can also render [Liquid components](/do
 ```eruby
 <p>
   Rendering a component:
-  <%= liquid_render "test_component", param: "Liquid FTW!" %>
+  <%%= liquid_render "test_component", param: "Liquid FTW!" %>
 </p>
 ```
 
-{% raw %}
 ```html
 <!-- src/_components/test_component.liquid -->
 <span>{{ param }}</span>
 ```
-{% endraw %}
 
 ## Layouts
 
@@ -174,14 +183,13 @@ layout: default
 somevalue: 123
 ---
 
-<h1><%= page.data[:title] %></h1>
+<h1><%%= page.data[:title] %></h1>
 
-<div>An ERB layout! <%= layout.name %> / somevalue: <%= layout.data[:somevalue] %></div>
+<div>An ERB layout! <%%= layout.name %> / somevalue: <%%= layout.data[:somevalue] %></div>
 
-<%= yield %>
+<%%= yield %>
 ```
 
-{% raw %}
 `src/page.html`
 ```Liquid
 ---
@@ -190,13 +198,12 @@ layout: testing
 
 A standard Liquid page. {{ page.layout }}
 ```
-{% endraw %}
 
 If in your layout or a layout partial you need to output the paths to your Webpack assets, you can do so with a `webpack_path` helper just like with Liquid layouts:
 
 ```eruby
-<link rel="stylesheet" href="<%= webpack_path :css %>" />
-<script src="<%= webpack_path :js %>" defer></script>
+<link rel="stylesheet" href="<%%= webpack_path :css %>" />
+<script src="<%%= webpack_path :js %>" defer></script>
 ```
 
 ## Markdown
@@ -204,18 +211,18 @@ If in your layout or a layout partial you need to output the paths to your Webpa
 When authoring a document using ERB, you might find yourself wanting to embed some Markdown within the document content. That's easy to do using a `markdownify` block:
 
 ```eruby
-<%= markdownify do %>
+<%%= markdownify do %>
    ## I'm a header!
 
    * Yay!
-   <%= "* Nifty!" %>
-<% end %>
+   <%%= "* Nifty!" %>
+<%% end %>
 ```
 
 You can also pass in any string variable as a method argument:
 
 ```eruby
-<%= markdownify some_string_var %>
+<%%= markdownify some_string_var %>
 ```
 
 ## Extensions and Permalinks
@@ -229,15 +236,15 @@ Bridgetown doesn't do anything with double extensions by default, but you can us
 permalink: /posts.json
 ---
 [
-  <%
+  <%%
     site.posts.docs.each_with_index do |post, index|
       last_item = index == site.posts.docs.length - 1
   %>
     {
-      "title": <%= jsonify post.data[:title].strip %>,
-      "url": "<%= absolute_url post.url %>"<%= "," unless last_item %>
+      "title": <%%= jsonify post.data[:title].strip %>,
+      "url": "<%%= absolute_url post.url %>"<%%= "," unless last_item %>
     }
-  <% end %>
+  <%% end %>
 ]
 ```
 
@@ -250,7 +257,7 @@ The `link_to` and `url_for` helpers let you create anchor tags which will link t
 To link to source content, pass in a path to file in your `src` folder that translates to a published URL. For example, if you have a blog post saved at `src/_posts/2020-10-29-my-nifty-article.md`
 
 ```eruby
-<%= link_to "Click me!", "_posts/2020-10-29-my-nifty-article.md" %>
+<%%= link_to "Click me!", "_posts/2020-10-29-my-nifty-article.md" %>
 
 <!-- output: -->
 <a href="/blog/my-nifty-article">Click me!</a>
@@ -259,7 +266,7 @@ To link to source content, pass in a path to file in your `src` folder that tran
 The `link_to` helper uses `url_for`, so you can use that to get the url directly:
 
 ```eruby
-<% article_url = url_for("_posts/2020-10-29-my-nifty-article.md") %>
+<%% article_url = url_for("_posts/2020-10-29-my-nifty-article.md") %>
 ```
 
 Note that `url_for` is also aliased to `link` in order to provide compatibility with [the link Liquid tag](/docs/liquid/tags#link){:data-no-swup="true"}.
@@ -267,7 +274,7 @@ Note that `url_for` is also aliased to `link` in order to provide compatibility 
 You can pass additional keyword arguments to `link_to` which will be translated to HTML attributes:
 
 ```eruby
-<%= link_to "Join our livestream!", "_events/livestream.md", class: "event", data_expire: "2020-11-08" %>
+<%%= link_to "Join our livestream!", "_events/livestream.md", class: "event", data_expire: "2020-11-08" %>
 
 <!-- output: -->
 <a href="/events/livestream" class="event" data-expire="2020-11-08">Join our livestream!</a>
@@ -276,13 +283,13 @@ You can pass additional keyword arguments to `link_to` which will be translated 
 You can also pass relative or aboslute URLs to `link_to` and they'll just pass-through to the anchor tag without change:
 
 ```eruby
-<%= link_to "Visit Bridgetown", "https://www.bridgetownrb.com" %>
+<%%= link_to "Visit Bridgetown", "https://www.bridgetownrb.com" %>
 ```
 
 Finally, if you pass a Ruby object (i.e., it responds to `url`), it will work as you'd expect:
 
 ```eruby
-<%= link_to "My last page", @site.pages.last %>
+<%%= link_to "My last page", @site.pages.last %>
 
 <!-- output: -->
 <a href="/this/is/my-last-page">My last page</a>
@@ -293,11 +300,11 @@ Finally, if you pass a Ruby object (i.e., it responds to `url`), it will work as
 If you need to capture a part of your template and store it in a variable for later use, you can use the `capture` helper.
 
 ```eruby
-<% test_capturing = capture do %>
-  This is how <%= "#{"cap"}turing" %> works!
-<% end %>
+<%% test_capturing = capture do %>
+  This is how <%%= "#{"cap"}turing" %> works!
+<%% end %>
 
-<%= test_capturing.reverse %>
+<%%= test_capturing.reverse %>
 ```
 
 One interesting use case for capturing is you could assign the captured text to a layout data variable. Using memoization, you could calculate an expensive bit of template once and then reuse it either in that layout or in a partial.
@@ -305,19 +312,19 @@ One interesting use case for capturing is you could assign the captured text to 
 Example:
 
 ```eruby
-<% # add this code to a layout: %>
-<% layout.data[:save_this_for_later] ||= capture do
+<%% # add this code to a layout: %>
+<%% layout.data[:save_this_for_later] ||= capture do
   puts "saving this into the layout!"
-%>An <%= "expensive " + "routine" %> to be saved<% end %>
+%>An <%%= "expensive " + "routine" %> to be saved<%% end %>
 
 Some text...
 
-<%= partial "use_the_saved_variable" %>
+<%%= partial "use_the_saved_variable" %>
 ```
 
 ```eruby
-<% # src/_partials/_use_the_saved_variable.erb #>
-Print this: <%= layout.data[:save_this_for_later] %>
+<%% # src/_partials/_use_the_saved_variable.erb %>
+Print this: <%%= layout.data[:save_this_for_later] %>
 ```
 
 Because of the use of the `||=` operator, you'll only see "saving this into the layout!" print to the console once when the site builds even if you use the layout on thousands of pages!
@@ -339,7 +346,7 @@ end
 ```
 
 ```eruby
-<%= uppercase_string "i'm a string" %>
+<%%= uppercase_string "i'm a string" %>
 
 <!-- output: -->
 I'M A STRING
@@ -362,15 +369,13 @@ Bridgetown::RubyTemplateView::Helpers.include MyFilters
 
 Usage is pretty straightforward:
 
-{% raw %}
 ```eruby
-<%= lowercase_string "WAY DOWN LOW" %>
+<%%= lowercase_string "WAY DOWN LOW" %>
 ```
 
 ```Liquid
 {{ "WAY DOWN LOW" | lowercase_string }}
 ```
-{% endraw %}
 
 ## Haml and Slim
 
@@ -383,7 +388,7 @@ All you'd need to do is run `bundle add bridgetown-haml -g bridgetown_plugins` (
 
 ## Turning off Liquid processing
 
-For pages/documents, Bridgetown will automatically detect if you use Liquid tags {% raw %}(aka `{% %}` or `{{ }}`){% endraw %} and process your file with Liquid even if it's using ERB or another template language. This happens prior to any other conversions, so you can in theory using both Liquid and ERB in the same file.
+For pages/documents, Bridgetown will automatically detect if you use Liquid tags (aka `{% %}` or `{{ }}`) and process your file with Liquid even if it's using ERB or another template language. This happens prior to any other conversions, so you can in theory using both Liquid and ERB in the same file.
 
 You can however turn that off with front matter:
 


### PR DESCRIPTION
I thought it would be a good exercise to—y'know—make sure the "ERB and Beyond" documentation page is itself using ERB instead of Liquid. In doing so I discovered I needed to fix the `liquid_render` helper so it uses `capture`. Will require a point release for 0.18.
