### PR TITLE
Migrate to dart sass since node-sass is deprecated

### DIFF
--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -27,10 +27,10 @@
     <% if options["use-postcss"] %>
     "postcss": "^8.1.9",
     "postcss-flexbugs-fixes": "^4.1.0",
-    "postcss-loader": "^5.0.0",
+    "postcss-loader": "^4.1.0",
     "postcss-preset-env": "^6.7.0",
     <% else %>
-    "fibers": "",
+    "fibers": "^5.0.0",
     "sass": "^1.32.8",
     "sass-loader": "^8.0.2",
     <% end %>

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -27,11 +27,12 @@
     <% if options["use-postcss"] %>
     "postcss": "^8.1.9",
     "postcss-flexbugs-fixes": "^4.1.0",
-    "postcss-loader": "^4.1.0",
+    "postcss-loader": "^5.0.0",
     "postcss-preset-env": "^6.7.0",
     <% else %>
-    "node-sass": "^4.13.1",
-    "sass-loader": "^8.0.2",    
+    "fibers": "",
+    "sass": "^1.32.8",
+    "sass-loader": "^8.0.2",
     <% end %>
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.11",

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -30,7 +30,6 @@
     "postcss-loader": "^4.1.0",
     "postcss-preset-env": "^6.7.0",
     <% else %>
-    "fibers": "^5.0.0",
     "sass": "^1.32.8",
     "sass-loader": "^8.0.2",
     <% end %>

--- a/bridgetown-core/lib/site_template/webpack.config.js.erb
+++ b/bridgetown-core/lib/site_template/webpack.config.js.erb
@@ -72,7 +72,7 @@ module.exports = {
           },
           "postcss-loader"
         ],
-      },      
+      },
       <% else %>
       {
         test: /\.(s[ac]|c)ss$/,
@@ -87,7 +87,9 @@ module.exports = {
           {
             loader: "sass-loader",
             options: {
+              implementation: require("sass"),
               sassOptions: {
+                fiber: false,
                 includePaths: [
                   path.resolve(__dirname, "src/_components")
                 ],


### PR DESCRIPTION
This is a 🙋 feature or enhancement, addressed in issues #278 and #273 to update the deprecated `node-sass` package. 
 

