### PR TITLE
Fixed “Community” url typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gem "bridgetown-core", path: "/path/to/bridgetown/bridgetown-core"
 
 ## Need help?
 
-If you don't find the answer to your problem in our [docs](https://www.bridgetownrb.com/docs/), ask the [community](https://www.bridgetownrb.com/docs/community/) for help.
+If you don't find the answer to your problem in our [docs](https://www.bridgetownrb.com/docs/), ask the [community](https://www.bridgetownrb.com/community) for help.
 
 ## Code of Conduct
 

--- a/bridgetown-core/lib/bridgetown-core/utils/require_gems.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/require_gems.rb
@@ -49,7 +49,7 @@ module Bridgetown
 
               The full error message from Ruby is: '#{e.message}'
 
-              If you run into trouble, you can find helpful resources at https://www.bridgetownrb.com/docs/community/
+              If you run into trouble, you can find helpful resources at https://www.bridgetownrb.com/community
             MSG
             raise Bridgetown::Errors::MissingDependencyException, name
           end

--- a/bridgetown-website/src/_posts/2020/2020-04-17-time-to-visit-bridgetown.md
+++ b/bridgetown-website/src/_posts/2020/2020-04-17-time-to-visit-bridgetown.md
@@ -72,7 +72,7 @@ Get started today.
 [Go Bridgetown](/docs/){:.button.is-large.is-warning.is-outlined}
 {:.has-text-centered.my-10}
 
-(or [find out how you can become a contributor](/docs/community/)…or perhaps join the Bridgetown core team!)
+(or [find out how you can become a contributor](/community)…or perhaps join the Bridgetown core team!)
 {:.has-text-centered}
 
 {%@ Note do %}

--- a/bridgetown-website/src/_posts/2020/2020-04-18-whats-the-deal-with-themes.md
+++ b/bridgetown-website/src/_posts/2020/2020-04-18-whats-the-deal-with-themes.md
@@ -58,4 +58,4 @@ Imagine adding a `cool-new-plugin` Gem to your site and suddenly you have a new 
 
 This is no small feat because, in addition to allowing multiple plugins to supply templates and assets, we also need to integrate plugins into Bridgetown's new Webpack pipeline. Getting templates, Ruby code, Javascript, stylesheets, images, etc. all working together in harmony across an advanced website build with numerous plugins is going to be a massive undertaking, no doubt about it. **But we think the end result will be well worth the effort.**
 
-If you have any feedback or ideas about themes in Bridgetown, please drop by [our community forum](https://community.bridgetownrb.com) and let us know, or head over to the [Bridgetown repository on GitHub](https://github.com/bridgetownrb/bridgetown) and contribute to the project!
+If you have any feedback or ideas about themes in Bridgetown, please drop by [our community forum](https://www.bridgetownrb.com/community) and let us know, or head over to the [Bridgetown repository on GitHub](https://github.com/bridgetownrb/bridgetown) and contribute to the project!

--- a/bridgetown-website/src/_posts/2020/2020-05-18-whats-new-in-0.14-hazelwood.md
+++ b/bridgetown-website/src/_posts/2020/2020-05-18-whats-new-in-0.14-hazelwood.md
@@ -107,7 +107,7 @@ Finally, the other major step forward in Hazelwood is we're starting to break up
 
 Bridgetown 0.14 "Hazelwood" is an exciting release, not merely because of what it enables website designers and developers to do today, but because of the impact it will have on future releases of Bridgetown.
 
-[Give Bridgetown a spin](/docs) and [let us know what you think](/docs/community)!
+[Give Bridgetown a spin](/docs) and [let us know what you think](/community)!
 
 Also check out [our new Core Concepts guide](/docs/core-concepts) to learn more about the fundamentals of Bridgetown.
 

--- a/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
+++ b/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
@@ -59,7 +59,7 @@ We're thrilled to be attracting both new and long-time fans of the Ruby programm
 
 ### Get Started with Bridgetown
 
-So enough with the technobabble. [Give Bridgetown a spin](/docs) and [let us know what you think](/docs/community)!
+So enough with the technobabble. [Give Bridgetown a spin](/docs) and [let us know what you think](/community)!
 
 Also check out [our Core Concepts guide](/docs/core-concepts) to learn more about the fundamentals of Bridgetown.
 

--- a/bridgetown-website/src/_posts/2020/2020-07-28-whats-new-in-0.16-crystal-springs.md
+++ b/bridgetown-website/src/_posts/2020/2020-07-28-whats-new-in-0.16-crystal-springs.md
@@ -27,7 +27,7 @@ Not only that, but ERB/Haml/Slim templates are automatically supplied with the f
 
 Want to add your own helpers? No problem! Simply decorate the `Bridgetown::RubyTemplateView::Helpers` class or add a mixin.
 
-All this and more is well-documented in [ERB and Beyond](/docs/erb-and-beyond). If you run into any problems or have suggestions on how to improve template support, [please let us know!](/docs/community)
+All this and more is well-documented in [ERB and Beyond](/docs/erb-and-beyond). If you run into any problems or have suggestions on how to improve template support, [please let us know!](/community)
 
 ### Class Map Liquid Tag
 

--- a/bridgetown-website/src/_posts/2020/2020-08-11-bulmatown-theme-and-snipcart.md
+++ b/bridgetown-website/src/_posts/2020/2020-08-11-bulmatown-theme-and-snipcart.md
@@ -106,5 +106,5 @@ Bridgetown can be effectively used for a small amount of e-commerce. [Snipcart](
 
 ----
 
-_Want to set up your own online store or portfolio? [Give Bridgetown a whirl](/docs) and [let us know how it goes](/docs/community)!_
+_Want to set up your own online store or portfolio? [Give Bridgetown a whirl](/docs) and [let us know how it goes](/community)!_
 {: .has-text-centered}

--- a/bridgetown-website/src/_posts/2020/2020-08-25-midsummer-2020-plugin-roundup.md
+++ b/bridgetown-website/src/_posts/2020/2020-08-25-midsummer-2020-plugin-roundup.md
@@ -97,5 +97,5 @@ Wow, what a day! You've learned about how to incorporate content from a headless
 
 ----
 
-_Want to set up your own website that's super fast and easy to customize? [Give Bridgetown a try today](/docs) and [let us know how it goes](/docs/community)!_
+_Want to set up your own website that's super fast and easy to customize? [Give Bridgetown a try today](/docs) and [let us know how it goes](/community)!_
 {: .has-text-centered}


### PR DESCRIPTION
This is a 🔦 documentation change. There are some  community link broken, as actual community url is *https://www.bridgetownrb.com/community*

## Summary

Fixed broken community url in some doc and posts.


