### PR TITLE
Allow finding and linking to alternate locale pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,8 @@ Security/YAMLLoad:
   Exclude:
     - !ruby/regexp /bridgetown-core/features\/.*.rb/
     - !ruby/regexp /bridgetown-core/test\/.*.rb$/
+Style/FetchEnvVar:
+  Enabled: false
 Style/FrozenStringLiteralComment:
   Exclude:
     - bridgetown-core/lib/site_template/**/*.rb

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -85,6 +85,7 @@ module Bridgetown
   autoload :LayoutPlaceable,     "bridgetown-core/concerns/layout_placeable"
   autoload :LayoutReader,        "bridgetown-core/readers/layout_reader"
   autoload :LiquidRenderable,    "bridgetown-core/concerns/liquid_renderable"
+  autoload :Localizable,         "bridgetown-core/concerns/localizable"
   autoload :LiquidRenderer,      "bridgetown-core/liquid_renderer"
   autoload :LogAdapter,          "bridgetown-core/log_adapter"
   autoload :PluginContentReader, "bridgetown-core/readers/plugin_content_reader"

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -79,7 +79,7 @@ module Bridgetown
 
       def determine_remote_filename(arg)
         if arg.end_with?(".rb")
-          arg.split("/").yield_self do |segments|
+          arg.split("/").then do |segments|
             arg.sub!(%r!/#{segments.last}$!, "")
             segments.last
           end

--- a/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
@@ -2,16 +2,18 @@
 
 module Bridgetown
   module Localizable
-    def in_locales
-      case self
-      when Bridgetown::Resource::Base
-        collection.resources.select { |item| item.data.slug == data.slug }.sort_by do |item|
-          site.config.available_locales.index item.data.locale
-        end
-      when Bridgetown::GeneratedPage
-        site.generated_pages.select { |item| item.data.slug == data.slug }.sort_by do |item|
-          site.config.available_locales.index item.data.locale
-        end
+    def all_locales
+      result_set = case self
+                   when Bridgetown::Resource::Base
+                     collection.resources
+                   when Bridgetown::GeneratedPage
+                     site.generated_pages
+                   else
+                     []
+                   end
+
+      result_set.select { |item| item.data.slug == data.slug }.sort_by do |item|
+        site.config.available_locales.index item.data.locale
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Localizable
+    def in_locales
+      case self
+      when Bridgetown::Resource::Base
+        collection.resources.select { |item| item.data.slug == data.slug }.sort_by do |item|
+          site.config.available_locales.index item.data.locale
+        end
+      when Bridgetown::GeneratedPage
+        site.generated_pages.select { |item| item.data.slug == data.slug }.sort_by do |item|
+          site.config.available_locales.index item.data.locale
+        end
+      end
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/configurable.rb
@@ -38,7 +38,7 @@ class Bridgetown::Site
     # @param strip_slash_only [Boolean] set to true if you wish "/" to be returned as ""
     # @return [String]
     def base_path(strip_slash_only: false)
-      (config[:base_path] || config[:baseurl]).yield_self do |path|
+      (config[:base_path] || config[:baseurl]).then do |path|
         strip_slash_only ? path.to_s.sub(%r{^/$}, "") : path
       end
     end
@@ -166,7 +166,7 @@ class Bridgetown::Site
       plugin_components_load_paths = Bridgetown::PluginManager.source_manifests
         .filter_map(&:components)
 
-      local_components_load_paths = config["components_dir"].yield_self do |dir|
+      local_components_load_paths = config["components_dir"].then do |dir|
         dir.is_a?(Array) ? dir : [dir]
       end
       local_components_load_paths.map! do |dir|

--- a/bridgetown-core/lib/bridgetown-core/drops/generated_page_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/generated_page_drop.rb
@@ -16,7 +16,7 @@ module Bridgetown
                      :url,
                      :relative_url,
                      :relative_path,
-                     :in_locales
+                     :all_locales
 
       private def_delegator :@obj, :data, :fallback_data
     end

--- a/bridgetown-core/lib/bridgetown-core/drops/generated_page_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/generated_page_drop.rb
@@ -15,7 +15,8 @@ module Bridgetown
                      :path,
                      :url,
                      :relative_url,
-                     :relative_path
+                     :relative_path,
+                     :in_locales
 
       private def_delegator :@obj, :data, :fallback_data
     end

--- a/bridgetown-core/lib/bridgetown-core/drops/resource_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/resource_drop.rb
@@ -24,7 +24,8 @@ module Bridgetown
                      :relative_url,
                      :date,
                      :taxonomies,
-                     :relations
+                     :relations,
+                     :in_locales
 
       private def_delegator :@obj, :data, :fallback_data
 

--- a/bridgetown-core/lib/bridgetown-core/drops/resource_drop.rb
+++ b/bridgetown-core/lib/bridgetown-core/drops/resource_drop.rb
@@ -25,7 +25,7 @@ module Bridgetown
                      :date,
                      :taxonomies,
                      :relations,
-                     :in_locales
+                     :all_locales
 
       private def_delegator :@obj, :data, :fallback_data
 

--- a/bridgetown-core/lib/bridgetown-core/filters/url_filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters/url_filters.rb
@@ -42,7 +42,7 @@ module Bridgetown
       # @param input [Object] value which responds to `to_s`
       # @return [String]
       def strip_extname(input)
-        Pathname.new(input.to_s).yield_self do |path|
+        Pathname.new(input.to_s).then do |path|
           path.dirname + path.basename(".*")
         end.to_s
       end

--- a/bridgetown-core/lib/bridgetown-core/generated_page.rb
+++ b/bridgetown-core/lib/bridgetown-core/generated_page.rb
@@ -4,6 +4,7 @@ module Bridgetown
   class GeneratedPage
     include LayoutPlaceable
     include LiquidRenderable
+    include Localizable
     include Publishable
     include Transformable
 

--- a/bridgetown-core/lib/bridgetown-core/plugin.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin.rb
@@ -51,7 +51,7 @@ module Bridgetown
     # config - The Hash of configuration options.
     #
     # Returns a new instance.
-    def initialize(config = {})
+    def initialize(config = {}) # rubocop:disable Style/RedundantInitialize
       # no-op for default
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/resource/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/base.rb
@@ -7,6 +7,7 @@ module Bridgetown
       include Bridgetown::Publishable
       include Bridgetown::LayoutPlaceable
       include Bridgetown::LiquidRenderable
+      include Bridgetown::Localizable
 
       # @return [HashWithDotAccess::Hash]
       attr_reader :data

--- a/bridgetown-core/lib/bridgetown-core/resource/relations.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/relations.rb
@@ -68,7 +68,7 @@ module Bridgetown
       # @return [String]
       def kind_of_relation_for_type(type)
         relation_schema&.each do |relation_type, collections|
-          collections = Array(collections).yield_self do |collections_arr|
+          collections = Array(collections).then do |collections_arr|
             collections_arr +
               collections_arr.map { |item| ActiveSupport::Inflector.pluralize(item) }
           end.flatten.uniq

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -320,7 +320,7 @@ module Bridgetown
         end
 
         if continue_processing
-          line_indentation = line.match(%r!^ +!).yield_self do |indent|
+          line_indentation = line.match(%r!^ +!).then do |indent|
             indent.nil? ? "" : indent[0]
           end
           new_indentation = line_indentation.rjust(starting_indent_length, " ")

--- a/bridgetown-core/test/resources/src/_layouts/localization.serb
+++ b/bridgetown-core/test/resources/src/_layouts/localization.serb
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="{%= site.locale %}">
+<head>
+  <title>{{ resource.data.title }}</title>
+</head>
+<body>
+{%= yield %}
+
+Other Locales:
+
+<ul>
+  {% resource.in_locales.each do |other_resource| %}
+    <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
+  {% end %}
+</ul>
+
+</body>
+</html>

--- a/bridgetown-core/test/resources/src/_layouts/localization.serb
+++ b/bridgetown-core/test/resources/src/_layouts/localization.serb
@@ -9,7 +9,7 @@
 Other Locales:
 
 <ul>
-  {% resource.in_locales.each do |other_resource| %}
+  {% resource.all_locales.each do |other_resource| %}
     <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
   {% end %}
 </ul>

--- a/bridgetown-core/test/resources/src/_noodles/ramen.liquid
+++ b/bridgetown-core/test/resources/src/_noodles/ramen.liquid
@@ -1,7 +1,6 @@
 ---
 title: "Noodles!"
 category: Low Cost
-slug: ramen # temp bugfix…delete this as soon as the new Front Matter PR gets merged!
 ---
 
 Mmm, {{ "yum!" }}

--- a/bridgetown-core/test/resources/src/_pages/multi-page.md
+++ b/bridgetown-core/test/resources/src/_pages/multi-page.md
@@ -1,4 +1,5 @@
 ---
+layout: localization
 title: "Multi-locale page"
 locale_overrides:
   fr:

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
@@ -5,3 +5,11 @@
 That's **nice**.
 
 Locale: {{ resource.data.locale }}
+
+Other Locales:
+
+<ul>
+  {%- for other_resource in resource.in_locales %}
+    <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
+  {%- endfor %}
+</ul>

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
@@ -9,7 +9,7 @@ Locale: {{ resource.data.locale }}
 Other Locales:
 
 <ul>
-  {%- for other_resource in resource.in_locales %}
+  {%- for other_resource in resource.all_locales %}
     <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
   {%- endfor %}
 </ul>

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
@@ -5,3 +5,11 @@
 C'est **bien**.
 
 Locale: {{ resource.data.locale }}
+
+Other Locales:
+
+<ul>
+  {%- for other_resource in resource.in_locales %}
+    <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
+  {%- endfor %}
+</ul>

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
@@ -9,7 +9,7 @@ Locale: {{ resource.data.locale }}
 Other Locales:
 
 <ul>
-  {%- for other_resource in resource.in_locales %}
+  {%- for other_resource in resource.all_locales %}
     <li>{{ other_resource.data.title }}: {{ other_resource.relative_url }}</li>
   {%- endfor %}
 </ul>

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -740,6 +740,8 @@ class TestFilters < BridgetownUnitTest
         assert prev.is_a?(Hash), "doc.next should be an object"
         relations = actual.delete("relations")
         refute_nil relations
+        all_locales = actual.delete("all_locales")
+        assert all_locales.length == 1
         assert_equal expected, actual
       end
 

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -63,4 +63,36 @@ class TestLocales < BridgetownUnitTest
       HTML
     end
   end
+
+  context "locales and a base_path combined" do
+    setup do
+      @site = resources_site(base_path: "/basefolder")
+      @site.process
+      # @type [Bridgetown::Resource::Base]
+      @resources = @site.collections.pages.resources.select do |page|
+        page.relative_path.to_s == "_pages/multi-page.md"
+      end
+      @english_resource = @resources.find { |page| page.data.locale == :en }
+      @french_resource = @resources.find { |page| page.data.locale == :fr }
+    end
+
+    should "have the correct permalink and locale in English" do
+      assert_equal "/basefolder/multi-page/", @english_resource.relative_url
+      assert_includes @english_resource.output, 'lang="en"'
+      assert_includes @english_resource.output, "<title>Multi-locale page</title>"
+      assert_includes @english_resource.output, "<p>English: Multi-locale page</p>"
+    end
+
+    should "have the correct permalink and locale in French" do
+      assert_equal "/basefolder/fr/multi-page/", @french_resource.relative_url
+      assert_includes @french_resource.output, 'lang="fr"'
+      assert_includes @french_resource.output, "<title>Sur mesure</title>"
+      assert_includes @french_resource.output, "<p>French: Sur mesure</p>"
+
+      assert_includes @french_resource.output, <<-HTML
+    <li>Multi-locale page: /basefolder/multi-page/</li>
+    <li>Sur mesure: /basefolder/fr/multi-page/</li>
+      HTML
+    end
+  end
 end

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -24,6 +24,11 @@ class TestLocales < BridgetownUnitTest
     should "have the correct permalink and locale in French" do
       assert_equal "/fr/second-level-page/", @french_resource.relative_url
       assert_includes @french_resource.output, "<p>C’est <strong>bien</strong>.</p>\n\n<p>Locale: fr</p>"
+
+      assert_includes @french_resource.output, <<-HTML
+    <li>I'm a Second Level Page: /second-level-page/</li>
+    <li>I'm a Second Level Page in French: /fr/second-level-page/</li>
+      HTML
     end
   end
 
@@ -41,12 +46,21 @@ class TestLocales < BridgetownUnitTest
 
     should "have the correct permalink and locale in English" do
       assert_equal "/multi-page/", @english_resource.relative_url
+      assert_includes @english_resource.output, 'lang="en"'
+      assert_includes @english_resource.output, "<title>Multi-locale page</title>"
       assert_includes @english_resource.output, "<p>English: Multi-locale page</p>"
     end
 
     should "have the correct permalink and locale in French" do
       assert_equal "/fr/multi-page/", @french_resource.relative_url
+      assert_includes @french_resource.output, 'lang="fr"'
+      assert_includes @french_resource.output, "<title>Sur mesure</title>"
       assert_includes @french_resource.output, "<p>French: Sur mesure</p>"
+
+      assert_includes @french_resource.output, <<-HTML
+    <li>Multi-locale page: /multi-page/</li>
+    <li>Sur mesure: /fr/multi-page/</li>
+      HTML
     end
   end
 end

--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_model.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_model.rb
@@ -66,6 +66,11 @@ module Bridgetown
 
           next unless template_config["enabled"]
 
+          if template.site.config.available_locales.size > 1 && !template_config["locale"]
+            template_config["locale"] =
+              template.data["locale"].to_s
+          end
+
           @logging_lambda.call "found page: #{template.path}", "debug" unless @debug
 
           # Request all documents in all collections that the user has requested


### PR DESCRIPTION
In this PR, resources and generated pages now offer an `all_locales` method. Calling this will return all of the resources (or generated pages) with the same slug…i.e. all the locales of that resource/page. For example:

`/some-page`
`/es/some-page`
`/zh-CN/some-page`

etc.

This also adds automatic support for multi-locale paginated pages (aka the English "Posts" page will show only English links, Spanish "Publicación" page will show only Spanish links, etc.).

Addresses #49 