### PR TITLE
Ensure gem-based Builders are part of priority sorting

### DIFF
--- a/bridgetown-builder/lib/bridgetown-builder.rb
+++ b/bridgetown-builder/lib/bridgetown-builder.rb
@@ -12,12 +12,14 @@ module Bridgetown
 end
 
 Bridgetown::Hooks.register_one :site, :pre_read, priority: :low, reloadable: false do |site|
+  builders = Bridgetown::Builders::PluginBuilder.plugin_registrations.to_a
+
   # SiteBuilder is the superclass sites can subclass to create any number of
   # builders, but if the site hasn't defined it explicitly, this is a no-op
-  if defined?(SiteBuilder)
-    SiteBuilder.descendants.sort.map do |c|
-      c.new(c.name, site).build_with_callbacks
-    end
+  builders += SiteBuilder.descendants if defined?(SiteBuilder)
+
+  builders.sort.map do |c|
+    c.new(c.name, site).build_with_callbacks
   end
 end
 

--- a/bridgetown-builder/lib/bridgetown-builder/builder.rb
+++ b/bridgetown-builder/lib/bridgetown-builder/builder.rb
@@ -10,9 +10,7 @@ module Bridgetown
 
     class << self
       def register
-        Bridgetown::Hooks.register_one :site, :pre_read, reloadable: false do |site|
-          new(name, site).build_with_callbacks
-        end
+        Bridgetown::Builders::PluginBuilder.plugin_registrations << self
       end
 
       def before_build(*args, **kwargs, &block)

--- a/bridgetown-builder/lib/bridgetown-builder/plugin.rb
+++ b/bridgetown-builder/lib/bridgetown-builder/plugin.rb
@@ -31,6 +31,12 @@ module Bridgetown
 
       attr_accessor :functions, :name, :site, :config
 
+      class << self
+        def plugin_registrations
+          @plugin_registrations ||= Set.new
+        end
+      end
+
       def initialize(name = nil, current_site = nil)
         self.functions = Set.new
         self.name = name || self.class.name

--- a/bridgetown-core/lib/bridgetown-core/commands/registrations.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/registrations.rb
@@ -4,12 +4,11 @@ module Bridgetown
   module Commands
     module Registrations
       def self.registrations
-        @registrations || []
+        @registrations ||= []
       end
 
       def self.register(&block)
-        @registrations ||= []
-        @registrations.push(block)
+        registrations << block
       end
     end
   end


### PR DESCRIPTION
Fixes #539 (again!)

Also improves display of `bridgetown plugins list` command and adds a `--verbose` flag for printing source paths.