### PR TITLE
Update `postcss-load-config` to `4.x` and address synchronisation issues (*breaking change*)

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -84,7 +84,7 @@ const importGlobPlugin = () => ({
 })
 
 // Plugin for PostCSS
-const postCssPlugin = (options, configuration) => ({
+const importPostCssPlugin = (options, configuration) => ({
   name: "postcss",
   async setup(build) {
     // Process .css files with PostCSS
@@ -98,7 +98,7 @@ const postCssPlugin = (options, configuration) => ({
         load: async filename => {
           let contents = await readCache(filename, "utf-8")
           const filedir = path.dirname(filename)
-          // We'll want to track any imports later when in watch mode:          
+          // We'll want to track any imports later when in watch mode:
           additionalFilePaths.push(filename)
 
           // We need to transform `url(...)` in imported CSS so the filepaths are properly
@@ -262,7 +262,7 @@ const postCssConfig = postcssrc.sync()
 module.exports = (outputFolder, esbuildOptions) => {
   esbuildOptions.plugins = esbuildOptions.plugins || []
   // Add the PostCSS & glob plugins to the top of the plugin stack
-  esbuildOptions.plugins.unshift(postCssPlugin(postCssConfig, esbuildOptions.postCssPluginConfig || {}))
+  esbuildOptions.plugins.unshift(importPostCssPlugin(postCssConfig, esbuildOptions.postCssPluginConfig || {}))
   if (esbuildOptions.postCssPluginConfig) delete esbuildOptions.postCssPluginConfig
   esbuildOptions.plugins.unshift(importGlobPlugin())
   // Add the Sass plugin

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -257,11 +257,11 @@ const bridgetownPreset = (outputFolder) => ({
 
 // Load the PostCSS config from postcss.config.js or whatever else is a supported location/format
 const postcssrc = require("postcss-load-config")
-const postCssConfig = postcssrc.sync()
 
-module.exports = (outputFolder, esbuildOptions) => {
+module.exports = async (outputFolder, esbuildOptions) => {
   esbuildOptions.plugins = esbuildOptions.plugins || []
   // Add the PostCSS & glob plugins to the top of the plugin stack
+  const postCssConfig = await postcssrc()
   esbuildOptions.plugins.unshift(importPostCssPlugin(postCssConfig, esbuildOptions.postCssPluginConfig || {}))
   if (esbuildOptions.postCssPluginConfig) delete esbuildOptions.postCssPluginConfig
   esbuildOptions.plugins.unshift(importGlobPlugin())

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/migrate-from-webpack.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/migrate-from-webpack.rb
@@ -11,7 +11,7 @@ default_postcss_config = File.expand_path("../../../site_template/postcss.config
 template default_postcss_config, "postcss.config.js"
 
 unless Bridgetown.environment.test?
-  required_packages = %w(esbuild glob postcss postcss-flexbugs-fixes postcss-preset-env postcss-import postcss-load-config@3.1.4)
+  required_packages = %w(esbuild glob postcss postcss-flexbugs-fixes postcss-preset-env postcss-import postcss-load-config@4.0.1)
   redundant_packages = %w(esbuild-loader webpack webpack-cli webpack-manifest-plugin webpack-merge css-loader file-loader mini-css-extract-plugin postcss-loader)
 
   say "Installing required packages"

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
@@ -5,14 +5,17 @@
 // This plugin will let you import `.lit.css` files as sidecar stylesheets.
 // Read https://edge.bridgetownrb.com/docs/components/lit#sidecar-css-files for documentation.
 const { litCssPlugin } = require("esbuild-plugin-lit-css")
-const postCssConfig = require("postcss-load-config").sync()
-const postCssProcessor = require("postcss")([...postCssConfig.plugins])
+const postcssrc = require("postcss-load-config")
+const postcss = require("postcss")
 
 module.exports = {
   plugins: [
     litCssPlugin({
       filter: /\.lit\.css$/,
       transform: async (css, { filePath }) => {
+        const postCssConfig = await postcssrc()
+        const postCssProcessor = postcss([...postCssConfig.plugins])
+
         const results = await postCssProcessor.process(css, { ...postCssConfig.options, from: filePath })
         return results.css
       }

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -27,7 +27,7 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     <%- if frontend_bundling_option == "esbuild" -%>
     "postcss-import": "^14.1.0",
-    "postcss-load-config": "^3.1.4",
+    "postcss-load-config": "^4.0.1",
     <%- else -%>
     "postcss-loader": "^6.2.1",
     <%- end -%>


### PR DESCRIPTION
This is a 🐛 bug fix (?)

## Summary

As reported in #591, `postcss-load-config` introduced a breaking change in their latest major version update: `4.x`. Instead of loading the configuration in a synchronous way, it's needed to load the configuration in an asynchronous way.

The PR;
- Allows loading the PostCSS configuration under `postcss-load-config > 4.x` again.
- Updates the `postcss-load-config` references from `3.1.4` to `4.0.1`.
- Updates the template for the `lit/esbuild-plugins` to also use the asynchronous API.
- Updates the naming of the "import" function of the PostCSS plugin to align it with the other "import" functions in the `esbuild.defaults.js`.

I'm a bit rusty on my JavaScript, so I'm looking for feedback on the proposed `async/await` changes. I'm also not sure how I could add a test case for this and whether or not I should add a test case for this fix.

I also wonder whether or not you'd want to support both `3.x` and `4.x` versions of the `postcss-load-config` package as I'd need to provide a way to use both versions to get the configuration object.

I tested out things locally with the latest version of `postcss-load-config` and was able to build the Bridgetown site again with the new configuration.

## Context

Fixes #591 
