### PR TITLE
Provide esbuild config typing via JSDoc

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.config.js
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.config.js
@@ -26,6 +26,11 @@ const outputFolder = "output"
 // ```
 // const esbuildOptions = { publicPath: "/my_subfolder/_bridgetown/static" }
 // ```
+
+/**
+ * @typedef { import("esbuild").BuildOptions } BuildOptions
+ * @type {BuildOptions}
+ */
 const esbuildOptions = {}
 
 build(outputFolder, esbuildOptions)


### PR DESCRIPTION
In editors like VSCode which can providing typing and documentation hovers through TypeScript-interpreted JSDoc, this will make it easier to edit the esbuild config and get links to esbuild documentation.