### PR TITLE
Make --version works.

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/base.rb
@@ -91,6 +91,8 @@ module Bridgetown
           puts "Usage:"
           puts "  bridgetown <command> [options]"
           puts ""
+          return if subcommand == "--version"
+
           super
 
           require "rake"


### PR DESCRIPTION
Currently `bridgetown --version` is break.