### PR TITLE
Improve Roda error handling and update static error pages

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/errors.rb
+++ b/bridgetown-core/lib/bridgetown-core/errors.rb
@@ -15,9 +15,9 @@ module Bridgetown
     InvalidURLError             = Class.new(FatalException)
     InvalidConfigurationError   = Class.new(FatalException)
 
-    def self.print_build_error(exc, trace: false)
-      Bridgetown.logger.error "Exception raised:", exc.class.to_s.bold
-      Bridgetown.logger.error exc.message.reset_ansi
+    def self.print_build_error(exc, trace: false, logger: Bridgetown.logger)
+      logger.error "Exception raised:", exc.class.to_s.bold
+      logger.error exc.message.reset_ansi
 
       trace_args = ["-t", "--trace"]
       print_trace_msg = true
@@ -28,12 +28,12 @@ module Bridgetown
                  exc.backtrace[0..4]
                end
       traces.each_with_index do |backtrace_line, index|
-        Bridgetown.logger.error "#{index + 1}:", backtrace_line.reset_ansi
+        logger.error "#{index + 1}:", backtrace_line.reset_ansi
       end
 
       return unless print_trace_msg
 
-      Bridgetown.logger.warn "Backtrace:", "Use the --trace option for complete information."
+      logger.warn "Backtrace:", "Use the --trace option for complete information."
     end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/rack/logger.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/logger.rb
@@ -4,18 +4,28 @@ require "logger"
 
 module Bridgetown
   module Rack
-    class Logger < Logger
+    class Logger < Bridgetown::LogWriter
       def self.message_with_prefix(msg)
-        return if msg.include?("/_bridgetown/live_reload")
+        #        return if msg.include?("/_bridgetown/live_reload")
 
         "\e[35m[Server]\e[0m #{msg}"
       end
 
-      def initialize(*)
-        super
+      def enable_prefix
         @formatter = proc do |_, _, _, msg|
           self.class.message_with_prefix(msg)
         end
+      end
+
+      def add(severity, message = nil, progname = nil)
+        return if progname&.include?("/_bridgetown/live_reload")
+
+        super
+      end
+
+      def initialize(*_args)
+        super()
+        enable_prefix
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/rack/roda.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/roda.rb
@@ -67,13 +67,74 @@ module Bridgetown
       rescue Errno::ENOENT
         "404 Not Found"
       end
+      plugin :exception_page
       plugin :error_handler do |e|
-        puts "\n#{e.class} (#{e.message}):\n\n"
-        puts e.backtrace
+        Bridgetown::Errors.print_build_error(
+          e, logger: Bridgetown::LogAdapter.new(self.class.opts[:common_logger])
+        )
+        next exception_page(e) if ENV.fetch("RACK_ENV", nil) == "development"
+
         output_folder = Bridgetown::Current.preloaded_configuration.destination
         File.read(File.join(output_folder, "500.html"))
       rescue Errno::ENOENT
         "500 Internal Server Error"
+      end
+
+      ::Roda::RodaPlugins::ExceptionPage.class_eval do
+        def self.css
+          <<~CSS
+            html * { padding:0; margin:0; }
+            body * { padding:10px 20px; }
+            body * * { padding:0; }
+            body { font-family: -apple-system, sans-serif; font-size: 90%; }
+            body>div { border-bottom:1px solid #ddd; }
+            code { font-family: ui-monospace, monospace; }
+            h1 { font-weight: bold; margin-block-end: .8em; }
+            h2 { margin-block-end:.8em; }
+            h2 span { font-size:80%; color:#f7f7db; font-weight:normal; }
+            h3 { margin:1em 0 .5em 0; }
+            h4 { margin:0 0 .5em 0; font-weight: normal; }
+            table {
+                border:1px solid #ccc; border-collapse: collapse; background:white; }
+            tbody td, tbody th { vertical-align:top; padding:2px 3px; }
+            thead th {
+                padding:1px 6px 1px 3px; background:#fefefe; text-align:left;
+                font-weight:normal; font-size:11px; border:1px solid #ddd; }
+            tbody th { text-align:right; opacity: 0.7; padding-right:.5em; }
+            table.vars { margin:5px 0 2px 40px; }
+            table.vars td, table.req td { font-family: ui-monospace, monospace; }
+            table td.code { width:100%;}
+            table td.code div { overflow:hidden; }
+            table.source th { color:#666; }
+            table.source td {
+                font-family: ui-monospace, monospace; white-space:pre; border-bottom:1px solid #eee; }
+            ul.traceback { list-style-type:none; }
+            ul.traceback li.frame { margin-bottom:1em; }
+            div.context { margin: 10px 0; }
+            div.context ol {
+                padding-left:30px; margin:0 10px; list-style-position: inside; }
+            div.context ol li {
+                font-family: ui-monospace, monospace; white-space:pre; color:#666; cursor:pointer; }
+            div.context ol.context-line li { color:black; background-color:#f7f7db; }
+            div.context ol.context-line li span { float: right; }
+            div.commands { margin-left: 40px; }
+            div.commands a { color:black; text-decoration:none; }
+            #summary { background: #1D453C; color: white; }
+            #summary h2 { font-weight: normal; color: white; }
+            #summary ul#quicklinks { list-style-type: none; margin-bottom: 2em; }
+            #summary ul#quicklinks li { float: left; padding: 0 1em; }
+            #summary ul#quicklinks>li+li { border-left: 1px #666 solid; }
+            #summary a { color: #f47c3c; }
+            #explanation { background:#eee; }
+            #traceback { background: white; }
+            #requestinfo { background:#f6f6f6; padding-left:120px; }
+            #summary table { border:none; background:transparent; }
+            #requestinfo h2, #requestinfo h3 { position:relative; margin-left:-100px; }
+            #requestinfo h3 { margin-bottom:-1em; }
+            .error { background: #ffc; }
+            .specific { color:#cc3300; font-weight:bold; }
+          CSS
+        end
       end
 
       before do

--- a/bridgetown-core/lib/site_template/src/404.html
+++ b/bridgetown-core/lib/site_template/src/404.html
@@ -5,5 +5,6 @@ layout: default
 
 <h1>404</h1>
 
-<p><strong>Page not found :(</strong></p>
+<h2>Page Not Found :(</h2>
+
 <p>The requested page could not be found.</p>

--- a/bridgetown-core/lib/site_template/src/500.html
+++ b/bridgetown-core/lib/site_template/src/500.html
@@ -1,0 +1,10 @@
+---
+permalink: /500.html
+layout: default
+---
+
+<h1>500</h1>
+
+<h2>Internal Server Error :(</h2>
+
+<p>The requested page could not be delivered.</p>

--- a/bridgetown-core/test/ssr/server/roda_app.rb
+++ b/bridgetown-core/test/ssr/server/roda_app.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RodaApp < Bridgetown::Rack::Roda
+  plugin :common_logger, StringIO.new # swallow logs in tests
+
   plugin :bridgetown_ssr do |site|
     site.data.iterations ||= 0
     site.data.iterations += 1

--- a/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
@@ -41,7 +41,7 @@ module Bridgetown
               #{code}
             end
           RUBY
-          instance_eval(code, file, -1)
+          instance_eval(code, file, ruby_content ? 1 : 0)
         end
       end
     end


### PR DESCRIPTION
No more "500 Internal Server Error" pages in development with zero context. Now we get a nice Rails-y Roda exception page with context info, plus much better exception logging. Also adds a 500.html file which would be used in production.