### PR TITLE
Documentation: Added a heads up regarding the WSL and Live-reload

### DIFF
--- a/bridgetown-website/src/_docs/installation/windows.md
+++ b/bridgetown-website/src/_docs/installation/windows.md
@@ -14,3 +14,13 @@ Try reading [these excellent instructions by GoRails](https://gorails.com/setup/
 
 {%@ "docs/install/node_on_linux" %}
 {%@ "docs/install/bridgetown" %}
+
+{%@ Note type: "warning" do %}
+    #### Windows Subsystem for Linux and Live-Reloading
+
+    Projects residing on recent versions of WSL (Windows Subsystem for Linux) might face issues with live-reloading if the live-reload server is initialized from a non-Linux directory. For example: initializing the server from a directory within `/mnt/c/`. 
+    
+    This issue impacts WSL Version 2 and it's not Bridgetown-exclusive. You can [learn more about it here.](https://github.com/microsoft/WSL/issues/216)
+
+    To minimize headaches, we recommend developing from within the Linux file system. If you use VS Code, the [Remote WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) allows you to interact with the the Linux subsystem directly. It may facilitate your development workflow.
+{% end %}


### PR DESCRIPTION
This is a 🔦 documentation change. 

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Minor documentation addition regarding an issue with the Windows Subsystem for Linux (V2) and live-reload. Namely that when a live-reload server has been initialized outside of the Linux file system, live-reload will stop working and assets won't properly called on fresh builds. 

Linked the open issue on the Microsoft repo for context, provided some advice and an extension that may facilitate workflow when interacting with the WSL.

## Context
Ran into this issue myself when attempting to build a Bridgetown website on an install of Windows with WSL 2 installed. 

I tried to match tone; I wasn't aware of a style guide for the docs so I tried my best. Let me know revisions are needed!
