### PR TITLE
Fix typo in generators page in docs

### DIFF
--- a/bridgetown-website/src/_docs/plugins/generators.md
+++ b/bridgetown-website/src/_docs/plugins/generators.md
@@ -96,7 +96,7 @@ Posts:
 ```ruby
 class CategoryPages < SiteBuilder
   def build
-    generate do
+    generator do
       if site.layouts.key? "category_index"
         site.categories.each_key do |category|
           site.pages << CategoryPage.new(site, category)


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This PR fixes a small typo in the "Generators" documentation page. The code snippet incorrectly used the method `generate` rather than `generator`.