### PR TITLE
Make configure command independent of Apply command

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/configure.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/configure.rb
@@ -27,7 +27,7 @@ module Bridgetown
         args.each do |configuration|
           configure configuration
         rescue Thor::Error
-          logger.error "Error:".red, "🚨 Configuration doesn't exist: #{configuration}"
+          @logger.error "Error:".red, "🚨 Configuration doesn't exist: #{configuration}"
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/commands/configure.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/configure.rb
@@ -4,6 +4,7 @@ module Bridgetown
   module Commands
     class Configure < Thor::Group
       include Thor::Actions
+      include Actions
       extend Summarizable
 
       Registrations.register do
@@ -20,7 +21,7 @@ module Bridgetown
       end
 
       def perform_configurations
-        logger = Bridgetown.logger
+        @logger = Bridgetown.logger
         list_configurations if args.empty?
 
         args.each do |configuration|
@@ -40,7 +41,7 @@ module Bridgetown
         configuration_file = find_in_source_paths("#{configuration}.rb")
 
         inside(New.created_site_dir || Dir.pwd) do
-          Apply.new.invoke(:apply_automation, [configuration_file])
+          apply configuration_file, verbose: false
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
@@ -4,9 +4,7 @@
 
 TEMPLATE_PATH = File.expand_path("./bt-postcss", __dir__)
 
-begin
-  find_in_source_paths("postcss.config.js")
-rescue Thor::Error
+unless File.exist?("postcss.config.js")
   error_message = "#{"postcss.config.js".bold} not found. Please configure postcss in your project."
 
   @logger.error "\nError:".red, "🚨 #{error_message}"

--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -4,9 +4,7 @@
 
 TEMPLATE_PATH = File.expand_path("./tailwindcss", __dir__)
 
-begin
-  find_in_source_paths("postcss.config.js")
-rescue Thor::Error
+unless File.exist?("postcss.config.js")
   error_message = "#{"postcss.config.js".bold} not found. Please configure postcss in your project."
 
   @logger.error "\nError:".red, "🚨 #{error_message}"


### PR DESCRIPTION
This is a 🙋 feature or enhancement. 


## Summary

Currently the `bridgetown configure` command invokes `bridgetown apply` under the hood. I've tweaked it so the configure command now directly calls Thor's `apply` method to execute the bundled configurations.

Going forward this will allow us to expose utility methods and instance variables (like `@site` potentially) just to our bundled configuration scripts and keep them isolated from what we expose to third party automations.