### PR TITLE
For template engine converters, set template_engine frontmatter automatically

### DIFF
--- a/bridgetown-core/features/template_engines.feature
+++ b/bridgetown-core/features/template_engines.feature
@@ -7,32 +7,52 @@ Feature: Template Engines
     And I have a _posts directory
     And I have a "_layouts/simple.html" file that contains "<h1><%= page.data.title %></h1> <%= yield %>"
     And I have the following post:
-      | title     | date       | layout | content                 |
+      | title     | date       | layout | content                                           |
       | Star Wars | 2009-03-27 | simple | _Luke_, <%= ["I", "am"].join(" ") %> your father. |
     And I have a configuration file with:
-      | key                | value |
-      | template_engine    | erb   |
+      | key             | value |
+      | template_engine | erb   |
     When I run bridgetown build
     Then I should get a zero exit status
     And I should see "<p><em>Luke</em>, I am your father.</p>" in "output/2009/03/27/star-wars.html"
     And I should see "<h1>Star Wars</h1>" in "output/2009/03/27/star-wars.html"
 
-  Scenario: Rendering a site with default ERB but Liquid template
+  Scenario: Rendering a site with default ERB but Liquid layout
     Given I have a _layouts directory
     And I have a _posts directory
     And I have a "_layouts/simple.liquid" file that contains "<h1>{{ page.title }}</h1> {{ content }}"
     And I have the following post:
-      | title     | date       | layout | content                 |
+      | title     | date       | layout | content                                         |
       | Star Wars | 2009-03-27 | simple | Luke, <%= ["I", "am"].join(" ") %> your father. |
     And I have a configuration file with:
-      | key                | value |
-      | template_engine    | erb   |
+      | key             | value |
+      | template_engine | erb   |
     When I run bridgetown build
     Then I should get a zero exit status
     And I should see "<p>Luke, I am your father.</p>" in "output/2009/03/27/star-wars.html"
     And I should see "<h1>Star Wars</h1>" in "output/2009/03/27/star-wars.html"
 
-  Scenario: Rendering a site with default ERB but Liquid template via front matter
+  Scenario: Rendering a site with default ERB but Liquid page
+    Given I have a _layouts directory
+    And I have a _posts directory
+    And I have a "_layouts/simple.html" file that contains "<h1><%= page.data.title %></h1> <%= page.data.template_engine %> <%= yield %>"
+    And I have a "liquidpage.liquid" file with content:
+      """
+      ---
+      title: Star Wars
+      layout: simple
+      ---
+      Luke, {{ "I,am" | split: "," | join: " " }} your <%= 'father'.upcase %>.
+      """
+    And I have a configuration file with:
+      | key             | value |
+      | template_engine | erb   |
+    When I run bridgetown build
+    Then I should get a zero exit status
+    And I should see "Luke, I am your <%= 'father'.upcase %>." in "output/liquidpage.html"
+    And I should see "<h1>Star Wars</h1>" in "output/liquidpage.html"
+
+  Scenario: Rendering a site with default ERB but Liquid layout via front matter
     Given I have a _layouts directory
     And I have a _posts directory
     And I have an "_layouts/simple.html" file with content:
@@ -43,11 +63,11 @@ Feature: Template Engines
       <h1>{{ page.title }}</h1> {{ content }}
       """
     And I have the following post:
-      | title     | date       | layout | content                 |
+      | title     | date       | layout | content                                         |
       | Star Wars | 2009-03-27 | simple | Luke, <%= ["I", "am"].join(" ") %> your father. |
     And I have a configuration file with:
-      | key                | value |
-      | template_engine    | erb   |
+      | key             | value |
+      | template_engine | erb   |
     When I run bridgetown build
     Then I should get a zero exit status
     And I should see "<p>Luke, I am your father.</p>" in "output/2009/03/27/star-wars.html"
@@ -58,7 +78,7 @@ Feature: Template Engines
     And I have a _posts directory
     And I have a "_layouts/simple.html" file that contains "<h1>{{ page.title }}</h1> {{ content }}"
     And I have the following post:
-      | title     | date       | layout | template_engine | content                 |
+      | title     | date       | layout | template_engine | content                                         |
       | Star Wars | 2009-03-27 | simple | erb             | Luke, <%= ["I", "am"].join(" ") %> your father. |
     When I run bridgetown build
     Then I should get a zero exit status
@@ -73,8 +93,8 @@ Feature: Template Engines
       <%= jsonify({key: [1, 1+1, 1+1+1]}) %>
       """
     And I have a configuration file with:
-      | key                | value |
-      | template_engine    | erb   |
+      | key             | value |
+      | template_engine | erb   |
     When I run bridgetown build
     Then I should get a zero exit status
     And I should see the output folder
@@ -85,11 +105,11 @@ Feature: Template Engines
     And I have a _posts directory
     And I have a "_layouts/simple.html" file that contains "<h1><%= page.data.title %></h1> <%= yield %>"
     And I have the following post:
-      | title     | date       | layout | template_engine | content                 |
+      | title     | date       | layout | template_engine | content                                           |
       | Star Wars | 2009-03-27 | simple | none            | _Luke_, <%= ["I", "am"].join(" ") %> your father. |
     And I have a configuration file with:
-      | key                | value |
-      | template_engine    | erb   |
+      | key             | value |
+      | template_engine | erb   |
     When I run bridgetown build
     Then I should get a zero exit status
     And I should see "<p><em>Luke</em>, &lt;%= " in "output/2009/03/27/star-wars.html"

--- a/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
@@ -101,6 +101,8 @@ module Bridgetown
       #
       # @return [String] The converted content.
       def convert(content, convertible)
+        return content if convertible.data[:template_engine] != "erb"
+
         erb_view = Bridgetown::ERBView.new(convertible)
 
         erb_renderer = Tilt::ErubiTemplate.new(
@@ -123,10 +125,13 @@ module Bridgetown
         if convertible.data[:template_engine] == "erb" ||
             (convertible.data[:template_engine].nil? &&
               @config[:template_engine] == "erb")
+          convertible.data[:template_engine] = "erb"
           return true
         end
 
-        super(ext)
+        super(ext).tap do |ext_matches|
+          convertible.data[:template_engine] = "erb" if ext_matches
+        end
       end
 
       def output_ext(ext)

--- a/bridgetown-core/lib/bridgetown-core/converters/liquid_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/liquid_templates.rb
@@ -23,6 +23,8 @@ module Bridgetown
       #
       # @return [String] The converted content.
       def convert(content, convertible)
+        return content if convertible.data[:template_engine] != "liquid"
+
         self.class.cached_partials ||= {}
 
         @site = convertible.site
@@ -53,9 +55,14 @@ module Bridgetown
       # rubocop: enable Metrics/AbcSize
 
       def matches(ext, convertible)
-        return true if convertible.render_with_liquid?
+        if convertible.render_with_liquid?
+          convertible.data[:template_engine] = "liquid"
+          return true
+        end
 
-        super(ext)
+        super(ext).tap do |ext_matches|
+          convertible.data[:template_engine] = "liquid" if ext_matches
+        end
       end
 
       def output_ext(ext)


### PR DESCRIPTION
…and check before conversions. This fixes #176

Basically we only want one template engine at a time per file. No Liquid + ERB, no ERB + Slim, whatever. Doesn't make sense. So this code guarantees mutual exclusivity. It's a little verbose and not great on the DRY metric, so I'll look into adding additional smarts to the `Converter` parent class so the individual converters can get cleaned up a bit. But for now, this should work.