### PR TITLE
Add a deployment description for GH Pages to the docs

### DIFF
--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -121,9 +121,9 @@ git push -u origin master
 
 After the build the site should be live at https://bridgetownrb.gitlab.io/mysite
 
-### GitHub Actions
+### GitHub Pages
 
-_description coming soon_
+Much like with GitLab, you can also deploy static sites to [GitHub Pages](https://pages.github.com/). You can make use of [GitHub Actions](https://github.com/features/actions) to automate building and deploying your site to GitHub Pages. For an out-of-the-box solution, check out the [`bridgetown-gh-pages-action`](https://github.com/andrewmcodes/bridgetown-gh-pages-action). One thing to note is that this action's default deployment branch is the `gh-pages` branch, so if you're using the default, you'll need to make sure your repo's GitHub Pages Settings at `https://github.com/<your-account>/<your-site>/settings/pages` have Source set to the `gh-pages` branch.
 
 ### Dokku
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I noticed that there's no description in the docs for how to build and deploy a Bridgetown site on GitHub Pages. I'm using the [bridgetown-gh-pages-action](https://github.com/andrewmcodes/bridgetown-gh-pages-action) GitHub Action to do so and after a little help from the author it's a very easy solution, so I thought I'd help out others who might not be aware of it by including it in the docs.

## Context

Updates the deployment docs for GitHub Pages.