### PR TITLE
Fix bug where sidecar aux process wasn't requiring bundler groups

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -160,7 +160,7 @@ module Bridgetown
 
     def load_tasks
       require "bridgetown-core/commands/base"
-      Bridgetown::PluginManager.require_from_bundler
+      Bridgetown::PluginManager.require_from_bundler(skip_yarn: true)
       load File.expand_path("bridgetown-core/tasks/bridgetown_tasks.rake", __dir__)
     end
 

--- a/bridgetown-core/lib/bridgetown-core/plugin.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin.rb
@@ -51,7 +51,7 @@ module Bridgetown
     # config - The Hash of configuration options.
     #
     # Returns a new instance.
-    def initialize(config = {})
+    def initialize(config = {}) # rubocop:disable Style/RedundantInitialize
       # no-op for default
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -40,7 +40,8 @@ module Bridgetown
       @loaders_manager = Bridgetown::Utils::LoadersManager.new(site.config)
     end
 
-    def self.require_from_bundler
+    def self.require_from_bundler(skip_yarn: false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # NOTE: investigate why this ENV var is really necessary
       if !ENV["BRIDGETOWN_NO_BUNDLER_REQUIRE"] && File.file?("Gemfile")
         require "bundler"
 
@@ -48,7 +49,7 @@ module Bridgetown
           (dep.groups & [PLUGINS_GROUP]).any? && dep.should_include?
         end
 
-        install_yarn_dependencies(required_gems)
+        install_yarn_dependencies(required_gems) unless skip_yarn
 
         required_gems.each do |installed_gem|
           add_registered_plugin installed_gem

--- a/bridgetown-core/lib/bridgetown-core/utils/aux.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/aux.rb
@@ -20,7 +20,8 @@ module Bridgetown
       def self.run_process(name, color, cmd)
         Thread.new do
           rd, wr = IO.pipe("BINARY")
-          pid = Process.spawn(cmd, out: wr, err: wr, pgroup: true)
+          pid = Process.spawn({ "BRIDGETOWN_NO_BUNDLER_REQUIRE" => nil },
+                              cmd, out: wr, err: wr, pgroup: true)
           @mutex.synchronize do
             add_pid pid
           end


### PR DESCRIPTION
Addresses bug report: https://github.com/bridgetownrb/bridgetown-activerecord/issues/1