### PR TITLE
Consider the default branch from the git config while create a new site or plugin

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/git_helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/git_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Commands
+    module GitHelpers
+
+      def initialize_new_repo
+        run "git init", abort_on_failure: true
+        `git symbolic-ref HEAD refs/heads/main` if user_default_branch.empty?
+      end
+
+      def destroy_existing_repo
+        run "rm -rf .git"
+      end
+
+      def user_default_branch
+        @user_default_branch ||= `git config init.defaultbranch`.strip
+      end
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/git_helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/git_helpers.rb
@@ -3,7 +3,6 @@
 module Bridgetown
   module Commands
     module GitHelpers
-
       def initialize_new_repo
         run "git init", abort_on_failure: true
         `git symbolic-ref HEAD refs/heads/main` if user_default_branch.empty?

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -4,6 +4,7 @@ module Bridgetown
   module Commands
     class New < Thor::Group
       include Thor::Actions
+      include GitHelpers
       extend Summarizable
 
       Registrations.register do
@@ -157,8 +158,7 @@ module Bridgetown
       def git_init(path)
         unless Bridgetown.environment == "test"
           inside(path) do
-            run "git init", abort_on_failure: true
-            run "if [[ -n $(git status | grep 'On branch master') ]]; then git checkout -b main; fi"
+            initialize_new_repo
           end
         end
       rescue SystemExit

--- a/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
@@ -5,6 +5,7 @@ module Bridgetown
     class Plugins < Thor
       include Thor::Actions
       include ConfigurationOverridable
+      include GitHelpers
 
       Registrations.register do
         desc "plugins <command>", "List installed plugins or access plugin content"
@@ -148,9 +149,8 @@ module Bridgetown
         new_gemspec = "#{name}.gemspec"
 
         inside name do # rubocop:todo Metrics/BlockLength
-          run "rm -rf .git"
-          run "git init"
-          run "if [[ -n $(git status | grep 'On branch master') ]]; then git checkout -b main; fi"
+          destroy_existing_repo
+          initialize_new_repo
 
           run "mv bridgetown-sample-plugin.gemspec #{new_gemspec}"
           gsub_file new_gemspec, "https://github.com/bridgetownrb/bridgetown-sample-plugin", "https://github.com/username/#{name}"


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

To set the default branch name in new bridgetown sites and plugins, we're currently using a flaky if/then line of shell script that checks if the branch name is `master` and updates it to `main` if it is.

A PR just got merged into Rails where this is implement in a more robust way that checks the git config for a default branch name first and sets the default branch to main only if it doesn't exist:

https://github.com/rails/rails/pull/40254/files

Copying the code from there I've improved the logic we use to set the default branch.
