### PR TITLE
Fix class duplication bug with reloads

### DIFF
--- a/bridgetown-core/.rubocop.yml
+++ b/bridgetown-core/.rubocop.yml
@@ -31,6 +31,10 @@ Performance/CollectionLiteralInLoop:
   Exclude:
     - test/test_filters.rb
 
+Style/OpenStructUse:
+  Exclude:
+    - test/**/*.rb
+
 Style/StringConcatenation:
   Exclude:
     - test/test_apply_command.rb

--- a/bridgetown-core/bridgetown-core.gemspec
+++ b/bridgetown-core/bridgetown-core.gemspec
@@ -53,4 +53,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("thor",                  "~> 1.1")
   s.add_runtime_dependency("tilt",                  "~> 2.0")
   s.add_runtime_dependency("webrick",               "~> 1.7")
+  s.add_runtime_dependency("zeitwerk",              "~> 2.5")
 end

--- a/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
@@ -38,7 +38,7 @@ module Bridgetown
       return if text.empty?
 
       src << bufvar << ".safe_append='"
-      src << text.gsub(%r{['\\]}, '\\\\\&') # rubocop:disable Style/StringLiterals
+      src << text.gsub(%r{['\\]}, '\\\\\&')
       src << "'.freeze;"
     end
 

--- a/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
@@ -28,6 +28,16 @@ module Bridgetown
         load_path.start_with?(root_dir) && ENV["BRIDGETOWN_ENV"] != "production"
       end
 
+      def clear_descendants_for_reload(_cpath, value, _abspath)
+        unless value.is_a?(Class) && value.singleton_class < ActiveSupport::DescendantsTracker
+          return
+        end
+
+        ActiveSupport::DescendantsTracker.class_variable_get(
+          :@@direct_descendants
+        )[value.superclass]&.reject! { _1 == value }
+      end
+
       def setup_loaders(autoload_paths = []) # rubocop:todo Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         (autoload_paths.presence || config.autoload_paths).each do |load_path|
           if @loaders.key?(load_path)
@@ -49,6 +59,7 @@ module Bridgetown
 
             loader.collapse(collapsed_path)
           end
+          loader.on_unload(&method(:clear_descendants_for_reload)) # rubocop:disable Performance/MethodObjectAsBlock
           Bridgetown::Hooks.trigger :loader, :pre_setup, loader, load_path
           loader.setup
           loader.eager_load if config.eager_load_paths.include?(load_path)


### PR DESCRIPTION
This fixes a nasty bug where classes were being duplicated in dev with Zeitwerk reloads and `ActiveSupport::DescendantsTracker`. So for example you'd have a `Post` subclass of `Bridgetown::Model::Base`, and you'd reload, and now you'd have two `Post`s, reload again, and you'd have three `Post`s, etc. Argh. Now descendant classes are specifically removed from the descendants tree upon unload.