### PR TITLE
Update site template configuration file with link to config options docs

### DIFF
--- a/bridgetown-core/lib/site_template/bridgetown.config.yml
+++ b/bridgetown-core/lib/site_template/bridgetown.config.yml
@@ -3,6 +3,9 @@
 # This config file is for settings that affect your whole site, values
 # which you are expected to set up once and rarely edit after that.
 #
+# A list of all available configuration options can be found here:
+# https://www.bridgetownrb.com/docs/configuration/options
+#
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # `bin/bridgetown start`. If you change this file, please restart the server process.
 #


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This commit adds a link to the configuration options docs directly into the default `bridgetown.config.yml`. This will make navigating to the docs quicker and will also increase discoverability of those options for folks getting started with Bridgetown.

## Context

I often need to reference the configuration options docs when updating my site config. Typically, I have to navigate to the Bridgetown site, and then search/find the link for the configuration options, which takes several clicks and can break my concentration. This change will also ensure that the options are easily discoverable in case someone has trouble finding them on the website.

Not a necessity, but it would be nice to have and provide a smoother DX after running `bridgetown new`.


