### PR TITLE
Change the default branch name of new bridgetown sites and plugins to `main`

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -158,7 +158,7 @@ module Bridgetown
         unless Bridgetown.environment == "test"
           inside(path) do
             run "git init", abort_on_failure: true
-            run "git checkout -b main"
+            run "if [[ -n $(git status | grep 'On branch master') ]]; then git checkout -b main; fi"
           end
         end
       rescue SystemExit

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -158,6 +158,7 @@ module Bridgetown
         unless Bridgetown.environment == "test"
           inside(path) do
             run "git init", abort_on_failure: true
+            run "git checkout -b main"
           end
         end
       rescue SystemExit

--- a/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
@@ -150,7 +150,7 @@ module Bridgetown
         inside name do # rubocop:todo Metrics/BlockLength
           run "rm -rf .git"
           run "git init"
-          run "git checkout -b main"
+          run "if [[ -n $(git status | grep 'On branch master') ]]; then git checkout -b main; fi"
 
           run "mv bridgetown-sample-plugin.gemspec #{new_gemspec}"
           gsub_file new_gemspec, "https://github.com/bridgetownrb/bridgetown-sample-plugin", "https://github.com/username/#{name}"

--- a/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
@@ -150,6 +150,7 @@ module Bridgetown
         inside name do # rubocop:todo Metrics/BlockLength
           run "rm -rf .git"
           run "git init"
+          run "git checkout -b main"
 
           run "mv bridgetown-sample-plugin.gemspec #{new_gemspec}"
           gsub_file new_gemspec, "https://github.com/bridgetownrb/bridgetown-sample-plugin", "https://github.com/username/#{name}"


### PR DESCRIPTION
Inspired by the Rails team changing their repo's default branch to `main`; I thought we should make it so all new Bridgetown sites and plugins have a `main` branch by default.