### PR TITLE
update start.js script to work on win10

### DIFF
--- a/bridgetown-website/start.js
+++ b/bridgetown-website/start.js
@@ -9,8 +9,8 @@ const port = 4001
 /////////////////
 concurrently([
   { command: "yarn webpack-dev", name: "Webpack", prefixColor: "yellow"},
-  { command: "sleep 4; yarn serve --port " + port, name: "Bridgetown", prefixColor: "green"},
-  { command: "sleep 8; yarn sync", name: "Live", prefixColor: "blue"}
+  { command: "sleep 4 && yarn serve --port " + port, name: "Bridgetown", prefixColor: "green"},
+  { command: "sleep 8 && yarn sync", name: "Live", prefixColor: "blue"}
 ], {
   restartTries: 3,
   killOthers: ['failure', 'success'],


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Brand new user of Bridgetown (yay!) and couldn't get the default site loading on `localhost` by following the getting started steps. Turns out I'm on Windows 10 and it doesn't know how to handle `sleep 8;` within my shell. 

I updated the command to allow the `sleep` plus running the next command. Now it works on my Windows10 and my Mac, but I have no other platform to test / verify.

## Context

Couldn't find a related issue, but could also be my search-fu not working.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
