### PR TITLE
Apply default theme for syntax highlighting

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -166,11 +166,14 @@ module Bridgetown
 
       def configure_sass
         copy_file("frontend/styles/index.css", "frontend/styles/index.scss")
+        copy_file("frontend/styles/syntax-highlighting.css",
+                  "frontend/styles/syntax-highlighting.scss")
       end
 
       def configure_postcss
         template("postcss.config.js.erb", "postcss.config.js")
         copy_file("frontend/styles/index.css")
+        copy_file("frontend/styles/syntax-highlighting.css")
       end
 
       # After a new site has been created, print a success notification and

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -116,6 +116,7 @@ module Bridgetown
         template("frontend/javascript/index.js.erb", "frontend/javascript/index.js")
         template("src/index.md.erb", "src/index.md")
         template("src/posts.md.erb", "src/posts.md")
+        copy_file("frontend/styles/syntax-highlighting.css")
 
         case options["templates"]
         when "erb"
@@ -166,14 +167,11 @@ module Bridgetown
 
       def configure_sass
         copy_file("frontend/styles/index.css", "frontend/styles/index.scss")
-        copy_file("frontend/styles/syntax-highlighting.css",
-                  "frontend/styles/syntax-highlighting.scss")
       end
 
       def configure_postcss
         template("postcss.config.js.erb", "postcss.config.js")
         copy_file("frontend/styles/index.css")
-        copy_file("frontend/styles/syntax-highlighting.css")
       end
 
       # After a new site has been created, print a success notification and

--- a/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
+++ b/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
@@ -1,7 +1,9 @@
 <%- if postcss_option -%>
 import "index.css"
+import "syntax-highlighting.css"
 <%- else -%>
 import "index.scss"
+import "syntax-highlighting.scss"
 <%- end -%>
 
 // Import all JavaScript & CSS files from src/_components

--- a/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
+++ b/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
@@ -1,10 +1,9 @@
 <%- if postcss_option -%>
 import "index.css"
-import "syntax-highlighting.css"
 <%- else -%>
 import "index.scss"
-import "syntax-highlighting.scss"
 <%- end -%>
+import "syntax-highlighting.css"
 
 // Import all JavaScript & CSS files from src/_components
 <%- if frontend_bundling_option == "esbuild" -%>

--- a/bridgetown-core/lib/site_template/frontend/styles/syntax-highlighting.css
+++ b/bridgetown-core/lib/site_template/frontend/styles/syntax-highlighting.css
@@ -1,0 +1,77 @@
+/* 
+  Syntax Highlighting for Code Snippets
+
+  https://www.bridgetownrb.com/docs/liquid/tags#stylesheets-for-syntax-highlighting
+
+  Other styles available eg. https://github.com/jwarby/jekyll-pygments-themes
+  To use another style, delete all styles in this file and replace them with
+  the new styles. Or create your own!
+
+*/
+
+pre.highlight {
+  padding: 16px;
+  background-color: #F6F8FA;
+}
+
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #999988; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { color: #000000; font-weight: bold } /* Keyword */
+.highlight .o { color: #000000; font-weight: bold } /* Operator */
+.highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .ge { color: #000000; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
+.highlight .gh { color: #999999 } /* Generic.Heading */
+.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight .kc { color: #000000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #009999 } /* Literal.Number */
+.highlight .s { color: #d01040 } /* Literal.String */
+.highlight .na { color: #008080 } /* Name.Attribute */
+.highlight .nb { color: #0086B3 } /* Name.Builtin */
+.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight .no { color: #008080 } /* Name.Constant */
+.highlight .nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #800080 } /* Name.Entity */
+.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlight .nl { color: #990000; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #555555 } /* Name.Namespace */
+.highlight .nt { color: #000080 } /* Name.Tag */
+.highlight .nv { color: #008080 } /* Name.Variable */
+.highlight .ow { color: #000000; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #009999 } /* Literal.Number.Float */
+.highlight .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight .sb { color: #d01040 } /* Literal.String.Backtick */
+.highlight .sc { color: #d01040 } /* Literal.String.Char */
+.highlight .sd { color: #d01040 } /* Literal.String.Doc */
+.highlight .s2 { color: #d01040 } /* Literal.String.Double */
+.highlight .se { color: #d01040 } /* Literal.String.Escape */
+.highlight .sh { color: #d01040 } /* Literal.String.Heredoc */
+.highlight .si { color: #d01040 } /* Literal.String.Interpol */
+.highlight .sx { color: #d01040 } /* Literal.String.Other */
+.highlight .sr { color: #009926 } /* Literal.String.Regex */
+.highlight .s1 { color: #d01040 } /* Literal.String.Single */
+.highlight .ss { color: #990073 } /* Literal.String.Symbol */
+.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #008080 } /* Name.Variable.Class */
+.highlight .vg { color: #008080 } /* Name.Variable.Global */
+.highlight .vi { color: #008080 } /* Name.Variable.Instance */
+.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -27,6 +27,7 @@ class TestNewCommand < BridgetownUnitTest
       "/Rakefile",
       "/package.json",
       "/frontend/javascript/index.js",
+      "/frontend/styles/syntax-highlighting.css",
       "/src/_layouts",
       "/src/_components",
       "/src/index.md",
@@ -109,7 +110,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for postcss configuration in site template to the new directory" do
-      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css", "/frontend/styles/syntax-highlighting.css"]
+      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
       postcss_template_files = static_template_files + postcss_config_files + template_config_files + liquid_config_files + esbuild_config_files
 
       capture_output do
@@ -124,7 +125,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for erb templates config to the new directory" do
-      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css", "/frontend/styles/syntax-highlighting.css"]
+      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
       postcss_template_files = static_template_files + postcss_config_files + template_config_files + erb_config_files + esbuild_config_files
 
       capture_output do
@@ -139,7 +140,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for sass configuration in site template to the new directory" do
-      sass_config_files = ["/frontend/styles/index.scss", "/frontend/styles/syntax-highlighting.scss"]
+      sass_config_files = ["/frontend/styles/index.scss"]
       sass_template_files = static_template_files + sass_config_files + template_config_files + liquid_config_files + webpack_config_files
 
       capture_output do

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -109,7 +109,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for postcss configuration in site template to the new directory" do
-      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
+      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css", "/frontend/styles/syntax-highlighting.css"]
       postcss_template_files = static_template_files + postcss_config_files + template_config_files + liquid_config_files + esbuild_config_files
 
       capture_output do
@@ -124,7 +124,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for erb templates config to the new directory" do
-      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css"]
+      postcss_config_files = ["/postcss.config.js", "/frontend/styles/index.css", "/frontend/styles/syntax-highlighting.css"]
       postcss_template_files = static_template_files + postcss_config_files + template_config_files + erb_config_files + esbuild_config_files
 
       capture_output do
@@ -139,7 +139,7 @@ class TestNewCommand < BridgetownUnitTest
     end
 
     should "copy the static files for sass configuration in site template to the new directory" do
-      sass_config_files = ["/frontend/styles/index.scss"]
+      sass_config_files = ["/frontend/styles/index.scss", "/frontend/styles/syntax-highlighting.scss"]
       sass_template_files = static_template_files + sass_config_files + template_config_files + liquid_config_files + webpack_config_files
 
       capture_output do


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This change adds a default theme for syntax highlighting so users
can see the full power of syntax highlighting when they create a
new bridgetown app.

The theme is stored in a new `syntax-higlighting.css` files.

## Context

- Closes #512
- This is a draft PR to promote discussion on this potential enhancement. I know there are further discussions happening in the issue, but perhaps this could be a good first step, or perhaps it will just help aid the ongoing conversation.
- This PR is unfinished, but I wanted to get something up and get feedback first. The things I know are missing are:
  - Upgrade path
  - Changelog
  - Documentation eg. perhaps extract Syntax Highlighting out of [liquid tags docs](https://www.bridgetownrb.com/docs/liquid/tags#stylesheets-for-syntax-highlighting) to its own page and use some of the content from the Guide-level explanation of the issue

### Before

![no-theme-code-snippet](https://user-images.githubusercontent.com/8590311/158993686-a3099358-4e93-4a6c-9ad0-1818ef52befd.png)

### After

![default-theme-code-snippet](https://user-images.githubusercontent.com/8590311/158993702-23b73b81-a483-4ba9-85d3-13fb4bb0ba6e.png)

