### PR TITLE
feat: Add hash attributes functionality to view tag helpers

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -96,15 +96,28 @@ module Bridgetown
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
       def link_to(text, relative_path, options = {})
-        segments = []
-        segments << "a"
-        segments << "href=\"#{url_for(relative_path)}\""
-        options.each do |attr, option|
-          attr = attr.to_s.tr("_", "-")
-          segments << "#{attr}=\"#{Utils.xml_escape(option)}\""
-        end
+        segments = attributes_from_options({ href: url_for(relative_path) }.merge(options))
+
         # TODO: this might leak an XSS string into text, need to check
-        safe("<#{segments.join(" ")}>#{text}</a>")
+        safe("<a #{segments}>#{text}</a>")
+      end
+
+      # Create a set of attributes from a hash.
+      #
+      # @param options [Hash] key-value pairs of HTML attributes
+      # @return [String]
+      def attributes_from_options(options)
+        segments = []
+        options.each do |attr, option|
+          attr = dashed(attr)
+          if option.is_a?(Hash)
+            option = option.transform_keys { |key| "#{attr}-#{dashed(key)}" }
+            segments << attributes_from_options(option)
+          else
+            segments << attribute_segment(attr, option)
+          end
+        end
+        segments.join(" ")
       end
 
       # Forward all arguments to I18n.t method
@@ -124,6 +137,27 @@ module Bridgetown
         input.to_s.html_safe
       end
       alias_method :raw, :safe
+
+      private
+
+      # Covert an underscored value into a dashed string.
+      #
+      # @example "foo_bar_baz" => "foo-bar-baz"
+      #
+      # @param value [String|Symbol]
+      # @return [String]
+      def dashed(value)
+        value.to_s.tr("_", "-")
+      end
+
+      # Create an attribute segment for a tag.
+      #
+      # @param attr [String] the HTML attribute name
+      # @param value [String] the attribute value
+      # @return [String]
+      def attribute_segment(attr, value)
+        "#{attr}=\"#{Utils.xml_escape(value)}\""
+      end
     end
   end
 end

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -32,6 +32,20 @@ class TestRubyHelpers < BridgetownUnitTest
     should "accept additional attributes" do
       assert_equal "<a href=\"/foo/bar\" class=\"classes\" data-test=\"abc123\">Label</a>", @helpers.link_to("Label", "/foo/bar", class: "classes", data_test: "abc123")
     end
+
+    should "accept hash attributes" do
+      assert_equal "<a href=\"/foo/bar\" class=\"classes\" data-controller=\"test\" data-action=\"test#test\">Label</a>", @helpers.link_to("Label", "/foo/bar", class: "classes", data: { controller: "test", action: "test#test" })
+    end
+  end
+
+  context "attributes_from_options" do
+    should "return an attribute string from a hash" do
+      assert_equal "class=\"classes\" data-test=\"abc123\"", @helpers.attributes_from_options(class: "classes", data_test: "abc123")
+    end
+
+    should "handle nested hashes" do
+      assert_equal "class=\"classes\" data-controller=\"test\" data-action=\"test#test\" data-test-target=\"test_value\" data-test-index-value=\"1\"", @helpers.attributes_from_options(class: "classes", data: { controller: "test", action: "test#test", test: { target: "test_value", index_value: "1" } })
+    end
   end
 
   context "class_map" do

--- a/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
@@ -303,6 +303,14 @@ You can pass additional keyword arguments to `link_to` which will be translated 
 <!-- output: -->
 <a href="/events/livestream" class="event" data-expire="2020-11-08">Join our livestream!</a>
 ```
+Passing a hash as the value of a keyword argument will result in individual attributes in the generated HTML. With the keyword argument key being added to the keys of the incoming hash:
+
+```eruby
+<%%= link_to "Join our livestream!", "_events/livestream.md", data: { controller: "testable", action: "testable#test" } %>
+
+<!-- output: -->
+<a href="/events/livestream" data-controller="testable" data-action="testable#test">Join our livestream!</a>
+```
 
 You can also pass relative or aboslute URLs to `link_to` and they'll just pass-through to the anchor tag without change:
 

--- a/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
@@ -303,7 +303,8 @@ You can pass additional keyword arguments to `link_to` which will be translated 
 <!-- output: -->
 <a href="/events/livestream" class="event" data-expire="2020-11-08">Join our livestream!</a>
 ```
-Passing a hash as the value of a keyword argument will result in individual attributes in the generated HTML. With the keyword argument key being added to the keys of the incoming hash:
+
+In order to simplify more complex lists of HTML attributes you may also pass a hash as the value of one of the keyword arguments.  This will convert all pairs in the hash into HTML attributes and prepend each key in the hash with the keyword argument:
 
 ```eruby
 <%%= link_to "Join our livestream!", "_events/livestream.md", data: { controller: "testable", action: "testable#test" } %>
@@ -311,6 +312,8 @@ Passing a hash as the value of a keyword argument will result in individual attr
 <!-- output: -->
 <a href="/events/livestream" data-controller="testable" data-action="testable#test">Join our livestream!</a>
 ```
+
+`link_to` uses [`attributes_from_options`](#attributes_from_options) under the hood to handle this converstion.
 
 You can also pass relative or aboslute URLs to `link_to` and they'll just pass-through to the anchor tag without change:
 
@@ -325,6 +328,24 @@ Finally, if you pass a Ruby object (i.e., it responds to `url`), it will work as
 
 <!-- output: -->
 <a href="/this/is/my-last-page">My last page</a>
+```
+
+## Other HTML Helpers
+
+### attributes_from_options
+`attributes_from_options` allows you to pass a hash and have it converted to a string of HTML attributes:
+```eruby
+<p <%= attributes_from_options({ class: "my-class", id: "some-id" }) %>>Hello, World!</p>
+
+<!-- output: -->
+<p class="my-class" id="some-id">Hello, World!</p>
+```
+`attributes_from_options` also allows for any value of the passed hash to itself be a hash. This will result in individual attributes being created from each pair in the hash. When doing this, the key the hash was paired with will be prepended to each attribute name:
+```eruby
+<button <%= attributes_from_options({ data: { controller: "clickable", action: "click->clickable#test" } }) %>>Click Me!</button>
+
+<!-- output: -->
+<button data-controller="clickable" data-action="click->clickable#test">Click Me!</button>
 ```
 
 ## Capture Helper


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds the ability to pass a hash to `link_to` (or call `attributes_from_options` to use on any HTML tag) and have the key-value pairs be listed as HTML attributes.

Example:

```ruby
<%= link_to "Label", "/foo/bar", class: "classes", data: { controller: "testable", action: "testable#test" } %>
```
would return:
```html
<a href="/foo/bar" class="classes" data-controller="testable" data-action="testable#test">Label</a>
```
You also have the ability to pass a hash as a keys value and have the values keys merged with the parent key. So:
```ruby
<%= link_to "Label", "/foo/bar", class: "classes", data: { controller: "testable", action: "testable#test", testable: { target: "test_value", index_value: "1" } } %>
```
would return:
```html
<a href="/foo/bar" class="classes" data-controller="testable" data-action="testable#test" data-testable-target="test_value" data-testable-index-value="1">Label</a>
```
This is very helpful when using stimulus controllers.

If you wanted to use this on a different HTML tag you could do:
```ruby
<div <%= attributes_from_options(class: "classes", data: { controller: "testable", action: "testable#test" }) %>>Content</div>
```
and you'd be left with:
```html
<div class="classes" data-controller="testable" data-action="testable#test">Content</div>
```

Naming is hard so I'm definitely open to suggests (I sorta hate `attributes_from_options` TBH).

Let me know if anything isn't to your liking and I'm happy to adjust!

## Context

Close #537 
