### PR TITLE
Install required packages in webpack enable postcss tool

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
@@ -2,3 +2,7 @@
 
 create_file "postcss.config.js"
 template "webpack.defaults.js.erb", "webpack.defaults.js", force: true
+
+packages = %w(postcss@8.3.0 postcss-loader@4.3.0 postcss-flexbugs-fixes postcss-preset-env)
+run "yarn add -D #{packages.join(' ')}"
+run "yarn remove sass sass-loader"

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
@@ -6,5 +6,5 @@ template default_postcss_config, "postcss.config.js"
 template "webpack.defaults.js.erb", "webpack.defaults.js", force: true
 
 packages = %w(postcss@8.3.0 postcss-loader@4.3.0 postcss-flexbugs-fixes postcss-preset-env)
-run "yarn add -D #{packages.join(' ')}"
+run "yarn add -D #{packages.join(" ")}"
 run "yarn remove sass sass-loader"

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/enable-postcss.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-create_file "postcss.config.js"
+default_postcss_config = File.expand_path("../../../site_template/postcss.config.js.erb", __dir__)
+
+template default_postcss_config, "postcss.config.js"
 template "webpack.defaults.js.erb", "webpack.defaults.js", force: true
 
 packages = %w(postcss@8.3.0 postcss-loader@4.3.0 postcss-flexbugs-fixes postcss-preset-env)

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -25,9 +25,9 @@
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^1.3.1",
     <% if options["use-postcss"] %>
-    "postcss": "^8.1.9",
+    "postcss": "^8.3.0",
     "postcss-flexbugs-fixes": "^4.1.0",
-    "postcss-loader": "^4.1.0",
+    "postcss-loader": "^4.3.0",
     "postcss-preset-env": "^6.7.0",
     <% else %>
     "sass": "^1.32.8",


### PR DESCRIPTION
When enabling postcss using `bridgetown webpack enable-postcss`, it only updates the webpack config and doesn't install the required packages. Adding a step to install the required postcss packages and uninstall the sass packages.

I also pulled in the default postcss config from the site template instead of creating an empty file