### PR TITLE
Add syntax-theme configuration command

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/configure.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/configure.rb
@@ -38,10 +38,18 @@ module Bridgetown
       protected
 
       def configure(configuration)
-        configuration_file = find_in_source_paths("#{configuration}.rb")
+        if configuration.include?(":")
+          configuration_filename = configuration.split(":").first
+          configuration_option = configuration.split(":").last.split.first
+        else
+          configuration_filename = configuration
+        end
+
+        configuration_file = find_in_source_paths("#{configuration_filename}.rb")
 
         inside(New.created_site_dir || Dir.pwd) do
-          @templates_dir = File.expand_path("../configurations/#{configuration}", __dir__)
+          @templates_dir = File.expand_path("../configurations/#{configuration_filename}", __dir__)
+          @configuration_option = configuration_option
           apply configuration_file, verbose: false
         end
       end

--- a/bridgetown-core/lib/bridgetown-core/configurations/syntax-theme.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/syntax-theme.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# TODO: handle if css vs scss
+
+theme = @configuration_option
+valid_themes = Rouge::Theme.registry.map { |k, _v| k }.sort
+
+unless valid_themes.include?(theme)
+  @logger.error "\nTheme not valid. Please provide a valid theme
+                   eg. #{"syntax-theme:github".bold.white}"
+  @logger.info "\nValid themes are: \n\n#{valid_themes.join("\n")}\n"
+
+  return
+end
+
+say_status :syntax_theme, "Generating syntax theme for #{theme.bold.white}"
+
+create_file "frontend/styles/syntax-theme.css" do
+  header_comments = <<~CSS
+    /*#{" "}
+      Syntax Highlighting Theme for Code Snippets
+
+      https://www.bridgetownrb.com/docs/liquid/tags#stylesheets-for-syntax-highlighting
+
+      Other styles available eg. https://github.com/jwarby/jekyll-pygments-themes
+
+      To use another style, run `bin/bridgetown configure syntax-theme:{theme}` from
+      the command line. Eg. `bin/bridgetown configure syntax-theme:github`. To see a
+      list of all available styles run `bin/bridgetown configure syntax-theme`.
+      Or create your own by editing this file manually!
+    */
+
+  CSS
+
+  header_comments +
+    Rouge::Theme.find(theme).render(scope: ".highlight")
+end

--- a/bridgetown-core/test/fixtures/test_configuration_with_option.rb
+++ b/bridgetown-core/test/fixtures/test_configuration_with_option.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# require "rouge"
+
+# TODO: handle if css vs scss
+
+theme = @configuration_option
+valid_themes = %w[github valid]
+
+unless valid_themes.include?(theme)
+  if defined?(say_status)
+    say_status :syntax_theme, "Theme not valid. Please provide a valid theme eg. syntax-theme:github"
+    say_status :syntax_theme, "Valid themes are: \n\n#{valid_themes.join("\n")}\n"
+  end
+
+  return
+end
+
+say_status :syntax_theme, "Generating syntax theme for #{theme}" if defined?(say_status)
+
+create_file "frontend/styles/syntax-test.css" do
+  <<~CSS
+    /*#{" "}
+      Syntax Highlighting for Code Snippets
+
+      https://www.bridgetownrb.com/docs/liquid/tags#stylesheets-for-syntax-highlighting
+
+      Other styles available eg. https://github.com/jwarby/jekyll-pygments-themes
+
+      To use another style, run `bin/bridgetown configure syntax-theme:{theme}` from#{" "}
+      the command line. Eg. `bin/bridgetown configure syntax-theme:github`. To see a#{" "}
+      list of all available styles run `bin/bridgetown configure syntax-theme`.
+      Or create your own by editing this file manually!
+    */
+
+    .highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+      color: #5e5d83;
+      font-style: italic;
+    }
+
+  CSS
+end

--- a/bridgetown-core/test/test_configure_command.rb
+++ b/bridgetown-core/test/test_configure_command.rb
@@ -10,11 +10,13 @@ class TestConfigureCommand < BridgetownUnitTest
   context "the configure command" do
     setup do
       FileUtils.cp(test_dir("fixtures", "test_automation.rb"), configurations_path)
+      FileUtils.cp(test_dir("fixtures", "test_configuration_with_option.rb"), configurations_path)
       @cmd = Bridgetown::Commands::Configure.new
     end
 
     teardown do
       File.delete("#{configurations_path}/test_automation.rb")
+      File.delete("#{configurations_path}/test_configuration_with_option.rb")
     end
 
     should "list all available configurations when invoked without args" do
@@ -51,6 +53,50 @@ class TestConfigureCommand < BridgetownUnitTest
       assert_match %r!Configuration doesn't exist: fail!, output
 
       File.delete("#{configurations_path}/roar.rb")
+    end
+
+    should "perform configuration when option provided" do
+      output = capture_stdout do
+        @cmd.invoke(:perform_configurations, ["test_configuration_with_option:github"])
+      end
+
+      frontend_styles_path = File.expand_path(root_dir("frontend", "styles"), __dir__)
+
+      assert_match %r!create.*syntax-test.css!, output
+      assert File.exist?("#{frontend_styles_path}/syntax-test.css")
+
+      File.delete("#{frontend_styles_path}/syntax-test.css")
+    end
+
+    should "perform multiple configurations when option provided" do
+      capture_stdout do
+        @cmd.invoke(:perform_configurations, ["test_configuration_with_option:github test_automation"])
+      end
+
+      frontend_styles_path = File.expand_path(root_dir("frontend", "styles"), __dir__)
+      assert File.exist?("#{frontend_styles_path}/syntax-test.css")
+      # TODO: This test doesn't work, but manual testing seems to prove it does work fine
+      # I _think_ it's something to do with capture_stdout not capturing everything... maybe?
+      # assert_match %r!fixture.*?Works\!!, output
+      # assert_match %r!create.*syntax-test.css!, output
+
+      File.delete("#{frontend_styles_path}/syntax-test.css")
+    end
+
+    should "show error when option doesn't exist" do
+      output = capture_stdout do
+        @cmd.invoke(:perform_configurations, ["test_configuration_with_option"])
+      end
+
+      assert_match %r!Theme not valid!, output
+    end
+
+    should "show error when option is invalid" do
+      output = capture_stdout do
+        @cmd.invoke(:perform_configurations, ["test_configuration_with_option:invalid"])
+      end
+
+      assert_match %r!Theme not valid!, output
     end
   end
 end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This change introduces a new bundled configuration `syntax-theme`
which sets a syntax highlighting theme for code snippets.

To specify _which_ theme to use, this change introduces the concept
of a configuration option which is set by defining the option after
the configuration, separated by a colon `:`. Eg.

`bridgetown configure syntax-theme:github` (`github` is the option)

We use the themes from the Rouge gem to output the required CSS.

![image](https://user-images.githubusercontent.com/8590311/163455837-4363cb5a-41af-42c0-97b0-0c134c9e1ffd.png)

## Context

- Closes https://github.com/bridgetownrb/bridgetown/issues/512
- Closes https://github.com/bridgetownrb/bridgetown/pull/516 (I opened a new PR to play with this new approach)

I wanted to push this up to get your early feedback. There are still many things to do:

- `bridgetown/bridgetown-core/test/fixtures/test_configuration_with_option.rb:7: warning: instance variable @configuration_option not initialized` when run tests bridgetown-core/test/test_configure_command.rb
- Detect and handle css vs scss
- Call syntax-theme configuration when running `bridgetown new`
- Add `import "syntax-theme.css"` to index.js as part of configuration (ensure it doesn't re-add it if already exists)
- Documentation
- Update `syntax-theme.css` header comments when documentation is finalised
- Test "perform multiple configurations when option provided" doesn't work
- conflict Overwrite UX confusion? (because user is being asked to overwrite a file which is scary (and they didn't create it in the first place). Should we say something in the output ahead of this? Or cover it in the documentation? Both?) Eg. what happens now:

```bash
$ bin/bridgetown configure syntax-theme:molokai
syntax_theme  Generating syntax theme for molokai
    conflict  frontend/styles/syntax-theme.css
Overwrite /home/jaredt/projects/bridgetest/frontend/styles/syntax-theme.css? (enter "h" for help) [Ynaqdhm]
```

Sorry for my slowness on this. I thought I had time to look at this weeks ago but life got in the way! Would love your feedback and then happy to carry on if you agree with the direction.