### PR TITLE
Add Bridgetown version to webpack defaults

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -5,6 +5,8 @@
 // run `bridgetown webpack update`. Any changes to this file will be overwritten
 // when an update is applied hence we strongly recommend adding overrides to
 // `webpack.config.js` instead of editing this file.
+//
+// Shipped with Bridgetown v<%= Bridgetown::VERSION %>
 
 const path = require("path");
 const rootDir = path.resolve(__dirname, "..")


### PR DESCRIPTION
I have some ideas for enhancing the webpack CLI took in the future ... potentially for 0.22. I think users should be able to update the webpack defaults from a specific version of Bridgetown. 

Say we ship a small update to the config in 0.22 and then a big one in 0.23. The user upgrades directly from 0.21 to 0.23; they cannot now access the 0.22 version of the webpack defaults.

The user should be able to optionally pass in a Bridgetown version like: `bridgetown webpack update 0.22` and this will get the appropriate file from GitHub using the release tag and install it locally.

As a first step to this I think it's useful for the user to see which version of Bridgetown their existing webpack defaults shipped with; this PR adds that in.
