### PR TITLE
Add gemspec metadata for all gems

### DIFF
--- a/bridgetown-builder/bridgetown-builder.gemspec
+++ b/bridgetown-builder/bridgetown-builder.gemspec
@@ -14,5 +14,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r!^(test|script|spec|features)/!) }
   spec.require_paths = ["lib"]
 
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/bridgetownrb/bridgetown",
+    "bug_tracker_uri" => "https://github.com/bridgetownrb/bridgetown/issues",
+    "changelog_uri"   => "https://github.com/bridgetownrb/bridgetown/releases",
+    "homepage_uri"    => spec.homepage,
+  }
+
   spec.add_dependency("bridgetown-core", Bridgetown::VERSION)
 end

--- a/bridgetown-paginate/bridgetown-paginate.gemspec
+++ b/bridgetown-paginate/bridgetown-paginate.gemspec
@@ -14,5 +14,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r!^(test|script|spec|features)/!) }
   spec.require_paths = ["lib"]
 
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/bridgetownrb/bridgetown",
+    "bug_tracker_uri" => "https://github.com/bridgetownrb/bridgetown/issues",
+    "changelog_uri"   => "https://github.com/bridgetownrb/bridgetown/releases",
+    "homepage_uri"    => spec.homepage,
+  }
+
   spec.add_dependency("bridgetown-core", Bridgetown::VERSION)
 end

--- a/bridgetown-routes/bridgetown-routes.gemspec
+++ b/bridgetown-routes/bridgetown-routes.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r!^(test|script|spec|features)/!) }
   spec.require_paths = ["lib"]
 
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/bridgetownrb/bridgetown",
+    "bug_tracker_uri" => "https://github.com/bridgetownrb/bridgetown/issues",
+    "changelog_uri"   => "https://github.com/bridgetownrb/bridgetown/releases",
+    "homepage_uri"    => spec.homepage,
+  }
+
   spec.add_dependency("bridgetown-core", Bridgetown::VERSION)
   spec.add_dependency("roda-route_list", ">= 2.1")
 end

--- a/bridgetown/bridgetown.gemspec
+++ b/bridgetown/bridgetown.gemspec
@@ -16,6 +16,13 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_path = "lib"
 
+  s.metadata      = {
+    "source_code_uri" => "https://github.com/bridgetownrb/bridgetown",
+    "bug_tracker_uri" => "https://github.com/bridgetownrb/bridgetown/issues",
+    "changelog_uri"   => "https://github.com/bridgetownrb/bridgetown/releases",
+    "homepage_uri"    => s.homepage,
+  }
+
   s.required_ruby_version     = ">= 2.7.0"
 
   s.add_dependency("bridgetown-core", Bridgetown::VERSION)


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

In trying to get to the repository for `bridgetown`, I noticed that the main gem didn't have metadata set up for RubyGems.org. This change adds the same metadata from `bridgetown-core` to all four other gems in the repository to make it easier to get to the source code and other areas.

## Context

[`bridgetown` 1.1.0 on RubyGems.org](https://rubygems.org/gems/bridgetown/versions/1.1.0)