### PR TITLE
Use correct ERB syntax in docs

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -98,7 +98,6 @@ module Bridgetown
       def link_to(text, relative_path, options = {})
         segments = attributes_from_options({ href: url_for(relative_path) }.merge(options))
 
-        # TODO: this might leak an XSS string into text, need to check
         safe("<a #{segments}>#{text}</a>")
       end
 
@@ -117,7 +116,7 @@ module Bridgetown
             segments << attribute_segment(attr, option)
           end
         end
-        segments.join(" ")
+        safe(segments.join(" "))
       end
 
       # Forward all arguments to I18n.t method

--- a/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
+++ b/bridgetown-website/src/_docs/template-engines/erb-and-beyond.md
@@ -344,14 +344,14 @@ Finally, if you pass a Ruby object (i.e., it responds to `url`), it will work as
 ### attributes_from_options
 `attributes_from_options` allows you to pass a hash and have it converted to a string of HTML attributes:
 ```eruby
-<p <%= attributes_from_options({ class: "my-class", id: "some-id" }) %>>Hello, World!</p>
+<p <%%= attributes_from_options({ class: "my-class", id: "some-id" }) %>>Hello, World!</p>
 
 <!-- output: -->
 <p class="my-class" id="some-id">Hello, World!</p>
 ```
 `attributes_from_options` also allows for any value of the passed hash to itself be a hash. This will result in individual attributes being created from each pair in the hash. When doing this, the key the hash was paired with will be prepended to each attribute name:
 ```eruby
-<button <%= attributes_from_options({ data: { controller: "clickable", action: "click->clickable#test" } }) %>>Click Me!</button>
+<button <%%= attributes_from_options({ data: { controller: "clickable", action: "click->clickable#test" } }) %>>Click Me!</button>
 
 <!-- output: -->
 <button data-controller="clickable" data-action="click->clickable#test">Click Me!</button>


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

I made a goof in #589. A few of the ERB expressions in the docs for `attributes_from_options` were being evaluated within the template. Adjusting the syntax from  `<%=`  to `<%%=`, so it’s escaped, should fix the issue.

## Context

re: Twitter convo w/ @jaredcwhite 
