### PR TITLE
Add webpack merge docs  to webpack config

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
@@ -1,7 +1,8 @@
-const config = require("./config/webpack.defaults.js")
+var config = require("./config/webpack.defaults.js")
+const { merge } = require('webpack-merge')
 
 // Add any overrides to the default webpack config here:
-
+//
 // Eg:
 //
 //  ```
@@ -9,6 +10,17 @@ const config = require("./config/webpack.defaults.js")
 //    config.resolve.modules.push(path.resolve(__dirname, 'frontend', 'components'))
 //    config.resolve.alias.frontendComponents = path.resolve(__dirname, 'frontend', 'components')
 //  ```
+//
+// You can also merge in custom config using the included `webpack-merge` package.
+// Complete docs available at: https://github.com/survivejs/webpack-merge
+//
+// Eg:
+//
+//  ```
+//    const customConfig = { ..... }
+//    config = merge(config, customConfig)
+//  ```
+
 
 
 

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
@@ -11,7 +11,7 @@ const { merge } = require('webpack-merge')
 //    config.resolve.alias.frontendComponents = path.resolve(__dirname, 'frontend', 'components')
 //  ```
 //
-// You can also merge in custom config using the included `webpack-merge` package.
+// You can also merge in a custom config using the included `webpack-merge` package.
 // Complete docs available at: https://github.com/survivejs/webpack-merge
 //
 // Eg:

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.config.js
@@ -1,5 +1,6 @@
-var config = require("./config/webpack.defaults.js")
 const { merge } = require('webpack-merge')
+
+var config = require("./config/webpack.defaults.js")
 
 // Add any overrides to the default webpack config here:
 //

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -35,6 +35,7 @@
     <% end %>
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.11",
-    "webpack-manifest-plugin": "^2.1.0"
+    "webpack-manifest-plugin": "^2.1.0",
+    "webpack-merge": "^5.8.0"
   }
 }


### PR DESCRIPTION
I've been knee deep in Webpacker 6 today and I discovered the amazing [`webpack-merge`](https://github.com/survivejs/webpack-merge) package to merge config objects.

I thought it'd be a good idea to include it in new sites by default and add some docs about how to use it.