### PR TITLE
Fix warnings in plugin tests by checking if an ivar was defined

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -5,7 +5,7 @@ class Bridgetown::Site
     # Returns the current and/or default configured locale
     # @return String
     def locale
-      if @locale
+      if defined?(@locale)
         @locale
       else
         @locale = ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -6,10 +6,10 @@ class Bridgetown::Site
     # @return String
     def locale
       @locale ||= begin
-        ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
+        locale = ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
         I18n.load_path << Dir[in_source_dir("_locales") + "/*.yml"]
         I18n.available_locales = config[:available_locales]
-        I18n.default_locale = @locale
+        I18n.default_locale = locale
       end
     end
 

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -5,10 +5,8 @@ class Bridgetown::Site
     # Returns the current and/or default configured locale
     # @return String
     def locale
-      if defined?(@locale)
-        @locale
-      else
-        @locale = ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
+      @locale ||= begin
+        ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
         I18n.load_path << Dir[in_source_dir("_locales") + "/*.yml"]
         I18n.available_locales = config[:available_locales]
         I18n.default_locale = @locale

--- a/bridgetown-core/lib/bridgetown-core/frontmatter_defaults.rb
+++ b/bridgetown-core/lib/bridgetown-core/frontmatter_defaults.rb
@@ -13,7 +13,7 @@ module Bridgetown
     end
 
     def reset
-      @glob_cache = {} if @glob_cache
+      @glob_cache = {} if defined?(@glob_cache)
     end
 
     def update_deprecated_types(set)

--- a/bridgetown-core/lib/bridgetown-core/frontmatter_defaults.rb
+++ b/bridgetown-core/lib/bridgetown-core/frontmatter_defaults.rb
@@ -13,7 +13,7 @@ module Bridgetown
     end
 
     def reset
-      @glob_cache = {} if defined?(@glob_cache)
+      @glob_cache = {}
     end
 
     def update_deprecated_types(set)


### PR DESCRIPTION
This is a 🐛 bug fix. 

## Summary

One of my plugins' tests were logging the following lines:

`frontmatter_defaults.rb:16: warning: instance variable @glob_cache not initialized`
`localizable.rb:8: warning: instance variable @locale not initialized`

This PR fixes those by checking if those instance variables were `defined?` rather than if they exist.
