### PR TITLE
Add Ruby 3.0 preview 2 to the build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.8, 2.6.6, 2.7.2]
+        ruby_version: [2.5.8, 2.6.6, 2.7.2, 3.0.0-preview2]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@master

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -58,6 +58,13 @@ SafeYAML::OPTIONS[:suppress_warnings] = true
 class Rb < String; end
 SafeYAML::OPTIONS[:whitelisted_tags] = ["!ruby/string:Rb"]
 
+if RUBY_VERSION.start_with?("3.0")
+  # workaround for Ruby 3 preview 2, maybe can remove later
+  old_verbose = $VERBOSE; $VERBOSE = nil
+  SafeYAML::SafeToRubyVisitor.const_set(:INITIALIZE_ARITY, 2)
+  $verbose = old_verbose
+end
+
 module Bridgetown
   # internal requires
   autoload :Cleaner,             "bridgetown-core/cleaner"

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -60,10 +60,12 @@ SafeYAML::OPTIONS[:whitelisted_tags] = ["!ruby/string:Rb"]
 
 if RUBY_VERSION.start_with?("3.0")
   # workaround for Ruby 3 preview 2, maybe can remove later
+  # rubocop:disable Style/GlobalVars
   old_verbose = $VERBOSE
   $VERBOSE = nil
   SafeYAML::SafeToRubyVisitor.const_set(:INITIALIZE_ARITY, 2)
   $verbose = old_verbose
+  # rubocop:enable Style/GlobalVars
 end
 
 module Bridgetown

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -60,7 +60,8 @@ SafeYAML::OPTIONS[:whitelisted_tags] = ["!ruby/string:Rb"]
 
 if RUBY_VERSION.start_with?("3.0")
   # workaround for Ruby 3 preview 2, maybe can remove later
-  old_verbose = $VERBOSE; $VERBOSE = nil
+  old_verbose = $VERBOSE
+  $VERBOSE = nil
   SafeYAML::SafeToRubyVisitor.const_set(:INITIALIZE_ARITY, 2)
   $verbose = old_verbose
 end

--- a/bridgetown-core/test/test_generated_site.rb
+++ b/bridgetown-core/test/test_generated_site.rb
@@ -11,7 +11,7 @@ class TestGeneratedSite < BridgetownUnitTest
       @site.process
       @index = File.read(
         dest_dir("index.html"),
-        Utils.merged_file_read_opts(@site, {})
+        **Utils.merged_file_read_opts(@site, {})
       )
     end
 


### PR DESCRIPTION
Adding this to our test matrix, and if there are Ruby 3-specific issues with the test suite we can fix those and merge into this branch.