### PR TITLE
Simplify the Roda boot process, add more route tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,9 +11,6 @@ inherit_gem:
 Bridgetown/NoPutsAllowed:
   Exclude:
     - rake/*.rake
-    - bridgetown-core/lib/bridgetown-core/commands/base.rb
-    - bridgetown-core/lib/bridgetown-core/commands/plugins.rb
-    - bridgetown-core/lib/bridgetown-core/rack/roda.rb
 
 AllCops:
   TargetRubyVersion: 2.7

--- a/bridgetown-core/.rubocop.yml
+++ b/bridgetown-core/.rubocop.yml
@@ -12,11 +12,15 @@ AllCops:
     - tmp/**/*
     - test/source/**/*
     - test/resources/src/_pages/*.rb
+    - lib/bridgetown-core/commands/base.rb
+    - lib/bridgetown-core/commands/plugins.rb
+    - lib/bridgetown-core/rack/roda.rb
     - lib/site_template/TEMPLATES/**/*
     - lib/site_template/Rakefile
     - lib/site_template/config.ru
     - lib/site_template/config/**/*
     - lib/site_template/plugins/site_builder.rb
+    - lib/site_template/server/roda_app.rb
 
 Lint/ConstantDefinitionInBlock:
   Exclude:

--- a/bridgetown-core/lib/site_template/server/roda_app.rb
+++ b/bridgetown-core/lib/site_template/server/roda_app.rb
@@ -4,21 +4,18 @@
 #
 # Learn more at: http://roda.jeremyevans.net
 
-# Uncomment to use file-based dynamic routing in your project (make sure you
-# uncomment the gem dependency in your Gemfile as well):
-# require "bridgetown-routes"
-
 class RodaApp < Bridgetown::Rack::Roda
   # Add additional Roda configuration here if needed
 
   # Uncomment to use Bridgetown SSR:
   # plugin :bridgetown_ssr
 
-  # And optionally file-based routing:
+  # Uncomment to use file-based dynamic routing in your project (make sure you
+  # uncomment the gem dependency in your `Gemfile` as well):
   # plugin :bridgetown_routes
 
   route do |r|
     # Load Roda routes in server/routes (and src/_routes via `bridgetown-routes`)
-    Bridgetown::Rack::Routes.start! self
+    r.bridgetown
   end
 end

--- a/bridgetown-core/test/ssr/server/roda_app.rb
+++ b/bridgetown-core/test/ssr/server/roda_app.rb
@@ -6,7 +6,5 @@ class RodaApp < Bridgetown::Rack::Roda
     site.data.iterations += 1
   end
 
-  route do |r|
-    r.bridgetown
-  end
+  route(&:bridgetown)
 end

--- a/bridgetown-core/test/ssr/server/roda_app.rb
+++ b/bridgetown-core/test/ssr/server/roda_app.rb
@@ -6,7 +6,7 @@ class RodaApp < Bridgetown::Rack::Roda
     site.data.iterations += 1
   end
 
-  route do |_r|
-    Bridgetown::Rack::Routes.start! self
+  route do |r|
+    r.bridgetown
   end
 end

--- a/bridgetown-core/test/ssr/server/routes/cookies.rb
+++ b/bridgetown-core/test/ssr/server/routes/cookies.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Routes::Cookies < Bridgetown::Rack::Routes
+  route do |r|
+    # route: GET /cookies
+    r.get "cookies" do
+      { value: r.cookies[:test_key] }
+    end
+
+    # route: POST /cookies
+    r.post "cookies" do
+      response.set_cookie :test_key, {
+        value: r.params[:value],
+        httponly: true,
+      }
+
+      { value: r.cookies[:test_key] }
+    end
+  end
+end

--- a/bridgetown-core/test/ssr/server/routes/ooh_json.rb
+++ b/bridgetown-core/test/ssr/server/routes/ooh_json.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Routes::OohJson < Bridgetown::Rack::Routes
+  route do |r|
+    # route: POST /cookies
+    r.post "ooh_json" do
+      next { keep_on: "running" } unless r.params[:tell_me] == "what you're chasin'"
+
+      { because_the_night: "will never give you what you want" }
+    end
+  end
+end

--- a/bridgetown-routes/lib/bridgetown-routes.rb
+++ b/bridgetown-routes/lib/bridgetown-routes.rb
@@ -16,6 +16,7 @@ module Bridgetown
 
     # rubocop:disable Bridgetown/NoPutsAllowed
     def self.print_roda_routes
+      # TODO: this needs to be fully documented, currently no info on how to generate .routes.json
       routes = begin
         JSON.parse(File.read("#{Dir.pwd}/.routes.json"))
       rescue StandardError

--- a/bridgetown-website/server/roda_app.rb
+++ b/bridgetown-website/server/roda_app.rb
@@ -7,9 +7,7 @@
 class RodaApp < Bridgetown::Rack::Roda
   plugin :bridgetown_ssr
 
-  route do
-    # Load all the files in server/routes
-    # see hello.rb.sample
-    Bridgetown::Rack::Routes.start! self
+  route do |r|
+    r.bridgetown
   end
 end

--- a/bridgetown-website/src/_docs/routes.md
+++ b/bridgetown-website/src/_docs/routes.md
@@ -157,12 +157,6 @@ To opt-into the `bridgetown-routes` gem, make sure it's enabled in your `Gemfile
 gem "bridgetown-routes", group: :bridgetown_plugins
 ```
 
-and required at the top of your `server/roda_app.rb` file:
-
-```ruby
-require "bridgetown-routes"
-```
-
 and added in as a Roda plugin below the SSR plugin:
 
 ```ruby


### PR DESCRIPTION
Instead of the main Roda app having to call `Bridgetown::Rack::Routes.start! self`, it can just use `r.bridgetown`.

Also made sure cookies support indifferent access (symbols as well as strings). Added more route tests to the suite.