### PR TITLE
Return ordered results for belongs_to array

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -48,6 +48,20 @@ module Bridgetown
       @resources ||= []
     end
 
+    # Fetch the collection resources and arrange them by slug in a hash.
+    #
+    # @return [Hash<String, Bridgetown::Resource::Base>]
+    def resources_by_slug
+      resources.group_by { |item| item.data.slug }.transform_values(&:first)
+    end
+
+    # Fetch the collection resources and arrange them by relative URL in a hash.
+    #
+    # @return [Hash<String, Bridgetown::Resource::Base>]
+    def resources_by_relative_url
+      resources.group_by(&:relative_url).transform_values(&:first)
+    end
+
     # Iterate over either Resources or Documents depending on how the site is
     # configured
     def each(&block)

--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bridgetown
-  class Collection
+  class Collection # rubocop:todo Metrics/ClassLength
     # @return [Bridgetown::Site]
     attr_reader :site
 

--- a/bridgetown-core/lib/bridgetown-core/resource/relations.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/relations.rb
@@ -94,9 +94,8 @@ module Bridgetown
       # @return [Bridgetown::Resource::Base, Array<Bridgetown::Resource::Base>]
       def belongs_to_relation_for_type(type)
         if resource.data[type].is_a?(Array)
-          other_collection_for_type(type).resources.select do |other_resource|
-            other_resource.data.slug.in?(resource.data[type])
-          end
+          other_slugs = other_collection_for_type(type).resources_by_slug
+          resource.data[type].map { |slug| other_slugs[slug] }.compact
         else
           other_collection_for_type(type).resources.find do |other_resource|
             other_resource.data.slug == resource.data[type]


### PR DESCRIPTION
## Summary

Previously, if you had an array of resource relations using `belong_to`, the result set would not be ordered in the same way as your front matter. Now you get exactly the results you specify. For example:

```yaml
pages: ["posts", "404", "about", "404", "posts"]
```

calling `resource.relations.pages` will literally retrieve an array of resources in that order (posts, 404, about, 404, posts).

## Context

Resolves #360
