### PR TITLE
Switch to streaming/event source mechanism for live reload

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/rack/roda.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/roda.rb
@@ -23,6 +23,7 @@ module Bridgetown
       plugin :json
       plugin :json_parser
       plugin :cookies
+      plugin :streaming
       plugin :public, root: Bridgetown::Current.preloaded_configuration.destination
       plugin :not_found do
         output_folder = Bridgetown::Current.preloaded_configuration.destination


### PR DESCRIPTION
Resolves #416 (maybe?)

Well this certainly ended up being an inordinate amount of work! Getting the streaming mechanism enabled wasn't too bad, but then I ran into a bad situation where Ctrl-C would hang until Puma determined the stream had completed (and the longer it would run, the longer it would hang!). It took quite a while to workaround that, and then I discovered long streams would also gunk up Puma's threads if enough pages were opened at once and you were clicking around, because of a delay between a page change and the socket (browser? Puma?) cleaning up and stopping the stream.

I think it's pretty balanced now, between the length of the stream before a browser-initiated reconnection and the interval checking the modification, as well as further modification checks in-browser between a previous stream and a reconnected stream. Good grief.

I tested in Safari and Firefox…haven't tried any other browsers yet.