### PR TITLE
Update Gemfile template with `nokogiri` commented out

### DIFF
--- a/bridgetown-core/lib/site_template/Gemfile.erb
+++ b/bridgetown-core/lib/site_template/Gemfile.erb
@@ -24,6 +24,10 @@ gem "bridgetown", "~> <%= Bridgetown::VERSION %>"
 # Uncomment to add file-based dynamic routing to your project:
 # gem "bridgetown-routes", "~> <%= Bridgetown::VERSION %>", group: :bridgetown_plugins
 
+# Uncomment to use the Inspectors API to manipulate the output
+# of your HTML or XML resources:
+# gem "nokogiri", "~> 1.13"
+
 # Puma is a Rack-compatible server used by Bridgetown
 # (you can optionally limit this to the "development" group)
 gem "puma", "~> 5.6"


### PR DESCRIPTION

This is a 🙋 feature or enhancement.

## Summary

This commit adds `nokogiri` to the default Gemfile, **commented out**, similar to the way Rails adds commented gems like:

```ruby
# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
# gem "image_processing", "~> 1.2"
```

This should make it more apparent, and harder to miss, that `nokogiri` must be added to the bundle to use the Inspectors API. It uses the `Inspectors API` verbiage to make it easy to search for directly in their editor and make it easier to search for on GitHub as people push public sites with this line it.

## Context

The other night, @DRBragg & I were building a site and wanted to test the new Inspectors API. To our dismay, it didn't appear to work and we chalked it up to a bug and were about to give up when my eye finally landed on this line in the docs:

```md
Bridgetown doesn’t directly install the Nokogiri gem, so be sure to run `bundle add nokogiri` if it isn’t already part of your bundle.
```

If I was about to give up, I am sure others would have quit already so I think that this addition could help ensure folks don't try this out, not see their change, and never come back.

## Alternatives

### Approach

I thought of a few alternatives, the main one being that `inspect_html` throws an explicit error if Nokogiri is not installed and the other was moving this line from the docs into an alert or at the top of the page: 

```md
Bridgetown doesn’t directly install the Nokogiri gem, so be sure to run `bundle add nokogiri` if it isn’t already part of your bundle.
```

### Verbiage

I considered using the same sort of pattern that Rails uses but opted for the already established pattern in this file. The alternative would look something like:

```md
# Enable the Inspectors API [https://edge.bridgetownrb.com/docs/plugins/inspectors]
# gem "nokogiri", "~> 1.13"
```

## Possible Issues

When new versions of the gem come out that are `>= 1.13`, we could get into a cycle of always bumping it in the template, but I think that's unnecessary.

If we wanted to, we could make a similar change:

```diff
- # gem "nokogiri", "~> 1.13"
+ # gem "nokogiri", ">= 1.13", "< 2.0" # or even 1.2
```