### PR TITLE
Add configure command to command line page on website

### DIFF
--- a/bridgetown-website/Gemfile
+++ b/bridgetown-website/Gemfile
@@ -8,7 +8,7 @@ gem "bridgetown-core", path: "../bridgetown-core"
 gem "bridgetown-paginate", path: "../bridgetown-paginate"
 
 group :bridgetown_plugins do
-  gem "bridgetown-feed", "~> 1.0", github: "bridgetownrb/bridgetown-feed", branch: "support-resources"
+  gem "bridgetown-feed", "~> 2.0", github: "bridgetownrb/bridgetown-feed", branch: "support-resources"
   gem "bridgetown-inline-svg", "~> 1.1"
   gem "bridgetown-quick-search", "~> 1.0.3", github: "bridgetownrb/bridgetown-quick-search", branch: "support-resources"
   gem "bridgetown-seo-tag", "3.0.5"

--- a/bridgetown-website/Gemfile
+++ b/bridgetown-website/Gemfile
@@ -8,7 +8,7 @@ gem "bridgetown-core", path: "../bridgetown-core"
 gem "bridgetown-paginate", path: "../bridgetown-paginate"
 
 group :bridgetown_plugins do
-  gem "bridgetown-feed", "~> 2.0", github: "bridgetownrb/bridgetown-feed", branch: "support-resources"
+  gem "bridgetown-feed", "~> 2.0"
   gem "bridgetown-inline-svg", "~> 1.1"
   gem "bridgetown-quick-search", "~> 1.0.3", github: "bridgetownrb/bridgetown-quick-search", branch: "support-resources"
   gem "bridgetown-seo-tag", "3.0.5"

--- a/bridgetown-website/src/_docs/command-line-usage.md
+++ b/bridgetown-website/src/_docs/command-line-usage.md
@@ -19,6 +19,7 @@ You can use this command in a number of ways:
   Bridgetown's native Ruby API.
 * [`bridgetown plugins [list|cd]`](/docs/commands/plugins) - Display information about installed plugins or allow you to copy content out of gem-based plugins into your site folders.
 * `bridgetown apply` - Run an [automation script](/docs/automations) for your existing site.
+* `bridgetown configure CONFIGURATION` - Run a [bundled configuration](/docs/bundled-configurations) for your existing site. Invoke without arguments to see all available configurations.
 * `bridgetown help` - Shows help, optionally for a given subcommand, e.g. `bridgetown help build`.
 * `bridgetown doctor` - Outputs any deprecation or configuration issues.
 * `bridgetown clean` - Removes all generated files: destination folder, metadata file, and Bridgetown caches.


### PR DESCRIPTION
## Summary

The `configure` command was missing from the "Command Line Usage" page on the website. This PR adds that in.