### PR TITLE
Performance refactor of the Webpack helper

### DIFF
--- a/bridgetown-core/features/webpack_path_tag.feature
+++ b/bridgetown-core/features/webpack_path_tag.feature
@@ -30,7 +30,7 @@ Feature: WebpackPath Tag
     Then the "output/index.html" file should exist
     And I should see "/_bridgetown/static/js/all.hashgoeshere.js" in "output/index.html"
     And I should not see "//_bridgetown/static/js/all.hashgoeshere.js" in "output/index.html"
-    And I should not see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+    And I should not see "MISSING_WEBPACK_MANIFEST_FILE" in "output/index.html"
 
   Scenario: Use custom filename in Webpack manifest
     Given I have a _layouts directory
@@ -59,7 +59,7 @@ Feature: WebpackPath Tag
     When I run bridgetown build
     Then the "output/index.html" file should exist
     And I should see "/_bridgetown/static/frontend/images/folder/somefile.hashgoeshere.png" in "output/index.html"
-    And I should not see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+    And I should not see "MISSING_WEBPACK_MANIFEST_FILE" in "output/index.html"
 
   Scenario: Missing Webpack manifest
     Given I have a _layouts directory
@@ -78,7 +78,7 @@ Feature: WebpackPath Tag
     And I have an "index.html" page with layout "default" that contains "page content"
     When I run bridgetown build
     Then the "output/index.html" file should exist
-    And I should see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+    And I should see "MISSING_WEBPACK_MANIFEST_FILE" in "output/index.html"
 
   Scenario: Missing Webpack manifest
     Given I have a _layouts directory
@@ -104,7 +104,7 @@ Feature: WebpackPath Tag
       """
     When I run bridgetown build
     Then the "output/index.html" file should exist
-    And I should see "Unknown Webpack asset type" in the build output
+    And I should see "Webpack:" in the build output
 
   Scenario: Broken Webpack manifest (css)
     Given I have a _layouts directory
@@ -130,7 +130,7 @@ Feature: WebpackPath Tag
       """
     When I run bridgetown build
     Then the "output/index.html" file should exist
-    And I should see "WebpackAssetError" in the build output
+    And I should see "Webpack:" in the build output
 
   Scenario: Broken Webpack manifest (js)
     Given I have a _layouts directory
@@ -156,7 +156,7 @@ Feature: WebpackPath Tag
       """
     When I run bridgetown build
     Then the "output/index.html" file should exist
-    And I should see "WebpackAssetError" in the build output
+    And I should see "Webpack:" in the build output
 
   Scenario: Use Webpack manifest in an ERB layout
     Given I have a _layouts directory
@@ -186,4 +186,4 @@ Feature: WebpackPath Tag
     Then the "output/index.html" file should exist
     And I should see "/_bridgetown/static/js/all.hashgoeshere.js" in "output/index.html"
     And I should see "Static: /_bridgetown" in "output/index.html"
-    And I should not see "MISSING_WEBPACK_MANIFEST" in "output/index.html"
+    And I should not see "MISSING_WEBPACK_MANIFEST_FILE" in "output/index.html"

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/content.rb
@@ -220,5 +220,15 @@ class Bridgetown::Site
     def add_generated_page(generated_page)
       generated_pages << generated_page
     end
+
+    # Loads and memoizes the parsed Webpack manifest file (if available)
+    # @return [Hash]
+    def frontend_manifest
+      @frontend_manifest ||= begin
+        manifest_file = in_root_dir(".bridgetown-webpack", "manifest.json")
+
+        JSON.parse(File.read(manifest_file)) if File.exist?(manifest_file)
+      end
+    end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
@@ -34,6 +34,7 @@ class Bridgetown::Site
       self.pages = []
       self.static_files = []
       self.data = HashWithDotAccess::Hash.new
+      @frontend_manifest = nil
       @post_attr_hash = {}
       @collections = nil
       @documents = nil

--- a/bridgetown-core/lib/bridgetown-core/errors.rb
+++ b/bridgetown-core/lib/bridgetown-core/errors.rb
@@ -14,7 +14,5 @@ module Bridgetown
     PostURLError                = Class.new(FatalException)
     InvalidURLError             = Class.new(FatalException)
     InvalidConfigurationError   = Class.new(FatalException)
-
-    WebpackAssetError           = Class.new(FatalException)
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -354,28 +354,19 @@ module Bridgetown
     # @raise [WebpackAssetError] if unable to find css or js in the manifest
     # file
     def parse_webpack_manifest_file(site, asset_type)
-      manifest_file = site.in_root_dir(".bridgetown-webpack", "manifest.json")
-      return "MISSING_WEBPACK_MANIFEST" unless File.exist?(manifest_file)
+      return log_webpack_asset_error("Webpack manifest") if site.frontend_manifest.nil?
 
-      manifest = JSON.parse(File.read(manifest_file))
+      asset_path = if %w(js css).include?(asset_type)
+                     site.frontend_manifest["main.#{asset_type}"]
+                   else
+                     site.frontend_manifest.find do |item, _|
+                       item.sub(%r{^../(frontend/|src/)?}, "") == asset_type
+                     end&.last
+                   end
 
-      known_assets = %w(js css)
-      asset_path = nil
-      if known_assets.include?(asset_type)
-        asset_path = manifest["main.#{asset_type}"]
-        log_webpack_asset_error(asset_type) && return if asset_path.nil?
-      else
-        asset_path = manifest.find do |item, _|
-          item.sub(%r{^../(frontend/|src/)?}, "") == asset_type
-        end&.last
-      end
+      return log_webpack_asset_error(asset_type) if asset_path.nil?
 
-      if asset_path
-        static_frontend_path(site, ["js", asset_path])
-      else
-        Bridgetown.logger.error("Unknown Webpack asset type", asset_type)
-        nil
-      end
+      static_frontend_path site, ["js", asset_path]
     end
 
     def static_frontend_path(site, additional_parts = [])
@@ -389,10 +380,13 @@ module Bridgetown
     end
 
     def log_webpack_asset_error(asset_type)
-      error_message = "There was an error parsing your #{asset_type} files. \
-        Please check your #{asset_type} for any errors."
+      Bridgetown.logger.warn(
+        "Webpack:",
+        "There was an error parsing your #{asset_type} file. \
+        Please check your #{asset_type} file for any errors."
+      )
 
-      Bridgetown.logger.warn(Errors::WebpackAssetError, error_message)
+      "MISSING_WEBPACK_MANIFEST_FILE"
     end
 
     def default_github_branch_name(repo_url)


### PR DESCRIPTION
The PR addresses a performance issue with the code which parses the Webpack manifest JSON file. Previously the loading and parsing of the file was happening every single time the Webpack helper was used…meaning if you had to generate 10,000 pages, the loading/parsing of the manifest occurred 10,000 times. Now it happens once. 😁

Bonus: you now have access to `site.frontend_manifest` in Ruby anytime you need direct access to the contents of the manifest.

Fixes #325