### PR TITLE
Resolve postcss-focus-within to v4

### DIFF
--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -33,5 +33,8 @@
     "webpack-cli": "^4.7.2",
     "webpack-manifest-plugin": "^3.1.1",
     "webpack-merge": "^5.8.0"
+  },
+  "resolutions": {
+    "postcss-focus-within": "^4.0.0"
   }
 }


### PR DESCRIPTION
There's a bug in `postcss-focus-within` v3 which has been fixed in v4; but `postcss-present-env` still relies on v3. There's a PR open to update it for over a year: https://github.com/csstools/postcss-preset-env/pull/172

To provide a better developer experience, I reckon it's best to fix this within Bridgetown by explicitly resolving this package to v4. I've set the resolution in our default `package.json`. I don't think there's much point in adding this resolution just when the `--use-postcss` flag is added as it doesn't really do any harm and I don't want to litter the file with multiple `if`s.

Also, this approach means we don't have to set the resolution in our `bridgetown webpack enable-postcss` command which makes life easier as the `yarn set resolution` command only exists in Yarn 2.

Fixes https://github.com/bridgetownrb/bridgetown/issues/356