### PR TITLE
Site fixes

### DIFF
--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -90,7 +90,7 @@ bin/bridgetown configure purgecss
 - [`postcss-color-function`](https://github.com/postcss/postcss-color-function)
 - [`cssnano`](https://cssnano.co)
 
-It will also configure [`postcss-preset-env`](http://preset-env.cssdb.org) to polyfill all features at [stage 2 and above](http://preset-env.cssdb.org/features#stage-2). If you don't need certain polyfills for your use case, you can bump up stage to 3 or 4 *(for example, [`custom properties`](http://preset-env.cssdb.org/features#custom-properties) won't get polyfilled if stage is set to 4)*. [`nesting-rules`](http://preset-env.cssdb.org/features#nesting-rules) and [`custom-media-queries`](http://preset-env.cssdb.org/features#custom-media-queries) are explicitly enabled.
+It will also configure [`postcss-preset-env`](https://preset-env.netlify.app) to polyfill all features at [stage 2 and above](https://preset-env.netlify.app/features/#stage-2). If you don't need certain polyfills for your use case, you can bump up stage to 3 or 4 *(for example, [`custom properties`](https://preset-env.netlify.app/features/#custom-properties) won't get polyfilled if stage is set to 4)*. [`nesting-rules`](https://preset-env.netlify.app/features/#nesting-rules) and [`custom-media-queries`](https://preset-env.netlify.app/features/#custom-media-queries) are explicitly enabled.
 
 This configuration will overwrite your `postcss.config.js` file.
 

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -90,7 +90,7 @@ bin/bridgetown configure purgecss
 - [`postcss-color-function`](https://github.com/postcss/postcss-color-function)
 - [`cssnano`](https://cssnano.co)
 
-It will also configure [`postcss-preset-env`](https://preset-env.netlify.app) to polyfill all features at [stage 2 and above](https://preset-env.netlify.app/features/#stage-2). If you don't need certain polyfills for your use case, you can bump up stage to 3 or 4 *(for example, [`custom properties`](https://preset-env.netlify.app/features/#custom-properties) won't get polyfilled if stage is set to 4)*. [`nesting-rules`](https://preset-env.netlify.app/features/#nesting-rules) and [`custom-media-queries`](https://preset-env.netlify.app/features/#custom-media-queries) are explicitly enabled.
+It will also configure [`postcss-preset-env`](http://preset-env.cssdb.org) to polyfill all features at [stage 2 and above](http://preset-env.cssdb.org/features#stage-2). If you don't need certain polyfills for your use case, you can bump up stage to 3 or 4 *(for example, [`custom properties`](http://preset-env.cssdb.org/features#custom-properties) won't get polyfilled if stage is set to 4)*. [`nesting-rules`](http://preset-env.cssdb.org/features#nesting-rules) and [`custom-media-queries`](http://preset-env.cssdb.org/features#custom-media-queries) are explicitly enabled.
 
 This configuration will overwrite your `postcss.config.js` file.
 

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -26,7 +26,7 @@ The full list of configurations can also be seen by running `bridgetown configur
 Bundled configurations can also be run while creating a new Bridgetown project using the `--configure=` or `-c` flag and passing in a comma-separated list of configurations.
 
 ```sh
-bridgetown new my_project -c swup,purgecss
+bridgetown new my_project -c turbo,purgecss
 ```
 
 ## Configuration Setup Details

--- a/bridgetown-website/src/_docs/command-line-usage.md
+++ b/bridgetown-website/src/_docs/command-line-usage.md
@@ -16,6 +16,7 @@ Available commands are:
 {% raw %}
 * `bridgetown new PATH` - Creates a new Bridgetown site at the specified path with a default configuration and typical site folder structure.
   * Use the `--apply=` or `-a` option to [apply an automation](/docs/automations) to the new site.
+  * Use the `--configure=` or `-c` option to [apply one or more bundled configurations](/docs/bundled-configurations) to the new site.
   * Use the `-t` option to choose ERB or Serbea templates instead of Liquid (aka `-t erb`).
   * Use the `-e` option to choose Webpack instead of esbuild for your frontend bundler (aka `-e webpack`).
   * When using Webpack, you can also choose to use Sass over PostCSS by adding the `--use-sass` option.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Just a few housekeeping changes for the docs:

- Add the `--configure=` option for `bridgetown new` to [Command Line Usage](https://edge.bridgetownrb.com/docs/command-line-usage). (It is already documented in [Bundled Configurations](https://edge.bridgetownrb.com/docs/bundled-configurations).)
- Replace `swup` with `turbo` in the example in [Bundled Configurations](https://edge.bridgetownrb.com/docs/bundled-configurations).
- ~~Fix the broken links to the postcss-preset-env site under recommended PostCSS plugins in [Bundled Configurations](https://edge.bridgetownrb.com/docs/bundled-configurations).~~
  - ~~[preset-env.cssdb.org](https://preset-env.cssdb.org) no longer exists. [cssdb.org](https://cssdb.org) exists, but it seems the postcss-preset-env content (including the same anchors) has been moved to [preset-env.netlify.app](https://preset-env.netlify.app), which is the site listed on [the postcss-preset-env repo](https://github.com/csstools/postcss-preset-env). So I changed the links to point to that site.~~
  - UPDATE Jan. 27: [preset-env.cssdb.org](https://preset-env.cssdb.org) is back online, so I've reverted this part.

## Context

I built a site from scratch in Bridgetown 1.0 beta, and I noticed these things along the way as I browsed the docs.