### PR TITLE
Clarify how to reference static files on the frontend from Webpack/Esbuild

### DIFF
--- a/bridgetown-website/src/_docs/frontend-assets.md
+++ b/bridgetown-website/src/_docs/frontend-assets.md
@@ -143,6 +143,29 @@ You can use the `asset_path` Liquid tag/Ruby helper to reference assets within t
 
 will look for `frontend/images/folder/somefile.png`.
 
+### Globbing multiple assets
+
+If you need to import an entire folder through the frontend pipeline for example with images, here's how to do it:
+
+###### Esbuild
+
+```js
+// frontend/javascript/index.js
+
+import images from '../images/**/*.{jpg,jpeg,png,svg}'
+Object.entries(images).forEach(image => image)
+```
+
+
+##### Webpack
+
+```js
+// frontend/javascript/index.js
+
+require.context('../images', true)
+```
+
+
 ## esbuild Setup
 
 {%@ Note do %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Provide examples for referencing static files with Esbuild and Webpack.

<!--
  Provide a description of what your pull request changes.
-->

## Context

Esbuild and Webpack have a slightly different strategy for referencing static files that are processed by
them. Provide examples to ease use.

Alternatively, we can include those examples directly in the templates, optionally in a commented-out state.

Feel free to close PR if obvious or incorrect.

Thank you!

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
