### PR TITLE
Add missing regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-.
+### Fixed
+
+- Prevent `.js` matches with any file like `foo.js.txt.bat.png` [#399](https://github.com/bridgetownrb/bridgetown/issues/399) ([nachoal](https://github.com/nachoal/))
 
 ## 0.21.4 - 2021-09-10
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Bridgetown is built by:
 |<a href="https://github.com/erikyuzwa">@erikyuzwa</a>|<a href="https://github.com/eclectic-coding">@eclectic-coding</a>|<a href="https://github.com/collindonnell">@collindonnell</a>|<a href="https://github.com/juhat">@juhat</a>|<a href="https://github.com/debashis-biswal">@debashis-biswal</a>|
 |Calgary, AB|North Carolina, US|Portland, OR|Budapest, Hungary||
 
+|<img src="https://avatars.githubusercontent.com/nachoal?s=256" alt="nachoal" width="128" />|
+|:---:|
+|<a href="https://github.com/nachoal">@nachoal</a>|<a href="https://github.com/nachoal">@nachoal</a>|
+|CDMX, México|
+
 |<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
 |:---:|
 |You Next?|

--- a/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/webpack/webpack.defaults.js.erb
@@ -24,8 +24,8 @@ const output = {
 
 // Rules and Loaders
 
-const jsRule =  {
-  test: /\.(js|jsx)/,
+const jsRule = {
+  test: /\.(js|jsx)$/,
   use: {
     loader: "esbuild-loader",
     options: {


### PR DESCRIPTION
This is a 🐛 bug fix. 

## Summary

This adds the missing regex `$` as per this [issue](https://github.com/bridgetownrb/bridgetown/issues/399 ) to avoid matching the wrong strings, e.g. `.js.gif` 

## Context

Fixes #399 