### PR TITLE
New bundled configurations: Lit, Shoelace, Ruby2JS

### DIFF
--- a/bridgetown-core/.rubocop.yml
+++ b/bridgetown-core/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - tmp/**/*
     - test/source/**/*
     - test/resources/src/_pages/*.rb
+    - lib/bridgetown-core/configurations/ruby2js/**/*
     - lib/site_template/TEMPLATES/**/*
     - lib/site_template/Rakefile
     - lib/site_template/config.ru

--- a/bridgetown-core/lib/bridgetown-core/commands/configure.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/configure.rb
@@ -60,7 +60,7 @@ module Bridgetown
 
       def configurations
         inside self.class.source_root do
-          return Dir.glob("*.rb").map { |file| file.sub(".rb", "") }
+          return Dir.glob("*.rb").map { |file| file.sub(".rb", "") }.sort
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
@@ -1,0 +1,5 @@
+// You can add "full-stack" esbuild plugins here that you wish to share between
+// the frontend bundles and Lit SSR:
+module.exports = {
+  plugins: []
+}

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/happy-days.lit.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/happy-days.lit.js
@@ -1,0 +1,26 @@
+import { LitElement, html, css } from "lit"
+
+export class HappyDaysElement extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      border: 2px dashed gray;
+      padding: 20px;
+      max-width: 300px;
+    }
+  `
+
+  static properties = {
+    hello: { type: String }
+  }
+
+  render() {
+    return html`
+      <p>Hello ${this.hello}! ${Date.now()}</p>
+    `;
+  }
+}
+
+// Try adding `<%= lit :happy_days, hello: "there" %>` somewhere in an ERB template
+// on your site to see this example Lit component in action!
+customElements.define('happy-days', HappyDaysElement)

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-components-entry.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-components-entry.js
@@ -1,0 +1,1 @@
+import components from "bridgetownComponents/**/*.{lit.js,lit.js.rb}"

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-ssr.config.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-ssr.config.js
@@ -1,0 +1,6 @@
+const build = require("bridgetown-lit-renderer/build")
+const { plugins } = require("./esbuild-plugins.js")
+
+const esbuildOptions = { plugins }
+
+build(esbuildOptions)

--- a/bridgetown-core/lib/bridgetown-core/configurations/ruby2js.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/ruby2js.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+unless Bridgetown::Utils.frontend_bundler_type == :esbuild
+  error_message = "#{"esbuild.config.js".bold} not found. (This configuration doesn't currently support Webpack.)"
+
+  @logger.error "\nError:".red, "🚨 #{error_message}"
+
+  return
+end
+
+say_status :ruby2js, "Installing Ruby2JS..."
+
+run "yarn add -D @ruby2js/esbuild-plugin"
+
+found_match = false
+gsub_file "esbuild.config.js", %r{const esbuildOptions = {}\n} do |_match|
+  found_match = true
+
+  <<~JS
+    const ruby2js = require("@ruby2js/esbuild-plugin")
+
+    const esbuildOptions = {
+      plugins: [
+        // See docs on Ruby2JS options here: https://www.ruby2js.com/docs/options
+        ruby2js({
+          eslevel: 2022,
+          autoexports: "default",
+          filters: ["camelCase", "functions", "lit", "esm", "return"]
+        })
+      ]
+    }
+  JS
+end
+
+unless found_match
+  insert_into_file "esbuild.config.js",
+                   after: 'const build = require("./config/esbuild.defaults.js")' do
+    <<~JS
+
+      const ruby2js = require("@ruby2js/esbuild-plugin")
+
+      // Uncomment and move the following into your plugins array:
+      //
+      //  ruby2js({
+      //    eslevel: 2022,
+      //    autoexports: "default",
+      //    filters: ["camelCase", "functions", "lit", "esm", "return"]
+      //  })
+      //
+      // See docs on Ruby2JS options here: https://www.ruby2js.com/docs/options
+
+    JS
+  end
+end
+
+copy_file in_templates_dir("hello_world.js.rb"), "src/_components/hello_world.js.rb"
+
+say_status :ruby2js, "Ruby2JS is now configured!"
+
+say "Check out the example `hello_world.js.rb` file in `src/_components`", :blue
+say 'For further reading, check out "https://www.ruby2js.com"', :blue

--- a/bridgetown-core/lib/bridgetown-core/configurations/ruby2js.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/ruby2js.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 unless Bridgetown::Utils.frontend_bundler_type == :esbuild
-  error_message = "#{"esbuild.config.js".bold} not found. (This configuration doesn't currently support Webpack.)"
+  error_message = "#{"esbuild.config.js".bold} not found. (This configuration doesn't currently " \
+                  "support Webpack.)"
 
   @logger.error "\nError:".red, "🚨 #{error_message}"
 
@@ -39,7 +40,7 @@ unless found_match
 
       const ruby2js = require("@ruby2js/esbuild-plugin")
 
-      // Uncomment and move the following into your plugins array:
+      // TODO: Uncomment and move the following into your plugins array:
       //
       //  ruby2js({
       //    eslevel: 2022,
@@ -55,7 +56,12 @@ end
 
 copy_file in_templates_dir("hello_world.js.rb"), "src/_components/hello_world.js.rb"
 
-say_status :ruby2js, "Ruby2JS is now configured!"
+if found_match
+  say_status :ruby2js, "Ruby2JS is now configured!"
+else
+  say_status :ruby2js, "Ruby2JS is just about configured!"
+  say_status :ruby2js, "You will need to edit `esbuild.config.js` to finish setting up the plugin."
+end
 
 say "Check out the example `hello_world.js.rb` file in `src/_components`", :blue
 say 'For further reading, check out "https://www.ruby2js.com"', :blue

--- a/bridgetown-core/lib/bridgetown-core/configurations/ruby2js/hello_world.js.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/ruby2js/hello_world.js.rb
@@ -1,0 +1,9 @@
+class HelloWorld < HTMLElement
+  def connected_callback()
+    self.inner_html = "<p><strong>Hello World!</strong></p>"
+  end
+end
+
+# Try adding `<hello-world></hello-world>` somewhere on your site to see this
+# example web component in action!
+custom_elements.define "hello-world", HelloWorld

--- a/bridgetown-core/lib/bridgetown-core/configurations/shoelace.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/shoelace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_status :shoelace, "Installing Shoelace..."
 
 run "yarn add @shoelace-style/shoelace"

--- a/bridgetown-core/lib/bridgetown-core/configurations/shoelace.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/shoelace.rb
@@ -1,0 +1,48 @@
+say_status :shoelace, "Installing Shoelace..."
+
+run "yarn add @shoelace-style/shoelace"
+
+say 'Adding Shoelace to "frontend/javascript/index.js"...', :magenta
+
+javascript_import do
+  <<~JS
+    // Import the base Shoelace stylesheet:
+    import "@shoelace-style/shoelace/dist/themes/light.css"
+
+    // Example components, mix 'n' match however you like!
+    import "@shoelace-style/shoelace/dist/components/button/button.js"
+    import "@shoelace-style/shoelace/dist/components/icon/icon.js"
+    import "@shoelace-style/shoelace/dist/components/spinner/spinner.js"
+
+    // Use the public icons folder:
+    import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js"
+    setBasePath("/shoelace-assets")
+  JS
+end
+
+say "Updating frontend build commands...", :magenta
+
+if Bridgetown::Utils.frontend_bundler_type == :esbuild
+  insert_into_file "package.json", before: '    "esbuild": "node' do
+    <<-JS
+    "shoelace:copy-assets": "mkdir -p src/shoelace-assets && cp -r node_modules/@shoelace-style/shoelace/dist/assets src/shoelace-assets",
+    JS
+  end
+  gsub_file "package.json", %r{"esbuild": "node}, '"esbuild": "yarn shoelace:copy-assets && node'
+  gsub_file "package.json", %r{"esbuild-dev": "node},
+            '"esbuild-dev": "yarn shoelace:copy-assets && node'
+else
+  insert_into_file "package.json", before: '    "webpack-build": "webpack' do
+    <<-JS
+    "shoelace:copy-assets": "mkdir -p src/shoelace-assets && cp -r node_modules/@shoelace-style/shoelace/dist/assets src/shoelace-assets",
+    JS
+  end
+  gsub_file "package.json", %r{"webpack-build": "webpack},
+            '"webpack-build": "yarn shoelace:copy-assets && webpack'
+  gsub_file "package.json", %r{"webpack-dev": "webpack},
+            '"webpack-dev": "yarn shoelace:copy-assets && webpack'
+end
+
+say_status :shoelace, "Shoelace is now configured!"
+
+say 'For further reading, check out "https://shoelace.style"', :blue

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -15,9 +15,9 @@
     <%- if frontend_bundling_option == "webpack" -%>
     "css-loader": "^4.3.0",
     <%- end -%>
-    "esbuild": "^0.13.15",
+    "esbuild": "^0.14.39",
     <%- if frontend_bundling_option == "webpack" -%>
-    "esbuild-loader": "^2.16.0",
+    "esbuild-loader": "^2.18.0",
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^1.3.1",
     <%- else -%>

--- a/bridgetown-website/package.json
+++ b/bridgetown-website/package.json
@@ -19,10 +19,13 @@
   },
   "dependencies": {
     "@hotwired/turbo": "^7.1.0",
-    "@ruby2js/esbuild-plugin": "^0.0.2",
+    "@ruby2js/esbuild-plugin": "^0.0.3",
     "@shoelace-style/shoelace": "^2.0.0-beta.62",
     "bridgetown-quick-search": "1.1.3",
     "hotkeys-js": "^3.8.7",
     "smoothscroll-polyfill": "^0.4.4"
+  },
+  "resolutions": {
+    "@ruby2js/ruby2js": "5.0.1"
   }
 }

--- a/bridgetown-website/src/_docs/routes.md
+++ b/bridgetown-website/src/_docs/routes.md
@@ -34,6 +34,7 @@ class Routes::Preview < Bridgetown::Rack::Routes
         item = Bridgetown::Model::Base.find("repo://#{collection}/#{path}")
 
         unless item.content.present?
+          response.status = 404
           next Bridgetown::Model::Base.find("repo://pages/_pages/404.html")
             .render_as_resource
             .output

--- a/bridgetown-website/yarn.lock
+++ b/bridgetown-website/yarn.lock
@@ -97,18 +97,18 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
   integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
 
-"@ruby2js/esbuild-plugin@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@ruby2js/esbuild-plugin/-/esbuild-plugin-0.0.2.tgz#ce0a42ad59dff4e80e7bddac55c93427a6d25a96"
-  integrity sha512-gcqCBel1h7o+tJWPPL6wI4kQbBfi/BdrLmTnM+ok4dPHde+0Bb5rj0gab6S+RoXfIqXg+JoNuV8VCTNhv1+bzQ==
+"@ruby2js/esbuild-plugin@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@ruby2js/esbuild-plugin/-/esbuild-plugin-0.0.3.tgz#62e9c6074732839b3256eac48dfdebc585144fb9"
+  integrity sha512-u6RYM45Nb761LXBjQKMcn1vfTgki3k55oF3/jiF/Qqeu3lCy1RAclJCqrKum9jm30DzWiG+1nZsCWrtZpbUdSg==
   dependencies:
     "@ruby2js/ruby2js" ">0.0.1"
     convert-source-map "^1.8.0"
 
-"@ruby2js/ruby2js@>0.0.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@ruby2js/ruby2js/-/ruby2js-0.2.1.tgz#0b3036e88305e1c671eb00b65006bc04e52e1a4d"
-  integrity sha512-WYMhAgY2m74xbMa6tHNSUU+uCS3EA4GDZfbhEafnYtJyMsxGszpKqkrjB+9hf6FePQoMX+x4jfXM73AUgkFg7A==
+"@ruby2js/ruby2js@5.0.1", "@ruby2js/ruby2js@>0.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@ruby2js/ruby2js/-/ruby2js-5.0.1.tgz#80e0ac745b1aaae34e0870f74369b5352b017da7"
+  integrity sha512-SPL5JFLNyytSZESSnLcFHkLrJkfwEajKGYb3YJJbtNtupCmBgMlYUCIft3RzDYwqlht0owfO9In2SsLxVSZ8LQ==
 
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
As [promised here](https://www.bridgetownrb.com/future/whats-next-cherry-blossoms-edition/), this PR adds bundled configurations for supporting Lit (plus the SSR plugin), Shoelace, and Ruby2JS. I'll also add Open Props shortly before merge.

Imagine being able to run this!

```bash
$ bridgetown new whoa -t erb -c turbo,ruby2js,shoelace,lit
```

- [ ] Documentation