### PR TITLE
Allow saving of models with repo origin

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/model/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/base.rb
@@ -69,8 +69,23 @@ module Bridgetown
         attributes[:_origin_]
       end
 
+      def origin=(new_origin)
+        attributes[:_id_] = new_origin.id
+        attributes[:_origin_] = new_origin
+      end
+
       def persisted?
-        id && origin.exists?
+        (id && origin&.exists?) == true
+      end
+
+      def save
+        unless origin.respond_to?(:write)
+          raise "`#{origin.class}' doesn't allow writing of model objects"
+        end
+
+        run_callbacks :save do
+          origin.write(self)
+        end
       end
 
       # @return [Bridgetown::Resource::Base]
@@ -100,9 +115,17 @@ module Bridgetown
         attributes[:_collection_]
       end
 
+      def collection=(new_collection)
+        attributes[:_collection_] = new_collection
+      end
+
       # @return [String]
       def content
         attributes[:_content_]
+      end
+
+      def content=(new_content)
+        attributes[:_content_] = new_content
       end
 
       def attributes

--- a/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
@@ -53,7 +53,7 @@ module Bridgetown
       end
 
       def write(model)
-        contents = "#{front_matter(model)}---\n\n#{model.content}"
+        contents = "#{front_matter_to_yaml(model)}---\n\n#{model.content}"
 
         # Create folders if necessary
         dir = File.dirname(original_path)
@@ -140,7 +140,7 @@ module Bridgetown
         end
       end
 
-      def front_matter(model)
+      def front_matter_to_yaml(model)
         data = model.data_attributes.to_h
         data = data.deep_merge(data) do |_, _, v|
           case v

--- a/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
@@ -26,6 +26,12 @@ module Bridgetown
           %w(.yaml .yml .json .csv .tsv .rb).freeze
         end
 
+        # Initializes a new repo object using a collection and a relative source path.
+        # You'll need to use this when you want to create and save a model to the source.
+        #
+        # @param collection [Bridgetown::Collection, String, Symbol] either a collection
+        #   label or Collection object
+        # @param relative_path [Pathname, String] the source path of the file to save
         def new_with_collection_path(collection, relative_path)
           collection = collection.label if collection.is_a?(Bridgetown::Collection)
 
@@ -53,6 +59,11 @@ module Bridgetown
       end
 
       def write(model)
+        if File.exist?(original_path) && !Bridgetown::Utils.has_yaml_header?(original_path)
+          raise Bridgetown::Errors::InvalidYAMLFrontMatterError,
+                "Only existing files containing YAML front matter can be overwritten by the model"
+        end
+
         contents = "#{front_matter_to_yaml(model)}---\n\n#{model.content}"
 
         # Create folders if necessary

--- a/bridgetown-core/test/test_model.rb
+++ b/bridgetown-core/test/test_model.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestModel < BridgetownUnitTest
+  context "Models" do
+    setup do
+      # @type [Bridgetown::Site]
+      @site = resources_site
+      # not sure why this is needed to autoload:
+      Bridgetown::Model::Origin # rubocop:disable Lint/Void
+      @origin = Bridgetown::Model::RepoOrigin.new_with_collection_path(:pages, "_pages/_test_file.md")
+      @filepath = @site.in_source_dir("_pages/_test_file.md")
+    end
+
+    should "save and load content" do
+      model = Bridgetown::Model::Base.new(title: "Hello", layout: :page)
+      model.content = "Super **great** content!"
+      model.origin = @origin
+      model.save
+
+      new_model = Bridgetown::Model::Base.new(@origin.read)
+
+      assert_equal model.title, new_model.title
+      assert_equal model.layout, new_model.layout.to_sym
+      assert_equal model.content, new_model.content
+    ensure
+      File.delete(@filepath) if File.exist?(@filepath)
+    end
+
+    should "refrain from overwriting non-YAML front matter files" do
+      model = Bridgetown::Model::Base.new(title: "Hello", layout: :page)
+      model.content = "Super **great** content!"
+      model.origin = @origin
+
+      File.write(@filepath, "~~~ruby")
+
+      assert_raises Bridgetown::Errors::FatalException do
+        model.save
+      end
+
+      File.write(@filepath, "---\n")
+      model.save
+
+      assert_includes File.read(@filepath), "---\ntitle: Hello"
+    ensure
+      File.delete(@filepath) if File.exist?(@filepath)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #451 

One gotcha that dawned on me as I was working on this is any file with Ruby front matter (aka not YAML) would potentially get overwritten with YAML front matter. Might need to add a check for that and raise an error so there's never accidental data loss.