### PR TITLE
Add SEO and feed configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - New GitHub Pages configurations will deploy a production build
+- Add an seo configuration (bridgetown-seo-tag gem)
+- Add a feed configuration (bridgetown-feed gem)
 
 ## [1.1.0] — 2022-07-18
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/feed.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/feed.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+say_status :feed, "Adding bridgetown-feed gem"
+
+bundle_command = <<~BUNDLE
+  bundle info bridgetown-feed ||
+  bundle add bridgetown-feed -g bridgetown_plugins
+BUNDLE
+
+run bundle_command, { verbose: false, capture: true }
+
+say_status :feed, "Adding feed tags"
+
+head_file = Dir.glob("src/**/{head.liquid,_head.erb,_head.serb}").first
+
+unless head_file
+  say_status :feed, "Feed tags could not be automatically inserted"
+  say_status :feed, "To enable, output `feed` in the application <head> element" \
+                    "using the relevant template language tags"
+  say ""
+  say "For help with tag configuration see #{"https://github.com/bridgetownrb/bridgetown-feed#readme".yellow.bold}"
+
+  return
+end
+
+File.open(head_file, "a+") do |file|
+  feed_tag = Bridgetown::Utils.build_output_tag_for_template_extname(
+    File.extname(head_file),
+    "feed_meta"
+  )
+
+  file.write("#{feed_tag}\n") unless file.grep(%r{#{feed_tag}}).any?
+
+  say ""
+  say_status :feed, "Feed tags added to #{head_file}"
+  say_status :feed, "For help with tag configuration see #{"https://github.com/bridgetownrb/bridgetown-feed#readme".yellow.bold}"
+end

--- a/bridgetown-core/lib/bridgetown-core/configurations/seo.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/seo.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+say_status :seo, "Adding bridgetown-seo-tag gem"
+
+bundle_command = <<~BUNDLE
+  bundle info bridgetown-seo-tag ||
+  bundle add bridgetown-seo-tag -g bridgetown_plugins
+BUNDLE
+
+run bundle_command, { verbose: false, capture: true }
+
+say_status :seo, "Adding SEO tags"
+
+head_file = Dir.glob("src/**/{head.liquid,_head.erb,_head.serb}").first
+
+unless head_file
+  say_status :seo, "SEO tags could not be automatically inserted"
+  say_status :seo, "To enable SEO, output `seo` in the application <head> element" \
+                   "using the relevant template language tags"
+  say ""
+  say "For help with tag configuration see #{"https://github.com/bridgetownrb/bridgetown-seo-tag#readme".yellow.bold}"
+
+  return
+end
+
+File.open(head_file, "a+") do |file|
+  seo_tag = Bridgetown::Utils.build_output_tag_for_template_extname(File.extname(head_file), "seo")
+
+  file.write("#{seo_tag}\n") unless file.grep(%r{#{seo_tag}}).any?
+
+  say ""
+  say_status :seo, "SEO tags added to #{head_file}"
+  say_status :seo, "For help with tag configuration see #{"https://github.com/bridgetownrb/bridgetown-seo-tag#readme".yellow.bold}"
+end

--- a/bridgetown-core/test/test_utils.rb
+++ b/bridgetown-core/test/test_utils.rb
@@ -435,4 +435,24 @@ class TestUtils < BridgetownUnitTest
       assert_equal "master", Utils.default_github_branch_name("https://github.com/thisorgdoesntexist/thisrepoistotallybogus")
     end
   end
+
+  context "The \`Utils.build_output_tag_for_template_extname\` method" do
+    setup do
+      Utils::TEMPLATE_EXTNAMES_TAGS = {
+        ".liquid" => ["{%", "%}"],
+        ".erb"    => ["<%=", "%>"],
+      }.freeze
+    end
+
+    should "return content within tags for the supplied file extname" do
+      assert_equal "{% content %}", Utils.build_output_tag_for_template_extname(".liquid", "content")
+      assert_equal "<%= content %>", Utils.build_output_tag_for_template_extname(".erb", "content")
+    end
+
+    should "raise an error if the supplied extname is not supported" do
+      assert_raises do
+        Utils.build_output_tag_for_template_extname(".not_a_template_engine", "content")
+      end
+    end
+  end
 end

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -24,6 +24,8 @@ The configurations we include are:
 - [GitHub Pages Configuration](#github-pages-configuration) (`gh-pages`)
 - [Automated Test Suite using Minitest](#automated-test-suite-using-minitest) (`minitesting`)
 - [Cypress](#cypress) (`cypress`)
+- [SEO](#seo) (`seo`)
+- [Feed (RSS-like)](#feed) (`feed`)
 
 The full list of configurations can also be seen by running `bridgetown configure` without arguments.
 
@@ -207,4 +209,24 @@ bin/bridgetown configure minitesting
 
 ```sh
 bin/bridgetown configure cypress
+```
+
+### SEO
+
+🔍 Adds metadata tags for search engines and social networks to better index and display your site's content. Check out the [gem readme](https://github.com/bridgetownrb/bridgetown-seo-tag#summary) for more info and configuration options.
+
+🛠 **Configure using:**
+
+```sh
+bin/bridgetown configure seo
+```
+
+### Feed
+
+🍽️ Generate an Atom (RSS-like) feed of your Bridgetown posts and other collection documents. Check out the [gem readme](https://github.com/bridgetownrb/bridgetown-feed#usage) for more info and configuration options.
+
+🛠 **Configure using:**
+
+```sh
+bin/bridgetown configure feed
 ```


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Adds SEO and Atom feed configurations for the relevant gems.

## Context

Resolves #228

## Example output

![D1F4A09E9136A1E34605340E3B122DAE](https://user-images.githubusercontent.com/1370570/184537153-eef56803-bb41-4368-815c-2a61a4d65117.jpg)


