### PR TITLE
Fix strip out newlines in generated package.json

### DIFF
--- a/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
+++ b/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
@@ -1,8 +1,8 @@
-<% if options["use-postcss"] %>
+<%- if options["use-postcss"] -%>
 import "index.css"
-<% else %>
+<%- else -%>
 import "index.scss"
-<% end %>
+<%- end -%>
 
 // Import all javascript files from src/_components
 const componentsContext = require.context("bridgetownComponents", true, /.js$/)

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -20,15 +20,15 @@
     "esbuild-loader": "^2.13.1",
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^1.3.1",
-    <% if options["use-postcss"] %>
+    <%- if options["use-postcss"] -%>
     "postcss": "^8.3.0",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^4.3.0",
     "postcss-preset-env": "^6.7.0",
-    <% else %>
+    <%- else -%>
     "sass": "^1.32.8",
     "sass-loader": "^8.0.2",
-    <% end %>
+    <%- end -%>
     "webpack": "^5.39.1",
     "webpack-cli": "^4.7.2",
     "webpack-manifest-plugin": "^3.1.1",


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary
Removes empty lines in package.json when creating a new site. 

<!--
  Provide a description of what your pull request changes.
-->

## Context

  The following will close issue #368 when PR is merged.
