### PR TITLE
Add inferred name attribute to default package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+* Change the `name` attribute of the default `package.json` to be inferred from the path passed to `bridgetown new`
+
 # 0.18.6 / 2020-11-12
 
 * Change the logging level for "Executing inline Ruby…" messages to the debug level [#184](https://github.com/bridgetownrb/bridgetown/pull/184) ([ianbayne](https://github.com/ianbayne))

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Bridgetown is built by:
 |<a href="https://github.com/jaredcwhite">@jaredcwhite</a>|<a href="https://github.com/jaredmoody">@jaredmoody</a>|<a href="https://github.com/andrewmcodes">@andrewmcodes</a>|<a href="https://github.com/ParamagicDev">@ParamagicDev</a>|<a href="https://github.com/MikeRogers0">@MikeRogers0</a>|
 |Portland, OR|Portland, OR|Wilmington, NC|Providence, RI|Ny-Ålesund, Svalbard|
 
-|<img src="https://avatars.githubusercontent.com/wout?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/codemargaret?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/julianrubisch?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/ianbayne?s=256" alt="" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
-|:---:|:---:|:---:|:---:|:---:|
-|<a href="https://github.com/wout">@wout</a>|<a href="https://github.com/codemargaret">@codemargaret</a>|<a href="https://github.com/julianrubisch">@julianrubisch</a>|<a href="https://github.com/ianbayne">@ianbayne</a>|You Next?|
-|Brighton, UK|Portland, OR|Vienna, Austria|Tokyo, Japan|Anywhere|
+|<img src="https://avatars.githubusercontent.com/wout?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/codemargaret?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/julianrubisch?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/ianbayne?s=256" alt="" width="128" />|<img src="https://avatars.githubusercontent.com/ayushn21?s=256" alt="" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|:---:|
+|<a href="https://github.com/wout">@wout</a>|<a href="https://github.com/codemargaret">@codemargaret</a>|<a href="https://github.com/julianrubisch">@julianrubisch</a>|<a href="https://github.com/ianbayne">@ianbayne</a>|<a href="https://github.com/ayushn21">@ayushn21</a>|You Next?|
+|Brighton, UK|Portland, OR|Vienna, Austria|Tokyo, Japan|London, UK|Anywhere|
 
 Interested in joining the Bridgetown Core Team? Send a DM to Jared on the [Bridgetown Community forum](https://community.bridgetownrb.com) and let's chat!
 

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -47,6 +47,8 @@ module Bridgetown
         raise ArgumentError, "You must specify a path." if args.empty?
 
         new_site_path = File.expand_path(args.join(" "), Dir.pwd)
+        @site_name = new_site_path.split(File::SEPARATOR).last
+
         if preserve_source_location?(new_site_path, options)
           say_status :conflict, "#{new_site_path} exists and is not empty.", :red
           Bridgetown.logger.abort_with "Ensure #{new_site_path} is empty or else " \
@@ -75,6 +77,7 @@ module Bridgetown
           "src/_posts/#{Time.now.strftime("%Y-%m-%d")}-welcome-to-bridgetown.md"
         )
         template("Gemfile.erb", "Gemfile")
+        template("package.json.erb", "package.json")
       end
 
       # After a new site has been created, print a success notification and

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "new-bridgetown-site",
+  "name": "<%= @site_name %>",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -60,7 +60,7 @@ class TestNewCommand < BridgetownUnitTest
       static_template_files = dir_contents(site_template).reject do |f|
         File.extname(f) == ".erb"
       end
-      static_template_files << "/Gemfile"
+      static_template_files.push "/Gemfile", "/package.json"
 
       capture_output do
         Bridgetown::Commands::Base.start(argumentize(@args))


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

✅ I've added tests (if it's a bug, feature or enhancement)
✅ The test suite passes locally (run `script/cibuild` to verify this)

## Summary

When we create a new Bridgetown site, the default `package.json` has a `name` attribute of `bridgetown-new-site`. 

I thought it would be a nicer developer experience if this name could be inferred from the path entered into the `new` command. So this change takes the last path component of the input path and sets that as the name in `package.json`.