### PR TITLE
Add mission comma in package.json which broken install

### DIFF
--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -31,7 +31,7 @@
     <% end %>
     "webpack": "^5.39.1",
     "webpack-cli": "^4.7.2",
-    "webpack-manifest-plugin": "^3.1.1"
+    "webpack-manifest-plugin": "^3.1.1",
     "webpack-merge": "^5.8.0"
   }
 }


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary
The package.json was missing a comma after the `"webpack-manifest-plugin": "^3.1.1"` line, which broke the installation.

