### PR TITLE
Update Tailwind config so `jit-refresh.css` is git ignored

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -38,6 +38,20 @@ end
 
 create_file "frontend/styles/jit-refresh.css", "/* #{Time.now.to_i} */"
 
+insert_into_file "Rakefile",
+                  after: %r{  task :(build|dev) do\n} do
+  <<-JS
+    sh "touch frontend/styles/jit-refresh.css"
+  JS
+end
+
+append_to_file ".gitignore" do
+  <<~FILES
+
+    frontend/styles/jit-refresh.css
+  FILES
+end
+
 create_builder "tailwind_jit.rb" do
   <<~RUBY
     class Builders::TailwindJit < SiteBuilder


### PR DESCRIPTION
Resolves #547

To set it up in an existing project, just make sure you've added `frontend/styles/jit-refresh.css` to your `.gitignore` file (you might have to delete it and commit first). Then update your `Rakefile` so it has the line

```ruby
sh "touch frontend/styles/jit-refresh.css"
```

right at the top of both the `:build` task and the `:dev` task. For example:

```ruby
namespace :frontend do
  desc "Build the frontend with esbuild for deployment"
  task :build do
    sh "touch frontend/styles/jit-refresh.css"
    sh "yarn run esbuild"
  end

  desc "Watch the frontend with esbuild during development"
  task :dev do
    sh "touch frontend/styles/jit-refresh.css"
    sh "yarn run esbuild-dev"
  rescue Interrupt
  end
end
```