### PR TITLE
Fix migrate-from-webpack process

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/migrate-from-webpack.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/migrate-from-webpack.rb
@@ -2,11 +2,6 @@
 
 # rubocop:disable Layout/LineLength
 
-if package_json["devDependencies"].key?("sass")
-  say "Unable to migrate, project uses Sass. Please migrate to PostCSS first before migrating to esbuild."
-  return
-end
-
 remove_file "webpack.config.js"
 remove_file "config/webpack.defaults.js"
 
@@ -16,7 +11,7 @@ default_postcss_config = File.expand_path("../../../site_template/postcss.config
 template default_postcss_config, "postcss.config.js"
 
 unless Bridgetown.environment.test?
-  required_packages = %w(esbuild glob postcss postcss-flexbugs-fixes postcss-preset-env postcss-import postcss-load-config)
+  required_packages = %w(esbuild glob postcss postcss-flexbugs-fixes postcss-preset-env postcss-import postcss-load-config@3.1.4)
   redundant_packages = %w(esbuild-loader webpack webpack-cli webpack-manifest-plugin webpack-merge css-loader file-loader mini-css-extract-plugin postcss-loader)
 
   say "Installing required packages"


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Since SASS is now again supported in 1.1.0 beta2, I wanted to finally update my blog from webpack to esbuild by running `bridgetown esbuild migrate-from-webpack`. However, in the process, I encountered two problems:

* There is a code that check if SASS is used and blocks from migrating if it is - this is now not necessary
* `postcss-load-config` released a new version few days ago with breaking API, which causes generated config to not work. Version pinning to last working versions is needed.
