### PR TITLE
Add `mailto:`-`<a>`-tag to generated footer

### DIFF
--- a/bridgetown-core/lib/site_template/src/_components/footer.liquid
+++ b/bridgetown-core/lib/site_template/src/_components/footer.liquid
@@ -1,3 +1,3 @@
 <footer>
-  Contact me at {{ metadata.email }}
+  Contact me at <a href="mailto:{{ metadata.email }}">{{ metadata.email }}</a>
 </footer>


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

Interestingly, I've run the test suite locally and this change didn't break any (so the footer might not be 100% tested?)

## Summary

One of the first changes I've made to the project I'm setting up right now, perhaps interesting for other folks as well?! Properly linking the site email in the generated `<footer>`.

## Context

No correlated issue found.
