### PR TITLE
Update installation.md

### DIFF
--- a/bridgetown-website/src/_docs/installation.md
+++ b/bridgetown-website/src/_docs/installation.md
@@ -31,5 +31,6 @@ For detailed installation instructions, take a look at the guide for your operat
 system:
 
 * [macOS](/docs/installation/macos/)
+* [Fedora Linux](/docs/installation/fedora/)
 * [Ubuntu Linux](/docs/installation/ubuntu/)
 * [Windows (via Linux Subsystem + Ubuntu)](/docs/installation/windows/)


### PR DESCRIPTION
Add link to Fedora Linux page


  -[x] I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  -[x] I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md

 This is a 🔦 documentation change. 

## Summary

Add link from installation page to Fedora installation guide

## Context

Related to pull request #209 