### PR TITLE
Fix netlify config to use native deploy command

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/netlify/netlify.toml
+++ b/bridgetown-core/lib/bridgetown-core/configurations/netlify/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn deploy && ./bin/netlify.sh"
+  command = "bin/bridgetown deploy && bin/netlify.sh"
   publish = "output"
 
 [build.environment]


### PR DESCRIPTION
Switch the TOML file in the bundled configuration to use `bin/bridgetown deploy` instead of `yarn deploy`