### PR TITLE
feat: add rb files to the Tailwind content glob

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/tailwindcss.rb
@@ -21,7 +21,7 @@ run "npx tailwindcss init"
 
 gsub_file "tailwind.config.js", "content: [],", <<~JS.strip
   content: [
-      './src/**/*.{html,md,liquid,erb,serb}',
+      './src/**/*.{html,md,liquid,erb,serb,rb}',
       './frontend/javascript/**/*.js',
     ],
 JS
@@ -59,7 +59,7 @@ create_builder "tailwind_jit.rb" do
         hook :site, :pre_reload do |_, paths|
           # Don't trigger refresh if it's a frontend-only change
           next if paths.length == 1 && paths.first.ends_with?("manifest.json")
-    
+
           # Save out a comment file to trigger Tailwind's JIT
           refresh_file = site.in_root_dir("frontend", "styles", "jit-refresh.css")
           File.write refresh_file, "/* \#{Time.now.to_i} */"


### PR DESCRIPTION
This is a 🙋 feature or enhancement. 

## Summary

This commit updates the Tailwind CSS content glob to also include ruby files when searching for classes in the src folder.

## Context

Components, plugins, helpers, data files, etc. that are written in Ruby may contain Tailwind CSS classes that won't get generated by the JIT because they aren't in the content scope. 

I have been using Tailwind for years but it took me close to 45 minutes before I realized the reason my classes were not generating the right CSS because they were in a Ruby component, not the accompanying erb file. Hopefully this will save people heartache and frustration if they run into the same issue and not make it be something you always need to add when generating a new site with Tailwind.

The one downside to this addition could be a performance hit. The larger the glob, the longer it takes Tailwind to scan for classes. 

Here is why I think that is ok:

- It is very easy to go in and scope down the glob if needed
- You would need to have an enormous amount of files for it to start bringing down perf, plus most of them probably won't be pure Ruby making the hit minimal compared to markdown or ERB
- The places you can write Ruby in your site is increasing, so people are bound to come across this and it can be very frustrating

A small change but hopefully it will at minimum save some frustration/time and prevent the need to Google to figure out what's happening.

Thanks for reading 😄

