### PR TITLE
fix: esbuild entrypoint selection for index.css

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -231,9 +231,10 @@ const bridgetownPreset = (outputFolder) => ({
           // We have an entrypoint!
           manifest[stripPrefix(value.entryPoint)] = outputPath
           entrypoints.push([outputPath, fileSize(key)])
-        } else if (key.match(/index(\.js)?\.[^-.]*\.css/) && inputs.find(item => item.match(/\.(s?css|sass)$/))) {
+        } else if (key.match(/index(\.js)?\.[^-.]*\.css/) && inputs.find(item => item.match(/frontend.*\.(s?css|sass)$/))) {
           // Special treatment for index.css
-          manifest[stripPrefix(inputs.find(item => item.match(/\.(s?css|sass)$/)))] = outputPath
+          const input = inputs.find(item => item.match(/frontend.*\.(s?css|sass)$/))
+          manifest[stripPrefix(input)] = outputPath
           entrypoints.push([outputPath, fileSize(key)])
         } else if (inputs.length > 0) {
           // Naive implementation, we'll just grab the first input and hope it's accurate


### PR DESCRIPTION
Fixes problems when referencing node_modules that are defining "index.css" themself, such as fontsource-packages. In such cases the manifest would reference the wrong file and the "frontend/index.scss" would be missing from the manifest and produce 404 errors.

This is a 🐛 bug fix. 

## Context

Fixes #616
