### PR TITLE
Improve our active ActiveSupport support =)

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -29,8 +29,12 @@ require "csv"
 require "json"
 
 # 3rd party
+require "active_support"
+require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/string/inquiry"
+require "active_support/core_ext/string/starts_ends_with"
 require "hash_with_dot_access"
 require "pathutil"
 require "addressable/uri"
@@ -136,7 +140,7 @@ module Bridgetown
     # Tells you which Bridgetown environment you are building in so
     #   you can skip tasks if you need to.
     def environment
-      ENV["BRIDGETOWN_ENV"] || "development"
+      (ENV["BRIDGETOWN_ENV"] || "development").inquiry
     end
     alias_method :env, :environment
 

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "digest"
-require "active_support/core_ext/hash/keys"
 
 module Bridgetown
   class RubyTemplateView


### PR DESCRIPTION
Fix for #73 

In addition, I added the `starts_with? ends_with?` aliases as well as string inquiry for the Bridgetown environment, so you can now call `Bridgetown.environment.production?` just like in Rails. :)