### PR TITLE
Add new console commands via `ConsoleMethods` mixin

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/console.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/console.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 
 module Bridgetown
+  module ConsoleMethods
+    def site
+      Bridgetown::Current.site
+    end
+
+    def collections
+      site.collections
+    end
+
+    def reload!
+      Bridgetown.logger.info "Reloading site..."
+
+      I18n.reload! # make sure any locale files get read again
+      Bridgetown::Hooks.trigger :site, :pre_reload, site
+      Bridgetown::Hooks.clear_reloadable_hooks
+      site.plugin_manager.reload_plugin_files
+      site.loaders_manager.reload_loaders
+
+      ConsoleMethods.site_reset(site)
+    end
+
+    def self.site_reset(site)
+      site.reset
+      Bridgetown.logger.info "Reading files..."
+      site.read
+      Bridgetown.logger.info "", "done!"
+      Bridgetown.logger.info "Running generators..."
+      site.generate
+      Bridgetown.logger.info "", "done!"
+    end
+  end
+
   module Commands
     class Console < Thor::Group
       extend Summarizable
@@ -37,24 +69,18 @@ module Bridgetown
         Bridgetown.logger.info "Environment:", Bridgetown.environment.cyan
         site = Bridgetown::Site.new(configuration_with_overrides(options))
 
-        unless options[:blank]
-          site.reset
-          Bridgetown.logger.info "Reading files..."
-          site.read
-          Bridgetown.logger.info "", "done!"
-          Bridgetown.logger.info "Running generators..."
-          site.generate
-          Bridgetown.logger.info "", "done!"
-        end
+        ConsoleMethods.site_reset(site) unless options[:blank]
 
-        $BRIDGETOWN_SITE = site
+        IRB::ExtendCommandBundle.include ConsoleMethods
         IRB.setup(nil)
         workspace = IRB::WorkSpace.new
         irb = IRB::Irb.new(workspace)
         IRB.conf[:IRB_RC]&.call(irb.context)
         IRB.conf[:MAIN_CONTEXT] = irb.context
-        eval("site = $BRIDGETOWN_SITE", workspace.binding, __FILE__, __LINE__)
-        Bridgetown.logger.info "Console:", "Now loaded as #{"site".cyan} variable."
+        Bridgetown.logger.info "Console:", "Your site is now available as #{"site".cyan}"
+        Bridgetown.logger.info "",
+                               "You can also access #{"collections".cyan} or perform a" \
+                               " #{"reload!".cyan}"
 
         trap("SIGINT") do
           irb.signal_handle


### PR DESCRIPTION
Inspired by Rails' `ConsoleMethods` technique, this PR adds a `Bridgetown::ConsoleMethods` module which mixes into IRB's main context. In addition to `site`, you can now access the `collections` shorthand, and you can also run `reload!` which will reload all plugins and reset/reread the site.

Also cool is you can extend `ConsoleMethods` to add your own commands to the console!

```ruby
# somewhere in plugins/site_builder.rb:

module ConsoleMethods
  def ruby_rocks
    "MINASWAN!"
  end
end

Bridgetown::ConsoleMethods.include ConsoleMethods
```

```
bin/bridgetown c

irb> ruby_rocks
=> "MINASWAN!"
```