### PR TITLE
Add Markdown support to convert `==` / `::` to `<mark>`

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -83,6 +83,7 @@ module Bridgetown
         "footnote_nr"             => 1,
         "show_warnings"           => false,
         "include_extraction_tags" => false,
+        "mark_highlighting"       => true,
       },
     }.each_with_object(Configuration.new) { |(k, v), hsh| hsh[k] = v.freeze }.freeze
 

--- a/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
@@ -76,7 +76,7 @@ module Bridgetown
           @config["syntax_highlighter"] ||= config["highlighter"] || "rouge"
           @config["syntax_highlighter_opts"] ||= {}
           @config["syntax_highlighter_opts"]["guess_lang"] = @config["guess_lang"]
-          require "kramdown-parser-gfm" if @config["input"] == "GFM"
+          require_relative "../../kramdown/parser/gfm" if @config["input"] == "GFM"
         end
 
         def convert(content)

--- a/bridgetown-core/lib/bridgetown-core/kramdown/parser/gfm.rb
+++ b/bridgetown-core/lib/bridgetown-core/kramdown/parser/gfm.rb
@@ -1,0 +1,36 @@
+# Frozen-string-literal: true
+
+require "kramdown-parser-gfm"
+
+module Kramdown
+  module Parser
+    class GFM
+      MARK_DELIMITER = %r{(==|::)+}.freeze
+      MARK_MATCH = %r{#{MARK_DELIMITER}(?!\s|=|:).*?[^\s=:]#{MARK_DELIMITER}}m.freeze
+
+      # Monkey-patch GFM initializer to add our new mark parser
+      alias_method :_old_initialize, :initialize
+      def initialize(source, options)
+        _old_initialize(source, options)
+        @span_parsers << :mark if @options[:mark_highlighting]
+      end
+
+      def parse_mark
+        line_number = @src.current_line_number
+
+        @src.pos += @src.matched_size
+        el = Element.new(:html_element, "mark", {}, category: :span, line: line_number)
+        @tree.children << el
+
+        env = save_env
+        reset_env(src: Kramdown::Utils::StringScanner.new(@src.matched[2..-3], line_number),
+                  text_type: :text)
+        parse_spans(el)
+        restore_env(env)
+
+        el
+      end
+      define_parser(:mark, MARK_MATCH)
+    end
+  end
+end

--- a/bridgetown-core/test/test_kramdown.rb
+++ b/bridgetown-core/test/test_kramdown.rb
@@ -57,6 +57,11 @@ class TestKramdown < BridgetownUnitTest
       assert_equal "<h1>Some Header</h1>", @converter.convert("# Some Header #").strip
     end
 
+    should "render mark tags" do
+      assert_equal "<p>This is <mark>highlighted</mark> like <mark>this.</mark></p>",
+                   @converter.convert("This is ::highlighted:: like ==this.==").strip
+    end
+
     should "should log kramdown warnings" do
       allow_any_instance_of(Kramdown::Document).to receive(:warnings).and_return(["foo"])
       expect(Bridgetown.logger).to receive(:warn).with("Kramdown warning:", "foo")

--- a/bridgetown-website/src/_docs/configuration/markdown.md
+++ b/bridgetown-website/src/_docs/configuration/markdown.md
@@ -24,6 +24,7 @@ currently supported options:
 * **html_to_native** - Convert HTML elements to native elements
 * **line_width** - Defines the line width to be used when outputting a document
 * **link_defs** - Pre-defines link definitions
+* **mark_highlighting** - When `true`, allows `==text==` or `::text::` to highlight text with `<mark>` tags (this is a custom Bridgetown-only option)
 * **math_engine** - Set the math engine
 * **math_engine_opts** - Set the math engine options
 * **parse_block_html** - Process kramdown syntax in block HTML tags

--- a/bridgetown-website/src/_docs/configuration/options.md
+++ b/bridgetown-website/src/_docs/configuration/options.md
@@ -466,4 +466,6 @@ kramdown:
   guess_lang        : true
   footnote_nr       : 1
   show_warnings     : false
+  include_extraction_tags: false
+  mark_highlighting : true
 ```


### PR DESCRIPTION
Many Markdown editors allow you to highlight text with `::double colons::` or with `==double equals==`. I've grown accustomed to this myself in various writing contexts. Because of that, it's frustrating to have to switch gears in Bridgetown `.md` files and add `<mark>` tags everywhere instead.

This PR patches Kramdown's GFM parser (our default) to add support for both those delimiters. So for example:

```md
This is ==now highlighted==! ::Yay!::
```

becomes

```html
This is <mark>now highlighted</mark>! <mark>Yay!</mark>
```

The `kramdown: mark_highlighting` YAML config option can be set to `false` to disable this new feature if for some reason it's a breaking change for existing websites.