### PR TITLE
A bit of a hooks refactor & cleaning up SSR reload hook

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/console.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/console.rb
@@ -18,6 +18,7 @@ module Bridgetown
       Bridgetown::Hooks.clear_reloadable_hooks
       site.plugin_manager.reload_plugin_files
       site.loaders_manager.reload_loaders
+      Bridgetown::Hooks.trigger :site, :post_reload, site
 
       ConsoleMethods.site_reset(site)
     end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/extensible.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/extensible.rb
@@ -58,8 +58,9 @@ class Bridgetown::Site
     end
 
     # Shorthand for registering a site hook via {Bridgetown::Hooks}
-    # @param event [Symbol] the hook event (pre_read, post_render, etc.)
-    # @yield Runs the block when the hook event is triggered
+    # @param event [Symbol] name of the event (`:pre_read`, `:post_render`, etc.)
+    # @yield the block will be called when the event is triggered
+    # @yieldparam site the site which triggered the event hook
     def on(event, reloadable: false, &block)
       Bridgetown::Hooks.register_one :site, event, reloadable: reloadable, &block
     end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/extensible.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/extensible.rb
@@ -56,5 +56,12 @@ class Bridgetown::Site
         c.new(config)
       end
     end
+
+    # Shorthand for registering a site hook via {Bridgetown::Hooks}
+    # @param event [Symbol] the hook event (pre_read, post_render, etc.)
+    # @yield Runs the block when the hook event is triggered
+    def on(event, reloadable: false, &block)
+      Bridgetown::Hooks.register_one :site, event, reloadable: reloadable, &block
+    end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/processable.rb
@@ -23,9 +23,9 @@ class Bridgetown::Site
 
     # Reset all in-memory data and content.
     #
-
+    # @param soft [Boolean] if true, persist some state and do a light refresh of layouts and data
     # @return [void]
-    def reset(soft: false)
+    def reset(soft: false) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       self.time = Time.now
       if config["time"]
         self.time = Bridgetown::Utils.parse_date(
@@ -52,6 +52,7 @@ class Bridgetown::Site
       Bridgetown::Hooks.trigger :site, (soft ? :after_soft_reset : :after_reset), self
     end
 
+    # Read layouts and merge any new data collection contents into the site data
     def refresh_layouts_and_data
       reader.read_layouts
 

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
@@ -32,7 +32,7 @@ class Bridgetown::Site
       @ssr_enabled = true
     end
 
-    def ssr_setup(&block) # rubocop:disable Metrics/AbcSize
+    def ssr_setup
       config.serving = true
       Bridgetown::Hooks.trigger :site, :pre_read, self
       defaults_reader.tap do |d|
@@ -46,10 +46,9 @@ class Bridgetown::Site
       end
       Bridgetown::Hooks.trigger :site, :post_read, self
 
-      hook = block&.(self) # provide additional setup hook
+      yield self if block_given? # provide additional setup hook
       return if Bridgetown.env.production?
 
-      @ssr_reload_hook = hook if hook.is_a?(Proc) && hook.lambda?
       Bridgetown::Watcher.watch(self, config)
     end
 
@@ -64,7 +63,6 @@ class Bridgetown::Site
           data[k] = v
         end
       end
-      @ssr_reload_hook.() if @ssr_reload_hook.is_a?(Proc)
     end
 
     def disable_ssr

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
@@ -52,19 +52,6 @@ class Bridgetown::Site
       Bridgetown::Watcher.watch(self, config)
     end
 
-    def ssr_reload
-      reset soft: true
-      reader.read_layouts
-
-      collections.data.tap do |coll|
-        coll.resources.clear
-        coll.read
-        coll.merge_data_resources.each do |k, v|
-          data[k] = v
-        end
-      end
-    end
-
     def disable_ssr
       Bridgetown.logger.info "SSR:", "now disabled."
       @ssr_enabled = false

--- a/bridgetown-core/lib/bridgetown-core/configurations/minitesting.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/minitesting.rb
@@ -82,7 +82,7 @@ create_file "plugins/test_output.rb" do
   <<~RUBY
     module TestOutput
       unless Bridgetown.env.development?
-        Bridgetown::Hooks.register :site, :post_write do
+        Bridgetown::Hooks.register_one :site, :post_write do
           # Load test suite to run on exit
           require "nokogiri"
           Dir["test/**/*.rb"].each { |file| require_relative("../\#{file}") }

--- a/bridgetown-core/lib/bridgetown-core/generators/prototype_generator.rb
+++ b/bridgetown-core/lib/bridgetown-core/generators/prototype_generator.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 # Handles Generated Pages
-Bridgetown::Hooks.register :generated_pages, :post_init, reloadable: false do |page|
+Bridgetown::Hooks.register_one :generated_pages, :post_init, reloadable: false do |page|
   if page.class != Bridgetown::PrototypePage && page.data["prototype"].is_a?(Hash)
     Bridgetown::PrototypeGenerator.add_matching_template(page)
   end
 end
 
 # Handles Resources
-Bridgetown::Hooks.register :resources, :post_read, reloadable: false do |resource|
+Bridgetown::Hooks.register_one :resources, :post_read, reloadable: false do |resource|
   if resource.data["prototype"].is_a?(Hash)
     Bridgetown::PrototypeGenerator.add_matching_template(resource)
   end
 end
 
 # Ensure sites clear out templates before rebuild
-Bridgetown::Hooks.register :site, :after_reset, reloadable: false do |_site|
+Bridgetown::Hooks.register_one :site, :after_reset, reloadable: false do |_site|
   Bridgetown::PrototypeGenerator.matching_templates.clear
 end
 

--- a/bridgetown-core/lib/bridgetown-core/hooks.rb
+++ b/bridgetown-core/lib/bridgetown-core/hooks.rb
@@ -52,7 +52,7 @@ module Bridgetown
     #   Default is true.
     # @yield the block will be called when the event is triggered. Typically it receives at
     #   least one argument.
-    # @yieldparam the object which triggered the event hook
+    # @yieldparam obj the object which triggered the event hook
     def self.register(owners, event, priority: DEFAULT_PRIORITY, reloadable: true, &block)
       Array(owners).each do |owner|
         register_one(owner, event, priority: priority, reloadable: reloadable, &block)
@@ -69,7 +69,7 @@ module Bridgetown
     #   Default is true.
     # @yield the block will be called when the event is triggered. Typically it receives at
     #   least one argument.
-    # @yieldparam the object which triggered the event hook
+    # @yieldparam obj the object which triggered the event hook
     def self.register_one(owner, event, priority: DEFAULT_PRIORITY, reloadable: true, &block)
       @registry[owner] ||= []
 

--- a/bridgetown-core/lib/bridgetown-core/hooks.rb
+++ b/bridgetown-core/lib/bridgetown-core/hooks.rb
@@ -17,34 +17,59 @@ module Bridgetown
 
     DEFAULT_PRIORITY = 20
 
-    # compatibility layer for octopress-hooks users
     PRIORITY_MAP = {
       low: 10,
       normal: 20,
       high: 30,
     }.freeze
 
-    # initial empty hooks
     @registry = {}
 
     NotAvailable = Class.new(RuntimeError)
     Uncallable = Class.new(RuntimeError)
 
-    # Ensure the priority is a Fixnum
     def self.priority_value(priority)
       return priority if priority.is_a?(Integer)
 
       PRIORITY_MAP[priority] || DEFAULT_PRIORITY
     end
 
-    # register hook(s) to be called later
+    # Sort registered hooks according to priority and load order
+    #
+    # @param hooks [Array<HookRegistration>]
+    def self.prioritized_hooks(hooks)
+      grouped_hooks = hooks.group_by(&:priority)
+      grouped_hooks.keys.sort.reverse.map { |priority| grouped_hooks[priority] }.flatten
+    end
+
+    # Register one or more hooks which may be triggered later for a particular event
+    #
+    # @param owners [Symbol, Array<Symbol>] name of the owner (`:site`, `:resource`, etc.)
+    # @param event [Symbol] name of the event (`:pre_read`, `:post_render`, etc.)
+    # @param priority [Integer, Symbol] either `:low`, `:normal`, or `:high`, or an integer.
+    #   Default is normal (20)
+    # @param reloadable [Boolean] whether the hook should be removed prior to a site reload.
+    #   Default is true.
+    # @yield the block will be called when the event is triggered. Typically it receives at
+    #   least one argument.
+    # @yieldparam the object which triggered the event hook
     def self.register(owners, event, priority: DEFAULT_PRIORITY, reloadable: true, &block)
       Array(owners).each do |owner|
         register_one(owner, event, priority: priority, reloadable: reloadable, &block)
       end
     end
 
-    # register a single hook to be called later
+    # Register a hook which may be triggered later for a particular event
+    #
+    # @param owner [Symbol] name of the owner (`:site`, `:resource`, etc.)
+    # @param event [Symbol] name of the event (`:pre_read`, `:post_render`, etc.)
+    # @param priority [Integer, Symbol] either `:low`, `:normal`, or `:high`, or an integer.
+    #   Default is normal (20)
+    # @param reloadable [Boolean] whether the hook should be removed prior to a site reload.
+    #   Default is true.
+    # @yield the block will be called when the event is triggered. Typically it receives at
+    #   least one argument.
+    # @yieldparam the object which triggered the event hook
     def self.register_one(owner, event, priority: DEFAULT_PRIORITY, reloadable: true, &block)
       @registry[owner] ||= []
 
@@ -68,10 +93,28 @@ module Bridgetown
       block
     end
 
-    def self.remove_hook(owner, _event, block)
+    # Delete a previously-registered hook
+    #
+    # @param owners [Symbol] name of the owner (`:site`, `:resource`, etc.)
+    # @param block [Proc] the exact block used originally to register the hook
+    def self.remove_hook(owner, block)
       @registry[owner].delete_if { |item| item.block == block }
     end
 
+    # Clear all hooks marked as reloadable from the registry
+    def self.clear_reloadable_hooks
+      Bridgetown.logger.debug("Clearing reloadable hooks")
+
+      @registry.each_value do |hooks|
+        hooks.delete_if(&:reloadable)
+      end
+    end
+
+    # Trigger all registered hooks for a particular owner and event.
+    # Any arguments after the initial two will be directly passed along to the hooks.
+    #
+    # @param owner [Symbol] name of the owner (`:site`, `:resource`, etc.)
+    # @param event [Symbol] name of the event (`:pre_read`, `:post_render`, etc.)
     def self.trigger(owner, event, *args) # rubocop:disable Metrics/CyclomaticComplexity
       # proceed only if there are hooks to call
       hooks = @registry[owner]&.select { |item| item.event == event }
@@ -79,25 +122,13 @@ module Bridgetown
 
       prioritized_hooks(hooks).each do |hook|
         if ENV["BRIDGETOWN_LOG_LEVEL"] == "debug"
-          hook_info = args[0].respond_to?(:url) ? args[0].relative_path : hook.block
+          hook_info = args[0].respond_to?(:relative_path) ? args[0].relative_path : hook.block
           Bridgetown.logger.debug("Triggering hook:", "#{owner}:#{event} for #{hook_info}")
         end
         hook.block.call(*args)
       end
-    end
 
-    def self.prioritized_hooks(hooks)
-      # sort hooks according to priority and load order
-      grouped_hooks = hooks.group_by(&:priority)
-      grouped_hooks.keys.sort.reverse.map { |priority| grouped_hooks[priority] }.flatten
-    end
-
-    def self.clear_reloadable_hooks
-      Bridgetown.logger.debug("Clearing reloadable hooks")
-
-      @registry.each_value do |hooks|
-        hooks.delete_if(&:reloadable)
-      end
+      true
     end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/rack/roda.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/roda.rb
@@ -39,7 +39,7 @@ module Bridgetown
         "500 Internal Server Error"
       end
 
-      def _roda_run_main_route(r) # rubocop:disable Naming/MethodParameterName
+      before do
         if self.class.opts[:bridgetown_site]
           # The site had previously been initialized via the bridgetown_ssr plugin
           Bridgetown::Current.site ||= self.class.opts[:bridgetown_site]
@@ -47,14 +47,12 @@ module Bridgetown
         Bridgetown::Current.preloaded_configuration ||=
           self.class.opts[:bridgetown_preloaded_config]
 
-        r.public
+        request.public
 
-        r.root do
+        request.root do
           output_folder = Bridgetown::Current.preloaded_configuration.destination
           File.read(File.join(output_folder, "index.html"))
         end
-
-        super
       end
 
       # Helper shorthand for Bridgetown::Current.site

--- a/bridgetown-core/lib/bridgetown-core/watcher.rb
+++ b/bridgetown-core/lib/bridgetown-core/watcher.rb
@@ -76,10 +76,12 @@ module Bridgetown
         Bridgetown::Hooks.clear_reloadable_hooks
         site.plugin_manager.reload_plugin_files
         site.loaders_manager.reload_loaders
-
-        site.ssr_reload if site.ssr?
         Bridgetown::Hooks.trigger :site, :post_reload, site
-        return if site.ssr?
+
+        if site.ssr?
+          site.reset(soft: true)
+          return
+        end
 
         site.process
         Bridgetown.logger.info "Done! 🎉", "#{"Completed".green} in less than" \

--- a/bridgetown-core/lib/bridgetown-core/watcher.rb
+++ b/bridgetown-core/lib/bridgetown-core/watcher.rb
@@ -137,7 +137,9 @@ module Bridgetown
         site.plugin_manager.reload_plugin_files
         site.loaders_manager.reload_loaders
 
-        return site.ssr_reload if site.ssr?
+        site.ssr_reload if site.ssr?
+        Bridgetown::Hooks.trigger :site, :post_reload, site
+        return if site.ssr?
 
         site.process
         Bridgetown.logger.info "Done! 🎉", "#{"Completed".green} in less than" \

--- a/bridgetown-paginate/lib/bridgetown-paginate/hooks.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/hooks.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Handles Generated Pages
-Bridgetown::Hooks.register :generated_pages, :post_init, reloadable: false do |page|
+Bridgetown::Hooks.register_one :generated_pages, :post_init, reloadable: false do |page|
   if page.class != Bridgetown::Paginate::PaginationPage &&
       page.site.config.dig("pagination", "enabled")
     data = page.data.with_dot_access
@@ -13,7 +13,7 @@ Bridgetown::Hooks.register :generated_pages, :post_init, reloadable: false do |p
 end
 
 # Handles Resources
-Bridgetown::Hooks.register :resources, :post_read, reloadable: false do |page|
+Bridgetown::Hooks.register_one :resources, :post_read, reloadable: false do |page|
   if page.site.config.dig("pagination", "enabled") && (
       (page.data.pagination.present? && page.data.pagination.enabled != false) ||
       (page.data.paginate.present? && page.data.paginate.enabled != false)
@@ -23,6 +23,6 @@ Bridgetown::Hooks.register :resources, :post_read, reloadable: false do |page|
 end
 
 # Ensure sites clear out templates before rebuild
-Bridgetown::Hooks.register :site, :after_reset, reloadable: false do |_site|
+Bridgetown::Hooks.register_one :site, :after_reset, reloadable: false do |_site|
   Bridgetown::Paginate::PaginationGenerator.matching_templates.clear
 end


### PR DESCRIPTION
Just a bit of a Hooks refactor, plus getting rid of the React-like "store a second hook via a proc returned from the original hook" weirdness in the SSR plugin (*shudder*…what was I thinking?!) in favor of using regular site hooks. (Speaking of which, `site` now has a pretty nice `on` method…)

Plus Hooks now has YARD documentation.

…OK, ended up refactoring Watcher as well. 😅 