### PR TITLE
Add new configuration to overt webpack warning

### DIFF
--- a/bridgetown-core/lib/site_template/webpack.config.js.erb
+++ b/bridgetown-core/lib/site_template/webpack.config.js.erb
@@ -54,6 +54,7 @@ module.exports = {
                   helpers: false,
                 },
               ],
+              ["@babel/plugin-proposal-private-methods", { "loose": true }],
             ],
           },
         },


### PR DESCRIPTION
This is a 🐛 bug fix.

## Context

Closes #313 
