### PR TITLE
Attempting to stabilize test suite

### DIFF
--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -31,143 +31,141 @@ class TestNewCommand < BridgetownUnitTest
     end
   end
 
-  unless ENV["GITHUB_ACTIONS"]
-    context "when args contains a path" do
-      setup do
-        @path = "new-site"
-        @args = "new #{@path}"
-        @full_path = File.expand_path(@path, Dir.pwd)
-        @full_path_source = File.expand_path("src", @full_path)
-      end
-
-      teardown do
-        FileUtils.rm_r @full_path if File.directory?(@full_path)
-      end
-
-      should "create a new folder with Gemfile and package.json" do
-        gemfile = File.join(@full_path, "Gemfile")
-        packagejson = File.join(@full_path, "package.json")
-        refute_exist @full_path
-        capture_output do
-          Bridgetown::Commands::Base.start(argumentize(@args))
-        end
-        assert_exist gemfile
-        assert_exist packagejson
-        assert_match(%r!gem "bridgetown", "~> #{Bridgetown::VERSION}"!, File.read(gemfile))
-        assert_match(%r!"start": "node start.js"!, File.read(packagejson))
-      end
-
-      should "display a success message" do
-        output = capture_output do
-          Bridgetown::Commands::Base.start(argumentize(@args))
-        end
-        success_message = "Your new Bridgetown site was generated in" \
-                          " #{@path.cyan}."
-
-        assert_includes output, success_message
-      end
-
-      should "copy the static files for postcss configuration in site template to the new directory" do
-        postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
-        postcss_template_files = static_template_files + postcss_config_files + template_config_files
-
-        capture_output do
-          Bridgetown::Commands::Base.start(argumentize("#{@args} --use-postcss"))
-        end
-
-        new_site_files = dir_contents(@full_path).reject do |f|
-          f.end_with?("welcome-to-bridgetown.md")
-        end
-
-        assert_same_elements postcss_template_files, new_site_files
-      end
-
-      should "copy the static files for sass configuration in site template to the new directory" do
-        sass_config_files = ["/frontend/styles/index.scss"]
-        sass_template_files = static_template_files + sass_config_files + template_config_files
-
-        capture_output do
-          Bridgetown::Commands::Base.start(argumentize(@args))
-        end
-
-        new_site_files = dir_contents(@full_path).reject do |f|
-          f.end_with?("welcome-to-bridgetown.md")
-        end
-
-        assert_same_elements sass_template_files, new_site_files
-      end
-
-      should "process any ERB files" do
-        erb_template_files = dir_contents(site_template_source).select do |f|
-          File.extname(f) == ".erb"
-        end
-
-        stubbed_date = "2013-01-01"
-        allow_any_instance_of(Time).to receive(:strftime) { stubbed_date }
-
-        erb_template_files.each do |f|
-          f.chomp! ".erb"
-          f.gsub! "0000-00-00", stubbed_date
-        end
-
-        capture_output do
-          Bridgetown::Commands::Base.start(argumentize(@args))
-        end
-
-        new_site_files = dir_contents(@full_path_source).select do |f|
-          erb_template_files.include? f
-        end
-
-        assert_same_elements erb_template_files, new_site_files
-      end
-
-      should "force created folder" do
-        capture_output { Bridgetown::Commands::Base.start(argumentize(@args)) }
-        output = capture_output do
-          Bridgetown::Commands::Base.start(argumentize("#{@args} --force"))
-        end
-        assert_match %r!new Bridgetown site was generated in!, output
-      end
-
-      should "skip bundle install when opted to" do
-        output = capture_output do
-          Bridgetown::Commands::Base.start(argumentize("#{@args} --skip-bundle"))
-        end
-
-        refute_exist File.join(@full_path, "Gemfile.lock")
-        bundle_message = "Bundle install skipped."
-        assert_includes output, bundle_message
-      end
+  context "when args contains a path" do
+    setup do
+      @path = SecureRandom.alphanumeric
+      @args = "new #{@path}"
+      @full_path = File.expand_path(@path, Dir.pwd)
+      @full_path_source = File.expand_path("src", @full_path)
     end
 
-    context "when multiple args are given" do
-      setup do
-        @site_name_with_spaces = "new site name"
-      end
-
-      teardown do
-        FileUtils.rm_r File.expand_path(@site_name_with_spaces, Dir.pwd)
-      end
-
-      should "create a new directory" do
-        refute_exist @site_name_with_spaces
-        invocation = argumentize("new #{@site_name_with_spaces}")
-        capture_output { Bridgetown::Commands::Base.start(invocation) }
-        assert_exist @site_name_with_spaces
-      end
+    teardown do
+      FileUtils.rm_r @full_path if File.directory?(@full_path)
     end
 
-    context "when no args are given" do
-      setup do
-        @empty_args = []
+    should "create a new folder with Gemfile and package.json" do
+      gemfile = File.join(@full_path, "Gemfile")
+      packagejson = File.join(@full_path, "package.json")
+      refute_exist @full_path
+      capture_output do
+        Bridgetown::Commands::Base.start(argumentize(@args))
+      end
+      assert_exist gemfile
+      assert_exist packagejson
+      assert_match(%r!gem "bridgetown", "~> #{Bridgetown::VERSION}"!, File.read(gemfile))
+      assert_match(%r!"start": "node start.js"!, File.read(packagejson))
+    end
+
+    should "display a success message" do
+      output = capture_output do
+        Bridgetown::Commands::Base.start(argumentize(@args))
+      end
+      success_message = "Your new Bridgetown site was generated in" \
+                        " #{@path.cyan}."
+
+      assert_includes output, success_message
+    end
+
+    should "copy the static files for postcss configuration in site template to the new directory" do
+      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
+      postcss_template_files = static_template_files + postcss_config_files + template_config_files
+
+      capture_output do
+        Bridgetown::Commands::Base.start(argumentize("#{@args} --use-postcss"))
       end
 
-      should "raise an ArgumentError" do
-        exception = assert_raises ArgumentError do
-          Bridgetown::Commands::Base.start(["new"])
-        end
-        assert_equal "You must specify a path.", exception.message
+      new_site_files = dir_contents(@full_path).reject do |f|
+        f.end_with?("welcome-to-bridgetown.md")
       end
+
+      assert_same_elements postcss_template_files, new_site_files
+    end
+
+    should "copy the static files for sass configuration in site template to the new directory" do
+      sass_config_files = ["/frontend/styles/index.scss"]
+      sass_template_files = static_template_files + sass_config_files + template_config_files
+
+      capture_output do
+        Bridgetown::Commands::Base.start(argumentize(@args))
+      end
+
+      new_site_files = dir_contents(@full_path).reject do |f|
+        f.end_with?("welcome-to-bridgetown.md")
+      end
+
+      assert_same_elements sass_template_files, new_site_files
+    end
+
+    should "process any ERB files" do
+      erb_template_files = dir_contents(site_template_source).select do |f|
+        File.extname(f) == ".erb"
+      end
+
+      stubbed_date = "2013-01-01"
+      allow_any_instance_of(Time).to receive(:strftime) { stubbed_date }
+
+      erb_template_files.each do |f|
+        f.chomp! ".erb"
+        f.gsub! "0000-00-00", stubbed_date
+      end
+
+      capture_output do
+        Bridgetown::Commands::Base.start(argumentize(@args))
+      end
+
+      new_site_files = dir_contents(@full_path_source).select do |f|
+        erb_template_files.include? f
+      end
+
+      assert_same_elements erb_template_files, new_site_files
+    end
+
+    should "force created folder" do
+      capture_output { Bridgetown::Commands::Base.start(argumentize(@args)) }
+      output = capture_output do
+        Bridgetown::Commands::Base.start(argumentize("#{@args} --force"))
+      end
+      assert_match %r!new Bridgetown site was generated in!, output
+    end
+
+    should "skip bundle install when opted to" do
+      output = capture_output do
+        Bridgetown::Commands::Base.start(argumentize("#{@args} --skip-bundle"))
+      end
+
+      refute_exist File.join(@full_path, "Gemfile.lock")
+      bundle_message = "Bundle install skipped."
+      assert_includes output, bundle_message
+    end
+  end
+
+  context "when multiple args are given" do
+    setup do
+      @site_name_with_spaces = "new site name"
+    end
+
+    teardown do
+      FileUtils.rm_r File.expand_path(@site_name_with_spaces, Dir.pwd)
+    end
+
+    should "create a new directory" do
+      refute_exist @site_name_with_spaces
+      invocation = argumentize("new #{@site_name_with_spaces}")
+      capture_output { Bridgetown::Commands::Base.start(invocation) }
+      assert_exist @site_name_with_spaces
+    end
+  end
+
+  context "when no args are given" do
+    setup do
+      @empty_args = []
+    end
+
+    should "raise an ArgumentError" do
+      exception = assert_raises ArgumentError do
+        Bridgetown::Commands::Base.start(["new"])
+      end
+      assert_equal "You must specify a path.", exception.message
     end
   end
 end

--- a/bridgetown-core/test/test_webpack_command.rb
+++ b/bridgetown-core/test/test_webpack_command.rb
@@ -11,68 +11,66 @@ class TestWebpackCommand < BridgetownUnitTest
     File.join(@full_path, "webpack.config.js")
   end
 
-  unless ENV["GITHUB_ACTIONS"]
-    context "the webpack command" do
-      setup do
-        @path = "new-site"
-        @full_path = File.expand_path(@path, Dir.pwd)
+  context "the webpack command" do
+    setup do
+      @path = SecureRandom.alphanumeric
+      @full_path = File.expand_path(@path, Dir.pwd)
 
-        capture_stdout { Bridgetown::Commands::Base.start(["new", @path]) }
-        @cmd = Bridgetown::Commands::Webpack.new
+      capture_stdout { Bridgetown::Commands::Base.start(["new", @path]) }
+      @cmd = Bridgetown::Commands::Webpack.new
+    end
+
+    teardown do
+      FileUtils.rm_r @full_path if File.directory?(@full_path)
+    end
+
+    should "list all available actions when invoked without args" do
+      output = capture_stdout do
+        @cmd.webpack
+      end
+      assert_match %r!setup!, output
+      assert_match %r!update!, output
+      assert_match %r!enable-postcss!, output
+    end
+
+    should "show error when action doesn't exist" do
+      output = capture_stdout do
+        @cmd.invoke(:webpack, ["qwerty"])
       end
 
-      teardown do
-        FileUtils.rm_r @full_path if File.directory?(@full_path)
+      assert_match %r!Please enter a valid action!, output
+    end
+
+    should "setup webpack defaults and config" do
+      File.delete webpack_defaults # Delete the file created during setup
+
+      @cmd.inside(@full_path) do
+        capture_stdout { @cmd.invoke(:webpack, ["setup"]) }
       end
 
-      should "list all available actions when invoked without args" do
-        output = capture_stdout do
-          @cmd.webpack
-        end
-        assert_match %r!setup!, output
-        assert_match %r!update!, output
-        assert_match %r!enable-postcss!, output
+      assert_exist webpack_defaults
+      assert_exist webpack_config
+    end
+
+    should "update webpack config" do
+      File.write(webpack_defaults, "OLD_VERSION")
+
+      @cmd.inside(@full_path) do
+        capture_stdout { @cmd.invoke(:webpack, ["update"]) }
       end
 
-      should "show error when action doesn't exist" do
-        output = capture_stdout do
-          @cmd.invoke(:webpack, ["qwerty"])
-        end
+      assert_file_contains %r!module.exports!, webpack_defaults
+      refute_file_contains %r!OLD_VERSION!, webpack_defaults
+    end
 
-        assert_match %r!Please enter a valid action!, output
+    should "enable postcss in webpack config" do
+      refute_file_contains %r!postcss-loader!, webpack_defaults
+
+      @cmd.inside(@full_path) do
+        capture_stdout { @cmd.invoke(:webpack, ["enable-postcss"]) }
       end
 
-      should "setup webpack defaults and config" do
-        File.delete webpack_defaults # Delete the file created during setup
-
-        @cmd.inside(@full_path) do
-          capture_stdout { @cmd.invoke(:webpack, ["setup"]) }
-        end
-
-        assert_exist webpack_defaults
-        assert_exist webpack_config
-      end
-
-      should "update webpack config" do
-        File.write(webpack_defaults, "OLD_VERSION")
-
-        @cmd.inside(@full_path) do
-          capture_stdout { @cmd.invoke(:webpack, ["update"]) }
-        end
-
-        assert_file_contains %r!module.exports!, webpack_defaults
-        refute_file_contains %r!OLD_VERSION!, webpack_defaults
-      end
-
-      should "enable postcss in webpack config" do
-        refute_file_contains %r!postcss-loader!, webpack_defaults
-
-        @cmd.inside(@full_path) do
-          capture_stdout { @cmd.invoke(:webpack, ["enable-postcss"]) }
-        end
-
-        assert_file_contains %r!postcss-loader!, webpack_defaults
-      end
+      assert_file_contains %r!postcss-loader!, webpack_defaults
     end
   end
 end


### PR DESCRIPTION
Looking into the test failure, it looks like the suite crashes when trying to create a new site in `test_webpack_command` and `test_new_command` due to a directory conflict.

In some cases, the new site's directory isn't totally cleaned up when running the whole test suite; not the individual case. I have no idea why it doesn't get cleaned up, can't see anything in to code to suggest it. 

Locally, I changed the hardcoded name of `new-site` and replaced it with `SecureRandom.alphanumeric` and it seemed to pass consistently. I think this is the right way to go as it would stand us in good stead if we were to parallelize the test suite in the future.

If anyone has any ideas as to why the directory isn't cleaned up sometimes, please let me know!

Opening this PR to see if CI passes consistently.

Resolves https://github.com/bridgetownrb/bridgetown/issues/318 (Hopefully)