### PR TITLE
Silence keyword arguments warning in ruby 2.7

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -123,8 +123,8 @@ module Bridgetown
       #
       # @return [String] the translated string
       # @see I18n
-      def t(*args)
-        I18n.send :t, *args
+      def t(*args, **kwargs)
+        I18n.send :t, *args, **kwargs
       end
 
       # For template contexts where ActiveSupport's output safety is loaded, we


### PR DESCRIPTION
Silence a warning under ruby 2.7.

```
site/.direnv/ruby/gems/bridgetown-core-1.1.0/lib/bridgetown-core/helpers.rb:115: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
site/.direnv/ruby/gems/i18n-1.12.0/lib/i18n.rb:210: warning: The called method `t' is defined here
```

Here is a similar fix in Rails, a while ago:

https://github.com/rails/rails/commit/adef6323e682e026ea6bdbf3a6eb187491f0fbd6#diff-9c5e802c729a438537b41a02f0b08eb594855d8bebcd0ff2e3452fc6a999375d

For reference, here is the issue in i18n gem (but I think this must be solved in this repo):
https://github.com/ruby-i18n/i18n/issues/516

***

I've only tested this quickly on my machine, but I think it should work.