### PR TITLE
feat: allow template to use `data` directly instead of `resource.data`

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/converters/liquid_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/liquid_templates.rb
@@ -89,6 +89,7 @@ module Bridgetown
         payload["paginator"] = document.respond_to?(:paginator) ? document.paginator.to_liquid : nil
         payload["layout"] = @layout ? @layout.to_liquid.merge({ data: @layout.data }) : {}
         payload["content"] = content
+        payload["data"] = payload["page"].data
       end
 
       def liquid_context

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -22,6 +22,10 @@ module Bridgetown
       @site = page.site
     end
 
+    def data
+      resource.data
+    end
+
     def partial(_partial_name = nil, **_options)
       raise "Must be implemented in a subclass"
     end

--- a/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/default.erb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/default.erb
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="<%= site.locale %>">
   <head>
-    <%= render "head", metadata: site.metadata, title: resource.data.title %>
+    <%= render "head", metadata: site.metadata, title: data.title %>
   </head>
-  <body class="<%= resource.data.layout %> <%= resource.data.page_class %>">
+  <body class="<%= data.layout %> <%= data.page_class %>">
     <%= render Shared::Navbar.new(metadata: site.metadata, resource: resource) %>
 
     <main>

--- a/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/page.erb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/page.erb
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1><%= resource.data.title %></h1>
+<h1><%= data.title %></h1>
 
 <%= yield %>

--- a/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/post.erb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/erb/_layouts/post.erb
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1><%= resource.data.title %></h1>
+<h1><%= data.title %></h1>
 
 <%= yield %>

--- a/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/default.liquid
+++ b/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/default.liquid
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="{{ site.locale }}">
   <head>
-    {% render "head", metadata: site.metadata, title: resource.data.title %}
+    {% render "head", metadata: site.metadata, title: data.title %}
   </head>
-  <body class="{{ resource.data.layout }} {{ resource.data.page_class }}">
+  <body class="{{ data.layout }} {{ data.page_class }}">
     {% render "navbar", metadata: site.metadata, resource: resource %}
 
     <main>

--- a/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/page.liquid
+++ b/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/page.liquid
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1>{{ page.title }}</h1>
+<h1>{{ data.title }}</h1>
 
 {{ content }}

--- a/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/post.liquid
+++ b/bridgetown-core/lib/site_template/TEMPLATES/liquid/_layouts/post.liquid
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1>{{ page.title }}</h1>
+<h1>{{ data.title }}</h1>
 
 {{ content }}

--- a/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/default.serb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/default.serb
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="{%= site.locale %}">
   <head>
-    {%@ "head", metadata: site.metadata, title: resource.data.title %}
+    {%@ "head", metadata: site.metadata, title: data.title %}
   </head>
-  <body class="{{ resource.data.layout }} {{ resource.data.page_class }}">
+  <body class="{{ data.layout }} {{ data.page_class }}">
     {%@ Shared::Navbar metadata: site.metadata, resource: resource %}
 
     <main>

--- a/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/page.serb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/page.serb
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1>{{ resource.data.title }}</h1>
+<h1>{{ data.title }}</h1>
 
 {%= yield %}

--- a/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/post.serb
+++ b/bridgetown-core/lib/site_template/TEMPLATES/serbea/_layouts/post.serb
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<h1>{{ resource.data.title }}</h1>
+<h1>{{ data.title }}</h1>
 
 {%= yield %}

--- a/bridgetown-core/test/resources/src/_pages/multi-page.multi.md
+++ b/bridgetown-core/test/resources/src/_pages/multi-page.multi.md
@@ -6,6 +6,6 @@ locale_overrides:
     title: "Sur mesure"
 ---
 
-{% if site.locale == "en" %}English:{% elsif site.locale == "fr" %}French:{% endif %} {{ resource.data.title }}
+{% if site.locale == "en" %}English:{% elsif site.locale == "fr" %}French:{% endif %} {{ data.title }}
 
 {{ site.locale | t }}: {{ "test.name" | t }}

--- a/bridgetown-core/test/source/src/_layouts/erblayout.erb
+++ b/bridgetown-core/test/source/src/_layouts/erblayout.erb
@@ -5,7 +5,7 @@ layout_var:
 
 <div>Test? <%= layout[:layout_var].first %></div>
 
-<h1><%= page.data.title %></h1>
+<h1><%= data.title %></h1>
 
 <%= yield %>
 

--- a/bridgetown-core/test/source/src/_layouts/serblayout.serb
+++ b/bridgetown-core/test/source/src/_layouts/serblayout.serb
@@ -5,7 +5,7 @@ layout_var:
 
 <div>Test? {%= layout[:layout_var].first %}</div>
 
-<h1>{{ page.data.title }}</h1>
+<h1>{{ data.title }}</h1>
 
 {%= yield %}
 

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -111,7 +111,7 @@ The organizations can then be accessed via `site.data.orgs`, followed by the fil
 ```liquid
 <ul>
 {% for org_hash in site.data.orgs %}
-{% assign org = org_hash[1] %}
+  {% assign org = org_hash[1] %}
   <li>
     <a href="https://github.com/{{ org.username }}" rel="noopener">
       {{ org.name }}
@@ -122,6 +122,21 @@ The organizations can then be accessed via `site.data.orgs`, followed by the fil
 </ul>
 ```
 {% endraw %}
+
+## Merging Site Data into Resource Data
+
+New for Bridgetown 1.2: for easier access to data in your templates whether that data comes from the resource directly or from data files, you can use [front matter](/docs/front-matter/) to specify a data path for merging into the resource.
+
+Just define a front matter variable in a resource like so:
+
+```yaml
+---
+title: Projects
+projects: site.data.projects
+---
+```
+
+Now your template you can reference `data.projects` just like you might `data.title` or any other front matter variable. You can even use [front matter defaults](/docs/content/front-matter-defaults/) to assign such a data variable to multiple resources at once.
 
 ## Example: Accessing a specific author
 
@@ -142,9 +157,10 @@ The author can then be specified as a page variable in a post's front matter:
 ---
 title: sample post
 author: dave
+people: site.data.people
 ---
 
-{% assign author = site.data.people[resource.data.author] %}
+{% assign author = data.people[data.author] %}
 <a rel="author noopener"
   href="https://twitter.com/{{ author.twitter }}"
   title="{{ author.name }}">

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -36,7 +36,7 @@ Want to switch to using a `site_metadata.rb` file where you have more programmat
 
 ## Example: Define a List of members
 
-Here is a basic example of using Data Files to avoid copy-pasting large chunks of code in your Bridgetown templates:
+Here is a basic example of using data files to avoid copy-pasting large chunks of code in your Bridgetown templates:
 
 In `_data/members.yml`:
 
@@ -138,9 +138,9 @@ projects: site.data.projects
 
 Now your template you can reference `data.projects` just like you might `data.title` or any other front matter variable. You can even use [front matter defaults](/docs/content/front-matter-defaults/) to assign such a data variable to multiple resources at once.
 
-## Example: Accessing a specific author
+### Example: Accessing a specific author
 
-Pages and posts can also access a specific data item. The example below shows how to access a specific item:
+You can access a specific data item from a dataset using a front matter variable. The example below shows how. First, define your dataset:
 
 `_data/people.yml`:
 
@@ -150,21 +150,20 @@ dave:
   twitter: DavidSilvaSmith
 ```
 
-The author can then be specified as a page variable in a post's front matter:
+That author can then be specified as a variable in a post's front matter:
 
 {% raw %}
 ```liquid
 ---
-title: sample post
+title: Sample Post
 author: dave
 people: site.data.people
 ---
 
 {% assign author = data.people[data.author] %}
-<a rel="author noopener"
-  href="https://twitter.com/{{ author.twitter }}"
-  title="{{ author.name }}">
-    {{ author.name }}
+
+<a rel="author" href="https://twitter.com/{{ author.twitter }}">
+  {{ author.name }}
 </a>
 ```
 {% endraw %}

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -138,7 +138,7 @@ projects: site.data.projects
 
 Now your template you can reference `data.projects` just like you might `data.title` or any other front matter variable. You can even use [front matter defaults](/docs/content/front-matter-defaults/) to assign such a data variable to multiple resources at once.
 
-### Example: Accessing a specific author
+### Example: Accessing a Specific Author
 
 You can access a specific data item from a dataset using a front matter variable. The example below shows how. First, define your dataset:
 

--- a/bridgetown-website/src/_docs/datafiles.md
+++ b/bridgetown-website/src/_docs/datafiles.md
@@ -136,7 +136,7 @@ projects: site.data.projects
 ---
 ```
 
-Now your template you can reference `data.projects` just like you might `data.title` or any other front matter variable. You can even use [front matter defaults](/docs/content/front-matter-defaults/) to assign such a data variable to multiple resources at once.
+Now in your template you can reference `data.projects` just like you might `data.title` or any other front matter variable. You can even use [front matter defaults](/docs/content/front-matter-defaults/) to assign such a data variable to multiple resources at once.
 
 ### Example: Accessing a Specific Author
 

--- a/bridgetown-website/src/_docs/front-matter.md
+++ b/bridgetown-website/src/_docs/front-matter.md
@@ -154,6 +154,10 @@ You can also use a resource's front matter variables in other places like layout
 you can even reference those variables in loops or as part of more
 complex queries (see the [Liquid](/docs/template-engines/liquid) or [ERB and Beyond](/docs/template-engines/erb-and-beyond) docs for more information).
 
+{%@Note do %}
+Starting in Bridgetown 1.2, you can use the shorthand `data` method to access resource data in a template. For example: `data.food` instead of `resource.data.food`, `data.slug` instead of `resource.data.slug`, etc. Note that you'll still need to use the `resource` object directly for predefined methods such as `resource.relative_url`, `resource.summary`, and some others.
+{% end %}
+
 ## Predefined Variables
 
 These resource variables are available out-of-the-box:

--- a/bridgetown-website/src/_docs/liquid/filters.md
+++ b/bridgetown-website/src/_docs/liquid/filters.md
@@ -3,6 +3,7 @@ title: Liquid Filters
 top_section: Designing Your Site
 order: 0
 category: template-engines
+bridgetown_filters: site.data.bridgetown_variables.liquid_filters
 shopify_filter_url: https://shopify.github.io/liquid/filters/
 shopify_filters:
 - abs
@@ -68,7 +69,7 @@ using [plugins](/docs/plugins/filters).
     </tr>
   </thead>
   <tbody>
-    {% site.data.bridgetown_variables.liquid_filters.each do |filter| %}
+    {% data.bridgetown_filters.each do |filter| %}
       <tr>
         <td>
           <p class="name"><strong>{{ filter.name }}</strong></p>
@@ -142,8 +143,8 @@ Or to get a list of comic-book based movies, one may use the following:
 
 ### Standard Liquid Filters
 
-For your convenience, here is the list of all [Liquid filters]({{ resource.data.shopify_filter_url }}) with links to examples in the official Liquid documentation.
+For your convenience, here is the list of all [Liquid filters]({{ data.shopify_filter_url }}) with links to examples in the official Liquid documentation.
 
-{% resource.data.shopify_filters.each do |filter| %}
-- [{{ filter }}]({{ filter | prepend: resource.data.shopify_filter_url | append: '/' }})
+{% data.shopify_filters.each do |filter| %}
+- [{{ filter }}]({{ filter | prepend: data.shopify_filter_url | append: '/' }})
 {% end %}

--- a/bridgetown-website/src/_docs/resources.md
+++ b/bridgetown-website/src/_docs/resources.md
@@ -22,7 +22,7 @@ Here's a page all about myself.
 
 Here's what I look like:
 
-![Me, Myself, and I](/images/{{ resource.data.headshot }})
+![Me, Myself, and I](/images/{{ data.headshot }})
 ```
 {% endraw %}
 

--- a/bridgetown-website/src/_layouts/default.serb
+++ b/bridgetown-website/src/_layouts/default.serb
@@ -3,7 +3,7 @@
   <head>
     {%@ "head" %}
   </head>
-  <body class="{{ resource.data.layout }} {{ resource.data.page_class }}">
+  <body class="{{ data.layout }} {{ data.page_class }}">
     {%@ Shared::Navbar metadata: site.metadata, resource: resource %}
 
     <main>

--- a/bridgetown-website/src/_layouts/page.serb
+++ b/bridgetown-website/src/_layouts/page.serb
@@ -5,9 +5,9 @@ layout: default
 <main-content>
   <section-wrapper><section>
 
-  {%= resource.data.breadcrumbs_for_layout %}
+  {%= data.breadcrumbs_for_layout %}
 
-  <h1 class="serif colorful">{{ resource.data.title }}</h1>
+  <h1 class="serif colorful">{{ data.title }}</h1>
 
   {%= yield %}
 

--- a/bridgetown-website/src/_layouts/post.serb
+++ b/bridgetown-website/src/_layouts/post.serb
@@ -9,17 +9,17 @@ layout: default
     <sl-icon library="remixicon" name="system/arrow-right-s-fill" slot="separator" style="font-size:1.2em; margin-top:0.1em"></sl-icon>
 
     <sl-breadcrumb-item href="/blog">Blog</sl-breadcrumb-item>
-    <sl-breadcrumb-item href="/blog/{{ resource.data.category }}">Category: {{ resource.data.category | titleize }}</sl-breadcrumb-item>
+    <sl-breadcrumb-item href="/blog/{{ data.category }}">Category: {{ data.category | titleize }}</sl-breadcrumb-item>
     <sl-breadcrumb-item></sl-breadcrumb-item>
   </sl-breadcrumb>
 
   <article>
-    <h1 class="serif colorful">{{ resource.data.title }}</h1>
+    <h1 class="serif colorful">{{ data.title }}</h1>
 
     <article-author class="mb-10 author has-text-centered p-author">
-      {% author = site.data.authors[resource.data.author] %}
+      {% author = site.data.authors[data.author] %}
       <img src="{{ author.avatar }}" alt="{{ author.name }}" class="avatar u-photo" />
-      <a href="/authors/{{ resource.data.author }}/" class="has-text-weight-bold u-url p-name">{{ author.name }}</a>
+      <a href="/authors/{{ data.author }}/" class="has-text-weight-bold u-url p-name">{{ author.name }}</a>
       on <no-br style="white-space:nowrap">{{ resource.date | strftime: "%B %-d, %Y" }}</no-br>
     </article-author>
 

--- a/bridgetown-website/src/_pages/authors/[author].serb
+++ b/bridgetown-website/src/_pages/authors/[author].serb
@@ -8,7 +8,7 @@ prototype:
   data_label: name
 ---
 
-{% resource.data.breadcrumbs_for_layout = capture do %}
+{% data.breadcrumbs_for_layout = capture do %}
   <sl-breadcrumb style="display:block; margin-bottom:2.1em">
     <sl-icon library="remixicon" name="system/arrow-right-s-fill" slot="separator" style="font-size:1.2em; margin-top:0.1em"></sl-icon>
 

--- a/bridgetown-website/src/_pages/blog.serb
+++ b/bridgetown-website/src/_pages/blog.serb
@@ -6,7 +6,7 @@ paginate:
 ---
 
 {% if paginator.previous_page %}
-  {% resource.data.breadcrumbs_for_layout = capture do %}
+  {% data.breadcrumbs_for_layout = capture do %}
     <sl-breadcrumb style="display:block; margin-bottom:2.1em">
       <sl-icon library="remixicon" name="system/arrow-right-s-fill" slot="separator" style="font-size:1.2em; margin-top:0.1em"></sl-icon>
 

--- a/bridgetown-website/src/_pages/blog/[category].serb
+++ b/bridgetown-website/src/_pages/blog/[category].serb
@@ -6,7 +6,7 @@ prototype:
   term: category
 ---
 
-{% resource.data.breadcrumbs_for_layout = capture do %}
+{% data.breadcrumbs_for_layout = capture do %}
   <sl-breadcrumb style="display:block; margin-bottom:2.1em">
     <sl-icon library="remixicon" name="system/arrow-right-s-fill" slot="separator" style="font-size:1.2em; margin-top:0.1em"></sl-icon>
 


### PR DESCRIPTION
Resolves #527 (including @johlym's feature request!)