### PR TITLE
Enhance front matter DSL with nesting and lambda value eval

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -6,6 +6,7 @@ module Bridgetown
     autoload :Ansi, "bridgetown-core/utils/ansi"
     autoload :RequireGems, "bridgetown-core/utils/require_gems"
     autoload :RubyExec, "bridgetown-core/utils/ruby_exec"
+    autoload :RubyFrontMatter, "bridgetown-core/utils/ruby_front_matter"
     autoload :RubyFrontMatterDSL, "bridgetown-core/utils/ruby_front_matter"
 
     # Constants for use in #slugify

--- a/bridgetown-core/lib/bridgetown-core/utils/ruby_front_matter.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/ruby_front_matter.rb
@@ -3,20 +3,23 @@
 module Bridgetown
   module Utils
     module RubyFrontMatterDSL
-      def front_matter(&block)
-        RubyFrontMatter.new.tap { |fm| fm.instance_exec(&block) }
+      def front_matter(eval_with: nil, &block)
+        RubyFrontMatter.new(eval_with: eval_with).tap { |fm| fm.instance_exec(&block) }
       end
     end
 
     class RubyFrontMatter
-      def initialize
+      def initialize(eval_with: nil)
         @data = {}
+        @eval_with = eval_with
       end
 
-      def method_missing(key, value) # rubocop:disable Style/MissingRespondToMissing
-        return super if respond_to?(key)
+      def method_missing(key, value = nil, &block) # rubocop:disable Metrics/CyclomaticComplexity, Style/MissingRespondToMissing
+        return super if respond_to?(key) || (value.nil? && block.nil? && !@data.key?(key))
 
-        set(key, value)
+        return get(key) if value.nil? && block.nil? && @data.key?(key)
+
+        set(key, value, &block)
       end
 
       def each(&block)
@@ -27,7 +30,19 @@ module Bridgetown
         @data[key]
       end
 
-      def set(key, value)
+      def set(key, value = nil, &block)
+        # Handle nested data within a block
+        if block
+          value = self.class.new(eval_with: @eval_with).tap do |fm|
+            fm.instance_exec(&block)
+          end.to_h
+        end
+
+        # Execute lambda value within the resolver
+        if @eval_with && value.is_a?(Hash) && value[:eval].is_a?(Proc)
+          value = @eval_with.instance_exec(&value[:eval])
+        end
+
         @data[key] = value
       end
 

--- a/bridgetown-core/test/resources/src/_events/2020-12-25-christmas.erb
+++ b/bridgetown-core/test/resources/src/_events/2020-12-25-christmas.erb
@@ -1,7 +1,7 @@
 ---<%
 front_matter do
   old_title "Christmas 2019"
-  title get(:old_title).sub("2019", "2020")
+  title old_title.sub("2019", "2020")
 end
 %>---
 

--- a/bridgetown-core/test/resources/src/_events/2021-05-14-the-weeknd.erb
+++ b/bridgetown-core/test/resources/src/_events/2021-05-14-the-weeknd.erb
@@ -1,7 +1,12 @@
 ---<%
-front_matter do
+special_config = Struct.new(:should_output).new
+special_config.should_output = false
+
+front_matter eval_with: special_config do
   title "The Weeknd"
-  config({ output: false })
+  config do
+    output eval: -> { should_output }
+  end
 end
 %>---
 


### PR DESCRIPTION
Partially addresses #365 

Also adds a neat feature where you can pass an evaluation scope and then use that within a lambda value. For example:

```ruby
special_config = Struct.new(:should_output).new
special_config.should_output = false

front_matter eval_with: special_config do
  title "The Weeknd"
  config do
    output eval: -> { should_output }
  end
end
```

This will resolve to:

```ruby
{
  title: "The Weeknd",
  config: {
    output: false
  }
}
```