### PR TITLE
Support kwargs-only method calls for `partial`

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
@@ -79,10 +79,15 @@ module Bridgetown
       Erubi.h(input)
     end
 
-    def partial(partial_name, options = {})
+    def partial(partial_name = nil, **options, &block)
+      partial_name = options[:template] if partial_name.nil? && options[:template]
       options.merge!(options[:locals]) if options[:locals]
-      options[:content] = yield if block_given?
+      options[:content] = capture(&block) if block
 
+      _render_partial partial_name, options
+    end
+
+    def _render_partial(partial_name, options)
       partial_path = _partial_path(partial_name, "erb")
       tmpl = site.tmp_cache["partial-tmpl:#{partial_path}"] ||= Tilt::ErubiTemplate.new(
         partial_path,

--- a/bridgetown-core/lib/bridgetown-core/converters/serbea_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/serbea_templates.rb
@@ -7,10 +7,7 @@ module Bridgetown
   class SerbeaView < ERBView
     include Serbea::Helpers
 
-    def partial(partial_name, options = {}, &block)
-      options.merge!(options[:locals]) if options[:locals]
-      options[:content] = capture(&block) if block
-
+    def _render_partial(partial_name, options)
       partial_path = _partial_path(partial_name, "serb")
       tmpl = site.tmp_cache["partial-tmpl:#{partial_path}"] ||=
         Tilt::SerbeaTemplate.new(partial_path)

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -22,16 +22,16 @@ module Bridgetown
       @site = page.site
     end
 
-    def partial(_partial_name, _options = {})
+    def partial(_partial_name = nil, **_options)
       raise "Must be implemented in a subclass"
     end
 
-    def render(item, options = {}, &block)
+    def render(item, **options, &block)
       if item.respond_to?(:render_in)
         result = item.render_in(self, &block)
         result&.html_safe
       else
-        partial(item, options, &block)&.html_safe
+        partial(item, **options, &block)&.html_safe
       end
     end
 

--- a/bridgetown-core/test/source/src/_layouts/serblayout.serb
+++ b/bridgetown-core/test/source/src/_layouts/serblayout.serb
@@ -9,7 +9,7 @@ layout_var:
 
 {%= yield %}
 
-{%= partial "testing/partials", locals: { yes: "yes." } %}
+{%= partial template: "testing/partials", locals: { yes: "yes." } %}
 {%= render "testing/partials", yes: "YES!!" %}
 
 <footer>{%= site.time %} / {%= Bridgetown::VERSION %}</footer>

--- a/bridgetown-website/plugins/builders/inspectors.rb
+++ b/bridgetown-website/plugins/builders/inspectors.rb
@@ -14,7 +14,7 @@ class Builders::Inspectors < SiteBuilder
     # LintHTML replacement to find div/span tags
     inspect_html do |document, resource|
       class_allow_list = (
-        Array(site.config.ex_span_sion&.allowed_classes) + %w[highlighter-rouge highlight]
+        Array(site.config.divicide&.allowed_classes) + %w[highlighter-rouge highlight]
       ).uniq
 
       tags = document.query_selector_all("div, span")

--- a/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
@@ -160,6 +160,15 @@ You can also pass variables to partials using either a `locals` hash or as keywo
 <%%= render "some/partial", locals: { key: "value", another_key: 123 } %>
 ```
 
+As an alternative to passing the partial filename as the first argument, you can supply a `template` keyword argument instead. This makes it easier to pass all arguments via a separate hash:
+
+```eruby
+<%% options = { template: "mypartial", title: "Hello!" } %>
+<%%= partial **options %>
+```
+
+Partials also support capture blocks, which can then be referenced via the `content` local variable within the partial.
+
 ## Rendering Ruby Components
 
 For better encapsulation and reuse of Ruby-based templates as part of a "design system" for your site, we encourage you to write Ruby components using either `Bridgetown::Component` or GitHub's ViewComponent library. [Check out the documentation and code examples here](/docs/components/ruby).


### PR DESCRIPTION
Fixes #575, helps along #581

**NOTE:** This change should be replicated in the Slim and Haml plugins.

- [x] Tests
- [x] Documentation