### PR TITLE
Update macOS documentation to refer to zsh instead of bash

### DIFF
--- a/bridgetown-website/src/_docs/installation/macos.md
+++ b/bridgetown-website/src/_docs/installation/macos.md
@@ -56,7 +56,7 @@ brew install ruby
 Add the brew ruby path to your shell config:
 
 ```sh
-echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.zprofile
 ```
 
 Then relaunch your terminal and check your updated Ruby setup:
@@ -79,7 +79,7 @@ gem install --user-install bundler
 Then append your path file with the following, replacing the `X.X` with the first two digits of your Ruby version.
 
 ```sh
-echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.zprofile
 ```
 
 Then relaunch your terminal and check that your gem paths point to your home directory by running:


### PR DESCRIPTION
Apple switched the default shell to zsh from bash in macOS 10.15 (Catalina), and
so instructions to update `~/.bash_profile` are incorrect. This change updates
the documentation to instead use `~/.zprofile`.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
