### PR TITLE
Specify production BRIDGETOWN_ENV for Github Pages builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- New GitHub Pages configurations will deploy a production build
 
 ## [1.1.0] — 2022-07-18
 

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Bridgetown is built by:
 |<a href="https://github.com/nachoal">@nachoal</a>|<a href="https://github.com/deivid-rodriguez">@deivid-rodriguez</a>|<a href="https://github.com/Eric-Guo">@Eric-Guo</a>|<a href="https://github.com/jacobherrington">@jacobherrington</a>|<a href="https://github.com/fpsvogel">@fpsvogel</a>|
 |CDMX, México|Madrid, Spain|Shanghai, China|Fayetteville, AR|Lexington, KY|
 
-|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
-|:---:|
-|You Next?|
-|Anywhere|
+|<img src="https://avatars.githubusercontent.com/vvveebs?s=256" alt="vvveebs" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
+|:---:|:---:|
+|<a href="https://github.com/vvveebs">@vvveebs</a>|You Next?|
+|London, UK|Anywhere|
 
 Interested in joining the Bridgetown Core Team? Send a DM to Jared in [Discord](https://discord.gg/4E6hktQGz4) and let's chat!
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/gh-pages/gh-pages.yml
+++ b/bridgetown-core/lib/bridgetown-core/configurations/gh-pages/gh-pages.yml
@@ -24,7 +24,9 @@ jobs:
       - run: yarn install
 
       - name: Build
-        run: bin/bridgetown deploy
+        env:
+          BRIDGETOWN_ENV: production
+        run:  bin/bridgetown deploy
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

The current GitHub Pages configuration builds the site using the default `development` environment.

This PR updates the relevant configuration to use the `production` environment instead as I think that's always going to be the intention for this workflow, and it matches other configurations such as [Netlify](https://github.com/bridgetownrb/bridgetown/blob/main/bridgetown-core/lib/bridgetown-core/configurations/netlify/netlify.toml#L7).