### PR TITLE
invalid multibyte char (US-ASCII) - Remove emojis?

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages.rb
@@ -4,10 +4,10 @@
 copy_file in_templates_dir("gh-pages.yml"), ".github/workflows/gh-pages.yml"
 
 # rubocop:disable Layout/LineLength
-say "🎉 A GitHub action to deploy your site to GitHub pages has been configured!"
+say "A GitHub action to deploy your site to GitHub pages has been configured!"
 say ""
 
-say "🛠️  After pushing the action, go to your repository settings and configure GitHub Pages to deploy from the branch `gh-pages`."
+say "After pushing the action, go to your repository settings and configure GitHub Pages to deploy from the branch `gh-pages`."
 say ""
 
 say "You'll likely also need to set `base_path` in your `bridgetown.config.yml` to your repository's name. If you do this you'll need to use the `relative_url` helper for all links and assets in your HTML."


### PR DESCRIPTION
I stumbled upon this error the first time I tried to run `/bin/bridgetown configure gh-pages`:

```
[...]
in `instance_eval': /Users/coorasse/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bridgetown-core-1.0.0/lib/bridgetown-core/configurations/gh-pages.rb:7: invalid multibyte char (US-ASCII) (SyntaxError)
[...]
```

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
