### PR TITLE
Include subdirectories of src/_locales in I18n loader

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -7,9 +7,7 @@ class Bridgetown::Site
     def locale
       @locale ||= begin
         locale = ENV.fetch("BRIDGETOWN_LOCALE", config[:default_locale]).to_sym
-        Dir["#{in_source_dir("_locales")}/*.{json,rb,yml}"].each do |locale_path|
-          I18n.load_path << locale_path
-        end
+        I18n.load_path += Dir["#{in_source_dir("_locales")}/**/*.{json,rb,yml}"]
         I18n.available_locales = config[:available_locales]
         I18n.default_locale = locale
         I18n.fallbacks = (config[:available_locales] + [:en]).uniq.to_h do |available_locale|


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Updates I18n.load_path to include subdirectories of src/_locales.
<!--
  Provide a description of what your pull request changes.
-->

## Context

Relates to the first part of #598
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
