### PR TITLE
Issue warning when a Rails-style extension is used (like `.html.erb`)

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/rack/roda.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/roda.rb
@@ -51,6 +51,9 @@ module Bridgetown
         request.root do
           output_folder = Bridgetown::Current.preloaded_configuration.destination
           File.read(File.join(output_folder, "index.html"))
+        rescue StandardError
+          response.status = 500
+          "<p>ERROR: cannot find <code>index.html</code> in the output folder.</p>"
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/resource/destination.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/destination.rb
@@ -12,6 +12,7 @@ module Bridgetown
       # @param resource [Bridgetown::Resource::Base]
       def initialize(resource)
         @resource = resource
+        warn_on_rails_style_extension
         @output_ext = resource.transformer.final_ext
       end
 
@@ -45,6 +46,23 @@ module Bridgetown
         FileUtils.mkdir_p(File.dirname(path))
         Bridgetown.logger.debug "Writing:", path
         File.write(path, output, mode: "wb")
+      end
+
+      private
+
+      def warn_on_rails_style_extension
+        return unless resource.relative_path.fnmatch?("*.{html,json,js}.*", File::FNM_EXTGLOB)
+
+        Bridgetown.logger.warn("Uh oh!", "You're using a Rails-style filename extension in:")
+        Bridgetown.logger.warn("", resource.relative_path)
+        Bridgetown.logger.warn(
+          "", "Instead, you can use either the desired output file extension or set a permalink."
+        )
+        Bridgetown.logger.warn(
+          "For more info:",
+          "https://www.bridgetownrb.com/docs/template-engines/erb-and-beyond#extensions-and-permalinks"
+        )
+        Bridgetown.logger.warn("")
       end
     end
   end

--- a/bridgetown-core/test/source/src/contacts/rails-style.html.erb
+++ b/bridgetown-core/test/source/src/contacts/rails-style.html.erb
@@ -1,0 +1,5 @@
+---
+title: Rails-style
+---
+
+Should issue a warning!

--- a/bridgetown-core/test/test_erb.rb
+++ b/bridgetown-core/test/test_erb.rb
@@ -5,7 +5,7 @@ require "helper"
 class TestERB < BridgetownUnitTest
   def setup
     @site = fixture_site
-    @site.process
+    @process_output = capture_output { @site.process }
     @erb_page = @site.resources.find { |p| p.data[:title] == "I'm an ERB Page" }
   end
 
@@ -48,6 +48,13 @@ class TestERB < BridgetownUnitTest
     should "render partials" do
       assert_includes @erb_page.output, "A partial success? yes."
       assert_includes @erb_page.output, "A partial success? YES!!"
+    end
+  end
+
+  context "Rails-style extensions" do
+    should "issue a warning" do
+      assert_includes @process_output, "Uh oh! You're using a Rails-style filename extension in:"
+      assert_includes @process_output, "rails-style.html.erb"
     end
   end
 end

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -874,7 +874,7 @@ class TestFilters < BridgetownUnitTest
               g["items"].is_a?(Array),
               "The list of grouped items for '' is not an Array."
             )
-            assert_equal 17, g["items"].size
+            assert_equal 18, g["items"].size
           end
         end
       end
@@ -1169,7 +1169,7 @@ class TestFilters < BridgetownUnitTest
               g["items"].is_a?(Array),
               "The list of grouped items for '' is not an Array."
             )
-            assert_equal 17, g["items"].size
+            assert_equal 18, g["items"].size
           end
         end
       end

--- a/bridgetown-core/test/test_site.rb
+++ b/bridgetown-core/test/test_site.rb
@@ -168,6 +168,7 @@ class TestSite < BridgetownUnitTest
         page_using_erb.erb
         page_using_serb.serb
         properties.html
+        rails-style.html.erb
         sitemap.xml
         static_files.html
         symlinked-file


### PR DESCRIPTION
Closes #464.