### PR TITLE
Use regional fallbacks from i18n

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/localizable.rb
@@ -12,9 +12,7 @@ class Bridgetown::Site
         end
         I18n.available_locales = config[:available_locales]
         I18n.default_locale = locale
-        I18n.fallbacks = (config[:available_locales] + [:en]).uniq.to_h do |available_locale|
-          [available_locale, [available_locale, locale, :en].uniq]
-        end
+        I18n.fallbacks = [locale, :en].uniq
         locale
       end
     end

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -165,4 +165,40 @@ class TestLocales < BridgetownUnitTest
       end
     end
   end
+
+  context "fallback chain" do
+    setup do
+      reset_i18n_config
+      @site = resources_site
+      @site.process
+    end
+
+    should "include English for base language" do
+      assert_equal %i[de en], I18n.fallbacks[:de]
+      assert_equal %i[fr en], I18n.fallbacks[:fr]
+    end
+
+    should "include English and base language for regional locale" do
+      assert_equal %i[de-NL de en], I18n.fallbacks[:"de-NL"]
+      assert_equal %i[fr-CA fr en], I18n.fallbacks[:"fr-CA"]
+    end
+  end
+
+  context "fallback chain with different default locale" do
+    setup do
+      reset_i18n_config
+      @site = resources_site("default_locale" => :es, "available_locales" => %w[en es])
+      @site.process
+    end
+
+    should "include both the default language and English in the fallback chain" do
+      assert_equal %i[de es en], I18n.fallbacks[:de]
+      assert_equal %i[es en], I18n.fallbacks[:es]
+    end
+
+    should "include base language, default, and English for regional language" do
+      assert_equal %i[de-NL de es en], I18n.fallbacks[:"de-NL"]
+      assert_equal %i[es-MX es en], I18n.fallbacks[:"es-MX"]
+    end
+  end
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement. 
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Updates i18n fallback chain to include base languages for regional variants (e.g. fr-CA falls back to fr before en).
Or, more specifically, adds the default locale (and English) to the existing fallbacks defined by the I18n backend.

<!--
  Provide a description of what your pull request changes.
-->

## Context

Second part of #598.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
