### PR TITLE
Update SSR tests to work with Rack 3

### DIFF
--- a/bridgetown-core/test/test_ssr.rb
+++ b/bridgetown-core/test/test_ssr.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require "helper"
+require "rack"
 
 class TestSSR < BridgetownUnitTest
   include Rack::Test::Methods
 
   def app
-    @@ssr_app ||= Rack::Builder.parse_file(File.expand_path("ssr/config.ru", __dir__)).first # rubocop:disable Style/ClassVars
+    @@ssr_app ||= Rack::Builder.parse_file(File.expand_path("ssr/config.ru", __dir__)) # rubocop:disable Style/ClassVars
   end
 
   def site


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

- Adding `require "rack"` because Rack no longer seems to be loaded. (Wasn't sure why this was now needed though 🤔.)
- Remove call to `.first` on the return value from `Rack::Builder.parse_file` - in Rack's latest version, [just the app is returned](https://github.com/rack/rack/pull/1663) rather than an array.

