### PR TITLE
Add confirmation for overwriting postcss config in tailwindcss and bt-postcss bundled configurations

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
@@ -13,12 +13,14 @@ unless File.exist?("postcss.config.js")
   return
 end
 
+confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
+return unless confirm.upcase == "Y"
+
 plugins = %w(postcss-easy-import postcss-mixins postcss-color-function cssnano)
 
 say "Adding the following PostCSS plugins: #{plugins.join(' | ')}", :green
 run "yarn add -D #{plugins.join(' ')}"
 
-remove_file "postcss.config.js"
-copy_file "#{TEMPLATE_PATH}/postcss.config.js", "postcss.config.js"
+copy_file "#{TEMPLATE_PATH}/postcss.config.js", "postcss.config.js", force: true
 
 # rubocop:enable all

--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
@@ -14,7 +14,7 @@ unless File.exist?("postcss.config.js")
 end
 
 confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
-return unless confirm.upcase == "Y"
+return unless confirm.casecmp?("Y")
 
 plugins = %w(postcss-easy-import postcss-mixins postcss-color-function cssnano)
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -14,7 +14,7 @@ unless File.exist?("postcss.config.js")
 end
 
 confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
-return unless confirm.upcase == "Y"
+return unless confirm.casecmp?("Y")
 
 run "yarn add -D tailwindcss"
 run "npx tailwindcss init"

--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable all
+
 TEMPLATE_PATH = File.expand_path("./tailwindcss", __dir__)
 
 unless File.exist?("postcss.config.js")
@@ -23,3 +25,5 @@ prepend_to_file "frontend/styles/index.css",
                 File.read("#{TEMPLATE_PATH}/css_imports.css")
 
 run "bundle exec bridgetown configure purgecss"
+
+# rubocop:enable all

--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -11,11 +11,13 @@ unless File.exist?("postcss.config.js")
   return
 end
 
+confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
+return unless confirm.upcase == "Y"
+
 run "yarn add -D tailwindcss"
 run "npx tailwindcss init"
 
-remove_file "postcss.config.js"
-copy_file "#{TEMPLATE_PATH}/postcss.config.js", "postcss.config.js"
+copy_file "#{TEMPLATE_PATH}/postcss.config.js", "postcss.config.js", force: true
 
 prepend_to_file "frontend/styles/index.css",
                 File.read("#{TEMPLATE_PATH}/css_imports.css")


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

The `tailwindcss` and `bt-postcss` bundled configurations overwrite the `postcss.config.js` and the only place this is documented is on the website.

This PR adds a confirmation that informs the user that the `postcss.config.js` will be overwritten and asks if they would like to proceed.

Any confusion with running these two configurations one after the other should hopefully be prevented with this warning.

One area we should improve in the future is perhaps silence this warning when the config is invoked as part of `bridgetown new` but for now I reckon this should be good enough.

Closes https://github.com/bridgetownrb/bridgetown/issues/315