### PR TITLE
Add link to docs when configure command is invoked without arguments

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/configure.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/configure.rb
@@ -50,6 +50,10 @@ module Bridgetown
           configuration = set_color configuration, :blue, :bold
           say configuration
         end
+        say "\n"
+
+        docs_url = "https://www.bridgetownrb.com/docs/bundled-configurations".yellow.bold
+        say "For more info, check out the docs at: #{docs_url}"
       end
 
       def configurations


### PR DESCRIPTION
The `configure` command prints out a list of bundle configurations we include but no info about what is what. I reckon it's a good idea to include a link to the docs page for bundled configurations when `configure` is invoked without args. 

The output will now look like:

```
$ bundle exec bridgetown configure
Please specify a valid packaged configuration from the below list:

bt-postcss
minitesting
netlify
tailwindcss
turbo
stimulus
swup
purgecss

For more info, check out the docs at: https://www.bridgetownrb.com/docs/bundled-configurations
```