### PR TITLE
Exclude current post from LSI-powered related posts

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/related_posts.rb
+++ b/bridgetown-core/lib/bridgetown-core/related_posts.rb
@@ -42,7 +42,7 @@ module Bridgetown
     end
 
     def lsi_related_posts
-      self.class.lsi.find_related(post, 11)
+      self.class.lsi.find_related(post, 11) - [post]
     end
 
     def most_recent_posts

--- a/bridgetown-core/test/test_related_posts.rb
+++ b/bridgetown-core/test/test_related_posts.rb
@@ -56,5 +56,14 @@ class TestRelatedPosts < BridgetownUnitTest
 
       assert_equal @site.posts[-1..-9], Bridgetown::RelatedPosts.new(@site.posts.last).build
     end
+
+    should "not return current post" do
+      allow_any_instance_of(::ClassifierReborn::LSI).to \
+        receive(:find_related).and_return(@site.posts)
+      allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
+
+      related_posts = Bridgetown::RelatedPosts.new(@site.posts.last).build
+      refute related_posts.include?(@site.posts.last)
+    end
   end
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

It seems that when using LSI to get related post, the first one is always current post (because, well, it _is_ the best match). This PR fixes it by manually removing current post from the result set. What's interesting is that Jekyll has exactly the same code as Bridgetown, but seems unaffected (i.e. I'm not getting current post as related, but on the other hand I use a bit old version of jekyll + classifier-reborn, maybe it's due to that).
