### PR TITLE
feat: add bundled configuration for Vercel

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/vercel.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/vercel.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+copy_file in_templates_dir("vercel.json"), "vercel.json"
+copy_file in_templates_dir("vercel_url.rb"), "plugins/builders/vercel_url.rb"

--- a/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel.json
+++ b/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel.json
@@ -1,0 +1,45 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "redirects": [],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(self), microphone=()"
+        }
+      ]
+    },
+    {
+      "source": "/feed.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/rss+xml"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    }
+  ]
+}

--- a/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
@@ -1,4 +1,4 @@
-class VercelUrl < SiteBuilder
+class Builders::VercelUrl < SiteBuilder
   def build
     hook :site, :pre_render do |s|
       next unless ENV["VERCEL_URL"] && ENV["VERCEL_ENV"] != "production"

--- a/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
@@ -1,0 +1,10 @@
+class VercelUrl < SiteBuilder
+  def build
+    hook :site, :pre_render do |s|
+      next unless ENV["VERCEL_URL"] && ENV["VERCEL_ENV"] != "production"
+
+      Bridgetown.logger.info("Subbing Vercel URL")
+      site.config.update(url: "https://" + ENV["VERCEL_URL"])
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/vercel/vercel_url.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Builders::VercelUrl < SiteBuilder
   def build
-    hook :site, :pre_render do |s|
+    hook :site, :pre_render do |site|
       next unless ENV["VERCEL_URL"] && ENV["VERCEL_ENV"] != "production"
 
       Bridgetown.logger.info("Subbing Vercel URL")
-      site.config.update(url: "https://" + ENV["VERCEL_URL"])
+      site.config.update(url: "https://#{ENV["VERCEL_URL"]}")
     end
   end
 end

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -17,6 +17,7 @@ The configurations we include are:
 - [Bridgetown recommended PostCSS plugins](#bridgetown-recommended-postcss-plugins) (`bt-postcss`)
 - [Render YAML Configuration](#render-yaml-configuration) (`render`)
 - [Netlify TOML Configuration](#netlify-toml-configuration) (`netlify`)
+- [Vercel JSON Configuration](#vercel-json-configuration) (`vercel`)
 - [Automated Test Suite using Minitest](#automated-test-suite-using-minitest) (`minitesting`)
 - [Cypress](#cypress) (`cypress`)
 
@@ -118,6 +119,16 @@ bin/bridgetown configure render
 
 ```sh
 bin/bridgetown configure netlify
+```
+
+### Vercel JSON Configuration
+
+⚙️ Adds a basic configuration to your site for use in [Vercel](https://vercel.com) deployments along with a builder to ensure Bridgetown uses the correct `absolute_url` on preview deployments.
+
+🛠 **Configure using:**
+
+```sh
+bin/bridgetown configure vercel
 ```
 
 ### Automated Test Suite using Minitest


### PR DESCRIPTION
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds a bundled configuration for Vercel with correct security headers and content type for feeds.xml (if using the RSS plugin).

It also correctly assigns the Bridgetown URL to the VERCEL_URL in non-production environments. This means that if a VERCEL_URL is in the environment, whether production or running via Vercel's CLI locally, the absolute url's will adjust accordingly.

See example of it in use in the [deploys on this PR](https://github.com/andrewmcodes/bridgetown-vercel-demo/pull/1)

## Context

I spoke about this with Jared. I think pre-1.0 we should make the deployment path to whatever service of your choosing as simple as possible without any need to dig into why something is behaving odd.
