### PR TITLE
Don't mutate bundler dependencies in place

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -44,8 +44,7 @@ module Bridgetown
       if !ENV["BRIDGETOWN_NO_BUNDLER_REQUIRE"] && File.file?("Gemfile")
         require "bundler"
 
-        required_gems = Bundler.require PLUGINS_GROUP
-        required_gems.select! do |dep|
+        required_gems = Bundler.require(PLUGINS_GROUP).select do |dep|
           (dep.groups & [PLUGINS_GROUP]).any? && dep.should_include?
         end
 


### PR DESCRIPTION
This is a 🐛 bug fix, although a workaround is already in place (#430) and in my opinion it should not be reverted because it's a more bullet proof approach. So this fix is not very important, but given the amount of `bundler` internals Bridgetown seems to use, it might save you & us from future trouble!

## Summary

It was [reported to us](https://github.com/rubygems/rubygems/issues/5022) a question about why your previous check of whether `puma` was present in the bundle (through `Bundler.definition.specs`) wouldn't work while the new one (through directly requiring it and rescuing `LoadError`) would work.

I investigated the root cause thanks to a helpful reproduction provided in the issue, and I found the culprit in `bridgetown`'s plugin manager mutating the array of bundler dependencies and causing this issue as a side effect.

Plugin manager uses `Bundler.require`, which returns the set of dependencies bundler definition is considering for the current invocation. And those dependencies were being filtered and the ones outside of plugins' groups removed (`puma` is usually one of these). `Bundler.definition.specs` materializes the current dependencies into a set of requirable specifications. However, since some dependencies had been wiped out by the plugin manager, the corresponding specs would no longer be materialized and would be missing.

This commit fixes the problem by not mutating bundler dependencies in-place.

## Context

My guess is that this might've worked in the past, but some changes in `bundler` made the issue surface. At some point requiring `bundler/setup` probably memoized the set of materialized specs, so the call to `Bundler.definition.specs` wouldn't be affected by any change in the underlying dependencies. I added a change in `bundler` to make sure the set of specs initially materialized by requiring `bundler/setup` is memoized, so that this kind of issue cannot reaper in other ways.
