### PR TITLE
Change logging level for "Executing inline Ruby…" messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # main
 
+# 0.18.6 / 2020-11-12
+
+* Change the logging level for "Executing inline Ruby…" messages to the debug level [#175](https://github.com/bridgetownrb/bridgetown/issues/175)
+
 # 0.18.5 / 2020-11-09
 
 * Bugfix: use HashWithDotAccess when parsing JSON in the HTTP Builder DSL

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Bridgetown is built by:
 |<a href="https://github.com/jaredcwhite">@jaredcwhite</a>|<a href="https://github.com/jaredmoody">@jaredmoody</a>|<a href="https://github.com/andrewmcodes">@andrewmcodes</a>|<a href="https://github.com/ParamagicDev">@ParamagicDev</a>|<a href="https://github.com/MikeRogers0">@MikeRogers0</a>|
 |Portland, OR|Portland, OR|Wilmington, NC|Providence, RI|Ny-Ålesund, Svalbard|
 
-|<img src="https://avatars.githubusercontent.com/wout?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/codemargaret?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/julianrubisch?s=256" alt="" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
-|:---:|:---:|:---:|:---:|
-|<a href="https://github.com/wout">@wout</a>|<a href="https://github.com/codemargaret">@codemargaret</a>|<a href="https://github.com/julianrubisch">@julianrubisch</a>|You Next?|
-|Brighton, UK|Portland, OR|Vienna, Austria|Anywhere|
+|<img src="https://avatars.githubusercontent.com/wout?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/codemargaret?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/julianrubisch?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/ianbayne?s=256" alt="" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|<a href="https://github.com/wout">@wout</a>|<a href="https://github.com/codemargaret">@codemargaret</a>|<a href="https://github.com/julianrubisch">@julianrubisch</a>|<a href="https://github.com/ianbayne">@ianbayne</a>|You Next?|
+|Brighton, UK|Portland, OR|Vienna, Austria|Tokyo, Japan|Anywhere|
 
 Interested in joining the Bridgetown Core Team? Send a DM to Jared on the [Bridgetown Community forum](https://community.bridgetownrb.com) and let's chat!
 

--- a/bridgetown-core/lib/bridgetown-core/utils/ruby_exec.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/ruby_exec.rb
@@ -20,14 +20,14 @@ module Bridgetown
             v.each do |nested_k, nested_v|
               next unless nested_v.is_a?(Rb)
 
-              Bridgetown.logger.warn("Executing inline Ruby…", convertible.relative_path)
+              Bridgetown.logger.debug("Executing inline Ruby…", convertible.relative_path)
               convertible.data[k][nested_k] = run(nested_v, convertible, renderer)
-              Bridgetown.logger.warn("Inline Ruby completed!", convertible.relative_path)
+              Bridgetown.logger.debug("Inline Ruby completed!", convertible.relative_path)
             end
           else
-            Bridgetown.logger.warn("Executing inline Ruby…", convertible.relative_path)
+            Bridgetown.logger.debug("Executing inline Ruby…", convertible.relative_path)
             convertible.data[k] = run(v, convertible, renderer)
-            Bridgetown.logger.warn("Inline Ruby completed!", convertible.relative_path)
+            Bridgetown.logger.debug("Inline Ruby completed!", convertible.relative_path)
           end
         end
       end


### PR DESCRIPTION
Hey there, I really like the idea of this project and your aims for it! I've got a Jekyll blog myself and I think it's really neat that Bridgetown fills a similar role, while at the same time being more in tune with the direction of the modern web (including webpack as a default, etc.). Additionally, the content of `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md` is very well written, and it's quite ingenious of you to let contributors include mention of themselves in the `README.md`. I guess you could say that I'm just impressed all around 😄 

  - [x] I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - [x] I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md

This is a 🙋 feature or enhancement.

## Summary

This is just a very small PR to get my feet wet with Bridgetown. It doesn't add any tests, but as it's just a simple change to the logging level, I don't feel that tests are warranted.

## Context
Closes #175.