### PR TITLE
Add bundled configuration for GH pages

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
@@ -38,6 +38,8 @@ class Bridgetown::Site
     # @param strip_slash_only [Boolean] set to true if you wish "/" to be returned as ""
     # @return [String]
     def base_path(strip_slash_only: false)
+      config[:base_path] = "/" unless Bridgetown.env.production?
+
       (config[:base_path] || config[:baseurl]).yield_self do |path|
         strip_slash_only ? path.to_s.sub(%r{^/$}, "") : path
       end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
@@ -38,7 +38,7 @@ class Bridgetown::Site
     # @param strip_slash_only [Boolean] set to true if you wish "/" to be returned as ""
     # @return [String]
     def base_path(strip_slash_only: false)
-      config[:base_path] = "/" unless Bridgetown.env.production?
+      config[:base_path] = "/" if Bridgetown.env.development?
 
       (config[:base_path] || config[:baseurl]).yield_self do |path|
         strip_slash_only ? path.to_s.sub(%r{^/$}, "") : path

--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
@@ -3,6 +3,7 @@
 `bundle lock --add-platform x86_64-linux`
 copy_file in_templates_dir("gh-pages.yml"), ".github/workflows/gh-pages.yml"
 
+# rubocop:disable Layout/LineLength
 say "🎉 A GitHub action to deploy your site to GitHub pages has been configured!"
 say ""
 
@@ -11,3 +12,4 @@ say ""
 
 say "You'll likely also need to set `base_path` in your `bridgetown.config.yml` to your repository's name. If you do this you'll need to use the `relative_url` helper for all links and assets in your HTML."
 say ""
+# rubocop:enable Layout/LineLength

--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
@@ -6,7 +6,7 @@ copy_file in_templates_dir("gh-pages.yml"), ".github/workflows/gh-pages.yml"
 say "🎉 A GitHub action to deploy your site to GitHub pages has been configured!"
 say ""
 
-say "🛠️  After pushing the action, go to your repository settings and configure GitHub pages to deploy from the branch `gh-pages`"
+say "🛠️  After pushing the action, go to your repository settings and configure GitHub Pages to deploy from the branch `gh-pages`."
 say ""
 
 say "You'll likely also need to set `base_path` in your `bridgetown.config.yml` to your repository's name. If you do this you'll need to use the `relative_url` helper for all links and assets in your HTML."

--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+`bundle lock --add-platform x86_64-linux`
+copy_file in_templates_dir("gh-pages.yml"), ".github/workflows/gh-pages.yml"
+
+say "🎉 A GitHub action to deploy your site to GitHub pages has been configured!"
+say ""
+
+say "🛠️  After pushing the action, go to your repository settings and configure GitHub pages to deploy from the branch `gh-pages`"
+say ""
+
+say "You'll likely also need to set `base_path` in your `bridgetown.config.yml` to your repository's name. If you do this you'll need to use the `relative_url` helper for all links and assets in your HTML."
+say ""

--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages/gh-pages.yml
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages/gh-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+      - run: yarn install
+
+      - name: Build
+        run: bin/bridgetown deploy
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./output

--- a/bridgetown-core/lib/site_template/bridgetown.config.yml
+++ b/bridgetown-core/lib/site_template/bridgetown.config.yml
@@ -19,8 +19,10 @@ url: "" # the base hostname & protocol for your site, e.g. https://example.com
 permalink: pretty
 
 # Other options you might want to investigate:
-# 
-# base_path: "/" # the subpath of your site, e.g. /blog
+#
+# base_path: "/" # the subpath of your site, e.g. /blog. If you set this option,
+# ensure you use the `relative_url` helper for all links and assets in your HTML.
+
 # timezone: America/Los_Angeles
 # pagination:
 #   enabled: true


### PR DESCRIPTION
This is a 🙋 feature or enhancement.
This is a 🔦 documentation change.

## Summary

Improve the DX when using GH pages.

I've added a bundled configuration that sets up a GH action to deploy the site to GH pages. The configuration also prints out some helpful info to the user about using the `base_path` config option as this is likely necessary with Pages.

### To Do

- [ ] Update docs site
- [ ] Figure out what to do with `base_path`. As it stands, this PR makes a change that ignores the setting in dev. Discussion is ongoing in Discord (https://discord.com/channels/711236503493148733/711236503975624727/944308666440499270).

## Context

Resolves #420