### PR TITLE
Fix class declaration keyword in liquid tags and helpers docs

### DIFF
--- a/bridgetown-website/src/_docs/plugins.md
+++ b/bridgetown-website/src/_docs/plugins.md
@@ -101,7 +101,7 @@ And then reference that data in any Liquid template:
 The `config` instance method is available to access the Bridgetown site configuration object, and along with that you can optionally define a default configuration that will be included in the config object—and can be overridden by config settings directly in `bridgetown.config.yml`. For example:
 
 ```ruby
-def BuilderWithConfiguration < SiteBuilder
+class BuilderWithConfiguration < SiteBuilder
   CONFIG_DEFAULTS = {
     custom_config: {
       my_setting: 123
@@ -117,6 +117,7 @@ def BuilderWithConfiguration < SiteBuilder
 
     p config[:my_setting] # "one two three"
   end
+end
 ```
 
 ### Gem-based Plugins

--- a/bridgetown-website/src/_docs/plugins/generators.md
+++ b/bridgetown-website/src/_docs/plugins/generators.md
@@ -26,7 +26,7 @@ for more details.
 
 Simply add a `generator` call to your `build` method. You can supply a block or pass in a method name as a symbol.
 
-```
+```ruby
 def build
   generator do
     # update or add content here

--- a/bridgetown-website/src/_docs/plugins/helpers.md
+++ b/bridgetown-website/src/_docs/plugins/helpers.md
@@ -34,7 +34,7 @@ http://www.example.com/mydynamicfile.js?1586194585
 You can accept multiple arguments to your helper by simply adding them to your block or method, and optional ones are simply specified with a default value (perhaps `nil` or `false`). For example:
 
 ```ruby
-def Helpers < SiteBuilder
+class Helpers < SiteBuilder
   def build
     helper "multiply_and_optionally_add" do |input, multiply_by, add_by = nil|
       value = input * multiply_by
@@ -61,7 +61,7 @@ Then just use it like this:
 As with other parts of the Builder API, you can also use an instance method to register your helper:
 
 ```ruby
-def Helpers < SiteBuilder
+class Helpers < SiteBuilder
   def build
     helper "cache_busting_url", :bust_it
   end
@@ -79,7 +79,7 @@ By default, the code within the helper block or method is executed within the sc
 To remedy this, simply pass the `helpers_scope: true` argument when defining a helper block. Then you can call other helpers as part of your code block (but not methods within your builder).
 
 ```ruby
-def Helpers < SiteBuilder
+class Helpers < SiteBuilder
   def build
     helper "slugify_and_upcase", helpers_scope: true do |url|
       slugify(url).upcase
@@ -95,7 +95,7 @@ When using the helpers scope, you have access to two variables: `site` and `view
 Within the helpers scope, you can "capture" the contents of a block and use that text inside your helper. Optionally, you can pass an object to the block itself from your helper. For example:
 
 ```ruby
-def Helpers < SiteBuilder
+class Helpers < SiteBuilder
   def build
     helper "capture_and_upcase", helpers_scope: true do |&block|
       label = "upcased"

--- a/bridgetown-website/src/_docs/plugins/tags.md
+++ b/bridgetown-website/src/_docs/plugins/tags.md
@@ -12,7 +12,7 @@ content and any HTML template. Built-in examples added by Bridgetown include the
 will output the time the page was rendered:
 
 ```ruby
-def RenderTime < SiteBuilder
+class RenderTime < SiteBuilder
   def build
     liquid_tag "render_time" do |attributes|
       "#{attributes} #{Time.now}"
@@ -41,7 +41,7 @@ And we would get something like this on the page:
 The `render_time` tag seen above can also be rewritten as a _tag block_. Look at this example:
 
 ```ruby
-def RenderTime < SiteBuilder
+class RenderTime < SiteBuilder
   def build
     liquid_tag "render_time", as_block: true do |attributes, tag|
       "#{tag.content} #{Time.now}"
@@ -76,7 +76,7 @@ the name `render_time`, but you'll want to avoid registering a tag and a tag blo
 As with other parts of the Builder API, you can also use an instance method to register your tag:
 
 ```ruby
-def Upcase < SiteBuilder
+class Upcase < SiteBuilder
   def build
     liquid_tag "upcase", :upcase_tag, as_block: true
   end


### PR DESCRIPTION
This is a 🔦 documentation change.


## Summary

Documentation fixes on the `plugins/tags` and `plugins/helpers` pages where it seems a class was declared with `def`. I've just replaced `def` with `class`.

This PR fixes #197 