### PR TITLE
Add config directory and move webpack defaults into it

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/setup.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/setup.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-template "webpack.defaults.js.erb", "webpack.defaults.js"
+template "webpack.defaults.js.erb", "config/webpack.defaults.js"
 copy_file "webpack.config.js", force: true

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/update.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/update.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-template "webpack.defaults.js.erb", "webpack.defaults.js", force: true
+template "webpack.defaults.js.erb", "config/webpack.defaults.js", force: true

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-const config = require("./webpack.defaults.js")
+const config = require("./config/webpack.defaults.js")
 
 // Add any overrides to the default webpack config here:
 

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -32,7 +32,7 @@ module.exports = {
     modules: [
       path.resolve(rootDir, 'frontend', 'javascript'),
       path.resolve(rootDir, 'frontend', 'styles'),
-      path.resolve('../node_modules')
+      path.resolve(rootDir, 'node_modules')
     ],
     alias: {
       bridgetownComponents: path.resolve(rootDir, "src", "_components")
@@ -101,7 +101,7 @@ module.exports = {
               sassOptions: {
                 fiber: false,
                 includePaths: [
-                  path.resolve(__dirname, "src/_components")
+                  path.resolve(rootDir, "src/_components")
                 ],
               },
             },

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -13,7 +13,7 @@ const ManifestPlugin = require("webpack-manifest-plugin");
 
 module.exports = {
   entry: {
-    main: "../frontend/javascript/index.js"
+    main: path.resolve(rootDir, "frontend", "javascript", "index.js")
   },
   devtool: "source-map",
   // Set some or all of these to true if you want more verbose logging:

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -13,7 +13,7 @@ const ManifestPlugin = require("webpack-manifest-plugin");
 
 module.exports = {
   entry: {
-    main: "./frontend/javascript/index.js"
+    main: "../frontend/javascript/index.js"
   },
   devtool: "source-map",
   // Set some or all of these to true if you want more verbose logging:

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -7,6 +7,7 @@
 // `webpack.config.js` instead of editing this file.
 
 const path = require("path");
+const rootDir = path.resolve(__dirname, "..")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
 
@@ -23,18 +24,18 @@ module.exports = {
     children: false,
   },
   output: {
-    path: path.resolve(__dirname, "output", "_bridgetown", "static", "js"),
+    path: path.resolve(rootDir, "output", "_bridgetown", "static", "js"),
     filename: "[name].[contenthash].js",
   },
   resolve: {
     extensions: [".js", ".jsx"],
     modules: [
-      path.resolve(__dirname, 'frontend', 'javascript'),
-      path.resolve(__dirname, 'frontend', 'styles'),
-      path.resolve('./node_modules')
+      path.resolve(rootDir, 'frontend', 'javascript'),
+      path.resolve(rootDir, 'frontend', 'styles'),
+      path.resolve('../node_modules')
     ],
     alias: {
-      bridgetownComponents: path.resolve(__dirname, "src", "_components")
+      bridgetownComponents: path.resolve(rootDir, "src", "_components")
     }
   },
   plugins: [
@@ -42,7 +43,7 @@ module.exports = {
       filename: "../css/[name].[contenthash].css",
     }),
     new ManifestPlugin({
-      fileName: path.resolve(__dirname, ".bridgetown-webpack", "manifest.json"),
+      fileName: path.resolve(rootDir, ".bridgetown-webpack", "manifest.json"),
     }),
   ],
   module: {

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -22,7 +22,7 @@ class TestNewCommand < BridgetownUnitTest
   end
 
   def template_config_files
-    ["/Gemfile", "/package.json", "/frontend/javascript/index.js", "/webpack.config.js", "/webpack.defaults.js"]
+    ["/Gemfile", "/package.json", "/frontend/javascript/index.js", "/webpack.config.js", "/config/webpack.defaults.js"]
   end
 
   def static_template_files

--- a/bridgetown-core/test/test_webpack_command.rb
+++ b/bridgetown-core/test/test_webpack_command.rb
@@ -53,7 +53,6 @@ class TestWebpackCommand < BridgetownUnitTest
     end
 
     should "update webpack config" do
-      webpack_defaults = File.join(@full_path, "webpack.defaults.js")
       File.write(webpack_defaults, "OLD_VERSION")
 
       @cmd.inside(@full_path) do

--- a/bridgetown-core/test/test_webpack_command.rb
+++ b/bridgetown-core/test/test_webpack_command.rb
@@ -4,7 +4,7 @@ require "helper"
 
 class TestWebpackCommand < BridgetownUnitTest
   def webpack_defaults
-    File.join(@full_path, "webpack.defaults.js")
+    File.join(@full_path, "config", "webpack.defaults.js")
   end
 
   def webpack_config

--- a/bridgetown-website/src/_docs/frontend-assets.md
+++ b/bridgetown-website/src/_docs/frontend-assets.md
@@ -7,7 +7,7 @@ category: frontendassets
 
 Bridgetown comes with a default configuration of [Webpack](https://webpack.js.org) to handle building and exporting frontend assets such as JavaScript/TypeScript/etc., CSS/Sass/etc., and related files that are imported through Webpack (fonts, icons, etc.)
 
-The default configuration is defined in `webpack.defaults.js`. You can add or override config options in `webpack.config.js`.
+The default configuration is defined in `config/webpack.defaults.js`. You can add or override config options in `webpack.config.js`.
 
 The default configuration can be updated to the latest version provided by Bridgetown using the `webpack` CLI tool:
 


### PR DESCRIPTION
Adding a `config` directory in the root project directory and moving the default webpack config into it. In future releases a lot more stuff will be moved into this directory.

https://github.com/bridgetownrb/bridgetown/discussions/271