### PR TITLE
feat: add `yarn clean` script to package.json

### DIFF
--- a/bridgetown-core/lib/site_template/package.json
+++ b/bridgetown-core/lib/site_template/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "bundle exec bridgetown build",
     "serve": "bundle exec bridgetown serve",
+    "clean": "bundle exec bridgetown clean",
     "webpack-build": "webpack --mode production",
     "webpack-dev": "webpack --mode development -w",
-    "deploy": "yarn webpack-build && yarn build",
+    "deploy": "yarn clean && yarn webpack-build && yarn build",
     "sync": "node sync.js",
     "start": "node start.js"
   },

--- a/bridgetown-website/package.json
+++ b/bridgetown-website/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "bundle exec bridgetown build",
     "serve": "bundle exec bridgetown serve",
+    "clean": "bundle exec bridgetown clean",
     "webpack-build": "webpack --mode production",
     "webpack-dev": "webpack --mode development -w",
-    "deploy": "bundle install --with test && yarn webpack-build && yarn build",
+    "deploy": "bundle install --with test && yarn clean && yarn webpack-build && yarn build",
     "sync": "node sync.js",
     "start": "node start.js",
     "test": "BRIDGETOWN_ENV=test yarn build"


### PR DESCRIPTION
# 🙋 Feature


## Summary

### What:

Adds a new script to our main `package.json` template, as well as the Bridgetown website.

`yarn clean`

Much like the build and serve commands, this is simply a npm script wrapping a BridgetownRB command.

Once executed, Bridgetown will search for files in the following locations:

- `./output`
- `./.bridgetown-metadata`
- `./.bridgetown-cache`
- `./.bridgetown-webpack`

If there are files present, it will remove them. Essentially clearing your cache and all remenants of the last build.

If the directory is empty, Bridgetown will alert you with something like: `Cleaner: Nothing to do for './.bridgetown-webpack'`

### Downside or Risk:

The only downside I can think of it people cleaning so much that it ends up removing some of the value that the caching is providing. However, this could also just be an indicator of where more tooling is needed if we see lots of users getting stuck with the questions of `why don't my styles look right`, which is usually when I reach for it after a moment or two. 

I guess there is also a chance someone could try to clean their site immediately after deploy but its a pretty common pattern in the JS community as well so I don't foresee an issue.

### Why:

I find myself always adding this script because it is nice shorthand to the longer `bundle exec bridgetown clean` or `bin/bridgetown clean`.

The reason I find myself reaching for it a lot is because its a nice final line of defense to determine if something is really broken or something
is just funky with the cache. When it comes to bundlers and tools like snowpack, it is even more handy due to how they load files.

I also find it good practice to always run a clean when the deploy script is executed. Sometimes I like to mimic production  locally to test file sizes and small optimizations. Also, it couldn't hurt.

My final hope by placing it in the `package.json` is that it will be easier to find for newcomers and they may think to reach for it sooner than others, which could save them an hour of debugging only to realize iCloud tried to store a file in the cloud or Webpack is being funky.

### Tests

I did not see anywhere that we were testing this generate `package.json` file, nor do I see a real need to. However, I will happily add tests if I just missed them!