### PR TITLE
Add support for Cable Car request/response cycles

### DIFF
--- a/bridgetown-routes/lib/bridgetown-routes.rb
+++ b/bridgetown-routes/lib/bridgetown-routes.rb
@@ -7,6 +7,7 @@ require_relative "bridgetown-routes/view_helpers"
 
 # Roda isn't defined for Bridgetown build-only
 require_relative "roda/plugins/bridgetown_routes" if defined?(Roda)
+require_relative "roda/plugins/bridgetown_cable_car" if defined?(Roda)
 
 module Bridgetown
   module Routes

--- a/bridgetown-routes/lib/roda/plugins/bridgetown_cable_car.rb
+++ b/bridgetown-routes/lib/roda/plugins/bridgetown_cable_car.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Roda
+  module RodaPlugins
+    module BridgetownCableCar
+      def self.configure(_app, _opts = {})
+        require "cable_ready"
+      end
+
+      module InstanceMethods
+        def cable_car
+          response["Content-Type"] = "application/vnd.cable-ready.json" if cable_ready?
+          CableReady::CableCar.instance
+        end
+
+        def cable_ready?
+          request.env["HTTP_ACCEPT"].include?("application/vnd.cable-ready.json")
+        end
+
+        def render_morph(data:, morph_wrapper: "morph-contents", **kwargs)
+          data[:layout] = "none" if cable_ready? && data[:layout]
+
+          @_morph_output = render_with data: data, will_morph: true, morph_wrapper: morph_wrapper
+
+          return unless cable_ready?
+
+          cable_car.morph(
+            "morph-contents",
+            html: @_morph_output,
+            permanent_attribute_name: "data-morph-permanent",
+            **kwargs
+          )
+        end
+
+        def dispatch
+          cable_ready? ? cable_car.dispatch : @_morph_output
+        end
+      end
+    end
+
+    register_plugin :cable_car, BridgetownCableCar
+  end
+end


### PR DESCRIPTION
This adds native Bridgetown Routes support for [CableCar](https://cableready.stimulusreflex.com/v/v5/cable-car) responses (likely to be consumed by [mrujs](https://github.com/paramagicdev/mrujs)).

Three bits of magic here: `render_morph`, `cable_car`, and `cable_ready?`

The `cable_car` helper just provides an instance of `CableReady::CableCar` and works much the same as in Rails app examples.

`render_morph` provides an extra level of wizardry — it automatically detects if a request is an ordinary one or is specially asking for `application/vnd.cable-ready.json`. If the former, it renders a normal response as if you used `render_with`. Otherwise it renders the resource minus its wrapper layout, and wraps that in a custom element that is used as the morph selector (previously added to the page using `render_with`'s `will_morph` flag), and issues a morph operation. In other words, you can have full resource morph round-tripping without even thinking about morphs. And obviously you can add additional operations yourself. As long as you call `dispatch` right at the end, you're good.

`cable_ready?` lets you know if the request expects a `application/vnd.cable-ready.json` response, so you can determine if you want to return CableCar operations or not.

Example:

`src/_routes/mrujs-form.erb`

```erb
---<%
default_data = {
  layout: :default,
  title: "Mrujs!"
}

r.get do
  render_with data: default_data, will_morph: true
end

r.post do
  form =
    {
      theinput: r.params[:theinput]
    }.with_dot_access
  sleep 1

  unless form.theinput == "Valid!"
    render_morph data: {
      **default_data,
      form: form,
      errors: {
        theinput: "bad news!"
      }
    }
  else
    render_morph data: {
      **default_data,
      woohoo: "YEAH!"
    }, delay: 500

    if cable_ready?
      cable_car
        .append("#server-time", html: <<~HTML)
          <li>The Time is #{Time.now}</li>
        HTML
    end
  end

  dispatch
end
%>---

<h1>Mrujs &amp; CableCar</h1>

<form method="post" action="/mrujs-form" data-remote="true">
  <input type="text" name="theinput" placeholder="stuff"
    value="<%= resource.data.form&.theinput %>"
    <% if resource.data.errors&.theinput %>
      style="border: 1px solid red"
    <% end %>
  />
  <% if resource.data.errors&.theinput %>
    <p style="color: red"><%= resource.data.errors.theinput %></p>
  <% end %>

  <input
    type="submit"
    data-disable-with="Submitting…"
    value="Submit me and get CableCar JSON back!"
  />
</form>

<ul id="server-time" data-morph-permanent></ul>

<script>
  document.querySelector("form").addEventListener("ajax:complete", () => {
    console.info("Form complete")
  })
</script>

<%= resource.data.woohoo.presence || "Howdy" %>
```