### PR TITLE
Add Dockerfile to deployment options

### DIFF
--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -77,6 +77,7 @@ RUN gem install bridgetown -N
 COPY . .
 RUN bundle install
 COPY --from=asset_builder /assets/output output/
+COPY --from=asset_builder /assets/.bridgetown-cache .bridgetown-cache/
 RUN ./bin/bridgetown build
 
 # Serve your site in a tiny production container, which serves on port 8043.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This PR adds documentation for Dockerfile-based deployments, which should cover a huge number of additional deployment options (Fly.io, Render/Heroku without buildpacks, Railway, etc).

## Context

This uses a multi-stage build that I've confirmed to work with my (relatively simple) personal site on Fly.io(https://stephen-dolan.fly.dev). There are a few advantages to multi-stage builds:
- Your final production image is **super small**, and doesn't have to contain ruby or nodejs runtimes.
- You can compile JS and Ruby output separately to keep those respective images really clean. No mucking around with installing nodejs package signatures and specifying hard-coded versions in the `ruby:alpine` image.

I'd welcome any tips regarding how to more effectively/minimally build a site for production use. I think there's value in keeping the Dockerfile simple enough for folks to run with and modify on their own, but even some comments with potential alternatives for folks running different setups (like webpack) might be nice!

This means your site is running _as an app_, so it's more expensive than running a free static site that many services (Netlify, Render, etc) can detect. That said, it gives you tons of flexibility and a lot more options for providers.
