### PR TITLE
Add Bridgetown recommended postcss plugins configuration

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# rubocop:disable all
+
+TEMPLATE_PATH = File.expand_path("./bt-postcss", __dir__)
+
+begin
+  find_in_source_paths("postcss.config.js")
+rescue Thor::Error
+  error_message = "#{"postcss.config.js".bold} not found. Please configure postcss in your project."
+
+  @logger.error "\nError:".red, "🚨 #{error_message}"
+  @logger.info "\nFor new projects, you can use #{"bridgetown new my_project --use-postcss".bold.blue}\n"
+
+  return
+end
+
+plugins = %w(postcss-easy-import postcss-mixins postcss-color-function cssnano)
+
+say "Adding the following PostCSS plugins: #{plugins.join(' | ')}", :green
+run "yarn add -D #{plugins.join(' ')}"
+
+remove_file "postcss.config.js"
+copy_file "#{TEMPLATE_PATH}/postcss.config.js", "postcss.config.js"
+
+# rubocop:enable all

--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss/postcss.config.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    plugins: {
+  plugins: {
     'postcss-easy-import': {},
     'postcss-mixins': {},
     'postcss-color-function': {},

--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss/postcss.config.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss/postcss.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+    plugins: {
+    'postcss-easy-import': {},
+    'postcss-mixins': {},
+    'postcss-color-function': {},
+    'postcss-flexbugs-fixes': {},
+    'postcss-preset-env': {
+      autoprefixer: {
+        flexbox: 'no-2009'
+      },
+      stage: 2,
+      features: {
+        'nesting-rules': true,
+        'custom-media-queries': true
+      },
+    },
+    'cssnano' : {
+      preset: 'default'
+    }
+  }
+}

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -18,6 +18,7 @@ The configurations we include are:
 - [PurgeCSS Post-Build Hook](#purgecss-post-build-hook) (`purgecss`)
 - [Stimulus](#stimulus) (`stimulus`)
 - [Turbo](#turbo) (`turbo`)
+- [Bridgetown recommended PostCSS plugins](#bridgetown-recommended-postcss-plugins) (`bt-postcss`)
 - [Netlify TOML Configuration](#netlify-toml-configuration) (`netlify`)
 - [Swup.js Page Transitions](#swupjs-page-transitions) (`swup`)
 - [Automated Test Suite using Minitest](#automated-test-suite-using-minitest) (`minitesting`)
@@ -74,6 +75,25 @@ bundle exec bridgetown configure stimulus
 
 ```
 bundle exec bridgetown configure turbo
+```
+
+### Bridgetown recommended PostCSS plugins
+
+⛓️ Installs and configures a set of PostCSS plugins recommended by the Bridgetown community.
+
+It will install the following plugins:
+- [`postcss-easy-import`](https://github.com/trysound/postcss-easy-import)
+- [`postcss-mixins`](https://github.com/postcss/postcss-mixins)
+- [`postcss-color-function`](https://github.com/postcss/postcss-color-function)
+- [`cssnano`](https://cssnano.co)
+
+It will also configure [`postcss-preset-env`](http://preset-env.cssdb.org) to allow all features at [Stage 2 and above](http://preset-env.cssdb.org/features#stage-2); along with [`nesting-rules`](http://preset-env.cssdb.org/features#nesting-rules) and [`custom-media-queries`](http://preset-env.cssdb.org/features#custom-media-queries).
+
+This configuration will overwrite your `postcss.config.js` file.
+
+🛠 **Configure using:**
+```
+bundle exec bridgetown configure bt-postcss
 ```
 
 ### Netlify TOML Configuration

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -94,6 +94,7 @@ This configuration will overwrite your `postcss.config.js` file.
 ```
 bundle exec bridgetown configure bt-postcss
 ```
+If you'd customize your setup further you can find more plugins [here](https://www.postcss.parts).
 
 ### Netlify TOML Configuration
 

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -79,9 +79,8 @@ bundle exec bridgetown configure turbo
 
 ### Bridgetown recommended PostCSS plugins
 
-⛓️ Installs and configures a set of PostCSS plugins recommended by the Bridgetown community.
+⛓️ Installs and configures a set of [PostCSS](https://postcss.org) plugins recommended by the Bridgetown community:
 
-It will install the following plugins:
 - [`postcss-easy-import`](https://github.com/trysound/postcss-easy-import)
 - [`postcss-mixins`](https://github.com/postcss/postcss-mixins)
 - [`postcss-color-function`](https://github.com/postcss/postcss-color-function)

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -86,7 +86,7 @@ bundle exec bridgetown configure turbo
 - [`postcss-color-function`](https://github.com/postcss/postcss-color-function)
 - [`cssnano`](https://cssnano.co)
 
-It will also configure [`postcss-preset-env`](http://preset-env.cssdb.org) to allow all features at [Stage 2 and above](http://preset-env.cssdb.org/features#stage-2); along with [`nesting-rules`](http://preset-env.cssdb.org/features#nesting-rules) and [`custom-media-queries`](http://preset-env.cssdb.org/features#custom-media-queries).
+It will also configure [`postcss-preset-env`](http://preset-env.cssdb.org) to polyfill all features at [stage 2 and above](http://preset-env.cssdb.org/features#stage-2). If you don't need certain polyfills for your use case, you can bump up stage to 3 or 4 *(for example, [`custom properties`](http://preset-env.cssdb.org/features#custom-properties) won't get polyfilled if stage is set to 4)*. [`nesting-rules`](http://preset-env.cssdb.org/features#nesting-rules) and [`custom-media-queries`](http://preset-env.cssdb.org/features#custom-media-queries) are explicitly enabled.
 
 This configuration will overwrite your `postcss.config.js` file.
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes locally (run `script/cibuild` to verify this)

## Summary

I've added a configuration for PostCSS plugins as discussed in https://github.com/bridgetownrb/bridgetown/issues/207.

I decided to go with this color adjustment plugin: https://github.com/postcss/postcss-color-function, instead of the one @jaredcwhite recommended. That one was logging a deprecation/incompatibility message with PostCSS 8. The one I included is also an official PostCSS plugin so in my mind that's better.

Any and all feedback appreciated :) 

## Context

Closes https://github.com/bridgetownrb/bridgetown/issues/207