### PR TITLE
Kwargs conversion of many methods

### DIFF
--- a/bridgetown-builder/test/test_helpers_dsl.rb
+++ b/bridgetown-builder/test/test_helpers_dsl.rb
@@ -23,10 +23,13 @@ class TestHelpers < BridgetownUnitTest
     setup do
       @site = Site.new(site_configuration)
       @builder = HelpersBuilder.new("HelpersBuilder", @site).build_with_callbacks
-      @resource = Bridgetown::Model::Base.build(self, :posts, "im-a-post.md", {
+      @resource = Bridgetown::Model::Base.build(
+        self,
+        :posts,
+        "im-a-post.md",
         title: "I'm a post!",
         date: "2019-05-01",
-      }).as_resource_in_collection
+      ).as_resource_in_collection
       @erb_view = Bridgetown::ERBView.new(@resource)
     end
 

--- a/bridgetown-core/features/support/formatter.rb
+++ b/bridgetown-core/features/support/formatter.rb
@@ -24,7 +24,7 @@ module Bridgetown
 
       #
 
-      def initialize(runtime, path_or_io, options)
+      def initialize(runtime, path_or_io, **options)
         @runtime = runtime
         @snippets_input = []
         @io = ensure_io(path_or_io)
@@ -209,7 +209,7 @@ module Bridgetown
 end
 
 AfterConfiguration do |config|
-  f = Bridgetown::Cucumber::Formatter.new(nil, $stdout, {})
+  f = Bridgetown::Cucumber::Formatter.new(nil, $stdout)
 
   config.on_event :test_case_started do |event|
     f.print_feature_element_name(event.test_case)

--- a/bridgetown-core/lib/bridgetown-core/commands/build.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/build.rb
@@ -29,7 +29,7 @@ module Bridgetown
       # Build your bridgetown site
       # Continuously watch if `watch` is set to true in the config.
       def build
-        Bridgetown.logger.adjust_verbosity(options)
+        Bridgetown.logger.adjust_verbosity(**options)
 
         unless caller_locations.find do |loc|
                  loc.to_s.include?("bridgetown-core/commands/start.rb")

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -65,7 +65,7 @@ module Bridgetown
         new_site_path = File.expand_path(args.join(" "), Dir.pwd)
         @site_name = new_site_path.split(File::SEPARATOR).last
 
-        if preserve_source_location?(new_site_path, options)
+        if preserve_source_location?(new_site_path, **options)
           say_status :conflict, "#{new_site_path} exists and is not empty.", :red
           Bridgetown.logger.abort_with(
             "Ensure #{new_site_path} is empty or else try again with `--force` to proceed and " \
@@ -77,14 +77,14 @@ module Bridgetown
 
         say_status :create, new_site_path
         create_site new_site_path
-        after_install new_site_path, args.join(" "), options
+        after_install new_site_path, args.join(" "), **options
       rescue ArgumentError => e
         say_status :alert, e.message, :red
       end
 
       protected
 
-      def preserve_source_location?(path, options)
+      def preserve_source_location?(path, **options)
         !options["force"] && Dir.exist?(path)
       end
 
@@ -179,7 +179,7 @@ module Bridgetown
       # unless the user opts to skip 'bundle install'.
       # rubocop:todo Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
-      def after_install(path, cli_path, options = {})
+      def after_install(path, cli_path, **options)
         git_init path
 
         @skipped_bundle = true # is set to false if bundle install worked

--- a/bridgetown-core/lib/bridgetown-core/commands/serve.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/serve.rb
@@ -157,7 +157,7 @@ module Bridgetown
         )
       end
 
-      def server_address(server, options = {})
+      def server_address(server, **options)
         format_url(
           server.config[:SSLEnable],
           server.config[:BindAddress],

--- a/bridgetown-core/lib/bridgetown-core/component.rb
+++ b/bridgetown-core/lib/bridgetown-core/component.rb
@@ -157,9 +157,8 @@ module Bridgetown
     # Provide a render helper for evaluation within the component context.
     #
     # @param item [Object] a component supporting `render_in` or a partial name
-    # @param options [Hash] passed to the `partial` helper if needed
     # @return [String]
-    def render(item, options = {}, &block)
+    def render(item, **options, &block)
       if item.respond_to?(:render_in)
         result = ""
         capture do # this ensures no leaky interactions between BT<=>VC blocks
@@ -167,7 +166,7 @@ module Bridgetown
         end
         result&.html_safe
       else
-        partial(item, options, &block)&.html_safe
+        partial(item, **options, &block)&.html_safe
       end
     end
 

--- a/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
@@ -95,7 +95,7 @@ module Bridgetown
         bufval: "Bridgetown::OutputBuffer.new",
         engine_class: ERBEngine
       )
-      tmpl.render(self, options)
+      tmpl.render(self, **options)
     end
   end
 

--- a/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/erb_templates.rb
@@ -84,10 +84,10 @@ module Bridgetown
       options.merge!(options[:locals]) if options[:locals]
       options[:content] = capture(&block) if block
 
-      _render_partial partial_name, options
+      _render_partial partial_name, **options
     end
 
-    def _render_partial(partial_name, options)
+    def _render_partial(partial_name, **options)
       partial_path = _partial_path(partial_name, "erb")
       tmpl = site.tmp_cache["partial-tmpl:#{partial_path}"] ||= Tilt::ErubiTemplate.new(
         partial_path,

--- a/bridgetown-core/lib/bridgetown-core/converters/markdown.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/markdown.rb
@@ -36,7 +36,7 @@ module Bridgetown
       # rubocop:disable Naming/AccessorMethodName
       def get_processor
         case @config["markdown"].downcase
-        when "kramdown" then KramdownParser.new(@config)
+        when "kramdown" then KramdownParser.new(**@config)
         else
           custom_processor
         end

--- a/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
@@ -11,7 +11,7 @@ module Kramdown
       attr_reader :options, :parser
 
       # The implementation is basically the core logic in +Kramdown::Document#initialize+
-      def setup(options)
+      def setup(**options)
         @cache ||= {}
 
         # reset variables on a subsequent set up with a different options Hash
@@ -44,8 +44,8 @@ module Kramdown
       end
     end
 
-    def initialize(source, options = {}) # rubocop:disable Lint/MissingSuper
-      BridgetownDocument.setup(options)
+    def initialize(source, **options) # rubocop:disable Lint/MissingSuper
+      BridgetownDocument.setup(**options)
 
       @options = BridgetownDocument.options
       @root, @warnings = BridgetownDocument.parser.parse(source, @options)
@@ -63,15 +63,13 @@ module Kramdown
   end
 end
 
-#
-
 module Bridgetown
   module Converters
     class Markdown
       class KramdownParser
         attr_reader :extractions
 
-        def initialize(config)
+        def initialize(**config)
           @config = config["kramdown"] || {}
           @config["syntax_highlighter"] ||= config["highlighter"] || "rouge"
           @config["syntax_highlighter_opts"] ||= {}
@@ -80,7 +78,7 @@ module Bridgetown
         end
 
         def convert(content)
-          document = Kramdown::BridgetownDocument.new(content, @config)
+          document = Kramdown::BridgetownDocument.new(content, **@config)
           html_output = document.to_html
           if @config["show_warnings"]
             document.warnings.each do |warning|

--- a/bridgetown-core/lib/bridgetown-core/converters/serbea_templates.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/serbea_templates.rb
@@ -7,11 +7,11 @@ module Bridgetown
   class SerbeaView < ERBView
     include Serbea::Helpers
 
-    def _render_partial(partial_name, options)
+    def _render_partial(partial_name, **options)
       partial_path = _partial_path(partial_name, "serb")
       tmpl = site.tmp_cache["partial-tmpl:#{partial_path}"] ||=
         Tilt::SerbeaTemplate.new(partial_path)
-      tmpl.render(self, options)
+      tmpl.render(self, **options)
     end
   end
 

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -33,10 +33,8 @@ module Bridgetown
         Bridgetown::Utils.live_reload_js(site)
       end
 
-      # @param pairs [Hash] A hash of key/value pairs.
-      #
       # @return [String] Space-separated keys where the values are truthy.
-      def class_map(pairs = {})
+      def class_map(**pairs)
         pairs.select { |_key, truthy| truthy }.keys.join(" ")
       end
 
@@ -94,32 +92,30 @@ module Bridgetown
       # @param text [String] the content inside the anchor tag
       # @param relative_path [String, Object] source file path, e.g.
       #   "_posts/2020-10-20-my-post.md", or object that responds to `url`
-      # @param options [Hash] key-value pairs of HTML attributes to add to the tag
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
-      def link_to(text, relative_path = nil, options = {})
+      def link_to(text, relative_path = nil, **options)
         if block_given?
           relative_path = text
           text = yield
         elsif relative_path.nil?
           raise ArgumentError, "You must provide a relative path"
         end
-        segments = attributes_from_options({ href: url_for(relative_path) }.merge(options))
+        segments = attributes_from_options(href: url_for(relative_path), **options)
 
         safe("<a #{segments}>#{text}</a>")
       end
 
       # Create a set of attributes from a hash.
       #
-      # @param options [Hash] key-value pairs of HTML attributes
       # @return [String]
-      def attributes_from_options(options)
+      def attributes_from_options(**options)
         segments = []
         options.each do |attr, option|
           attr = dashed(attr)
           if option.is_a?(Hash)
             option = option.transform_keys { |key| "#{attr}-#{dashed(key)}" }
-            segments << attributes_from_options(option)
+            segments << attributes_from_options(**option)
           else
             segments << attribute_segment(attr, option)
           end

--- a/bridgetown-core/lib/bridgetown-core/hooks.rb
+++ b/bridgetown-core/lib/bridgetown-core/hooks.rb
@@ -87,7 +87,7 @@ module Bridgetown
         if Bridgetown.respond_to?(:logger)
           Bridgetown.logger.debug("Registering hook:", @registry[owner].last.to_s)
         else
-          p "Registering hook:", @registry[owner].last.to_s
+          p "Registering hook:", @registry[owner].last.to_s # rubocop:disable Lint/Debugger
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/log_adapter.rb
+++ b/bridgetown-core/lib/bridgetown-core/log_adapter.rb
@@ -35,7 +35,7 @@ module Bridgetown
       @level = level
     end
 
-    def adjust_verbosity(options = {})
+    def adjust_verbosity(**options)
       # Quiet always wins.
       if options[:quiet]
         self.log_level = :error

--- a/bridgetown-core/lib/bridgetown-core/model/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/base.rb
@@ -14,7 +14,7 @@ module Bridgetown
           raise "A Bridgetown site must be initialized and added to Current" unless site
 
           origin = origin_for_id(id, site: site)
-          klass_for_id(id, origin: origin).new(origin.read)
+          klass_for_id(id, origin: origin).new(**origin.read)
         end
 
         def origin_for_id(id, site: Bridgetown::Current.site)
@@ -49,11 +49,11 @@ module Bridgetown
             data[:_collection_] = site.collections[collection_name]
             data
           end
-          new(data)
+          new(**data)
         end
       end
 
-      def initialize(attributes = {})
+      def initialize(**attributes)
         run_callbacks :load do
           super
         end

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -47,9 +47,9 @@ module Bridgetown
       site.site_payload.site
     end
 
-    def liquid_render(component, options = {}, &block)
+    def liquid_render(component, **options, &block)
       options[:_block_content] = capture(&block) if block && respond_to?(:capture)
-      render_statement = _render_statement(component, options)
+      render_statement = _render_statement(component, **options)
 
       template = site.liquid_renderer.file(
         "#{resource.path}.#{Digest::SHA2.hexdigest(render_statement)}"
@@ -83,7 +83,7 @@ module Bridgetown
 
     private
 
-    def _render_statement(component, options)
+    def _render_statement(component, **options)
       render_statement = if options[:_block_content]
                            ["{% rendercontent \"#{component}\""]
                          else

--- a/bridgetown-core/lib/bridgetown-core/url.rb
+++ b/bridgetown-core/lib/bridgetown-core/url.rb
@@ -4,10 +4,10 @@
 #
 # Examples
 #
-#   URL.new({
+#   URL.new(
 #     :template => /:categories/:title.html",
 #     :placeholders => {:categories => "ruby", :title => "something"}
-#   }).to_s
+#   ).to_s
 #
 module Bridgetown
   # TODO: remove this class in favor of the new Resource permalink processor
@@ -23,7 +23,7 @@ module Bridgetown
     #           :permalink    - If supplied, no URL will be generated from the
     #                           template. Instead, the given permalink will be
     #                           used as URL.
-    def initialize(options)
+    def initialize(**options)
       @template     = options[:template]
       @placeholders = options[:placeholders] || {}
       @permalink    = options[:permalink]

--- a/bridgetown-core/script/console
+++ b/bridgetown-core/script/console
@@ -7,20 +7,20 @@ require "bridgetown"
 
 TEST_DIR = File.expand_path("../test", __dir__)
 
-def fixture_site(overrides = {})
-  Bridgetown::Site.new(site_configuration(overrides))
+def fixture_site(**overrides)
+  Bridgetown::Site.new(site_configuration(**overrides))
 end
 
-def build_configs(overrides, base_hash = Bridgetown::Configuration::DEFAULTS)
+def build_configs(base_hash = Bridgetown::Configuration::DEFAULTS, **overrides)
   Bridgetown::Utils.deep_merge_hashes(base_hash, overrides)
 end
 
-def site_configuration(overrides = {})
+def site_configuration(**overrides)
   build_configs({
     "root_dir"    => site_root_dir,
     "source"      => source_dir,
     "destination" => dest_dir,
-  }, build_configs(overrides))
+  }, build_configs(**overrides))
 end
 
 def dest_dir(*subdirs)

--- a/bridgetown-core/test/helper.rb
+++ b/bridgetown-core/test/helper.rb
@@ -128,15 +128,15 @@ class BridgetownUnitTest < Minitest::Test
     RSpec::Mocks.teardown
   end
 
-  def fixture_site(overrides = {})
-    Bridgetown::Site.new(site_configuration(overrides))
+  def fixture_site(**overrides)
+    Bridgetown::Site.new(site_configuration(**overrides))
   end
 
-  def resources_site(overrides = {})
+  def resources_site(**overrides)
     overrides["content_engine"] = "resource"
     overrides["available_locales"] ||= %w[en fr]
     overrides["plugins_dir"] = resources_root_dir("plugins")
-    new_config = site_configuration(overrides)
+    new_config = site_configuration(**overrides)
     new_config.root_dir = resources_root_dir
     new_config.source = resources_root_dir("src")
     Bridgetown::Site.new new_config
@@ -151,7 +151,7 @@ class BridgetownUnitTest < Minitest::Test
     )
   end
 
-  def site_configuration(overrides = {})
+  def site_configuration(**overrides)
     Bridgetown.reset_configuration!
 
     load_plugin_content(Bridgetown::Current.preloaded_configuration)

--- a/bridgetown-core/test/test_components.rb
+++ b/bridgetown-core/test/test_components.rb
@@ -21,7 +21,7 @@ class TestComponents < BridgetownUnitTest
   def setup
     refresh_zeitwork do
       Example.send(:remove_const, "OverrideComponent") if defined?(Example::OverrideComponent)
-      @site = fixture_site({ level: "Level" })
+      @site = fixture_site(level: "Level")
     end
 
     @site.process

--- a/bridgetown-core/test/test_configuration.rb
+++ b/bridgetown-core/test/test_configuration.rb
@@ -13,7 +13,7 @@ class TestConfiguration < BridgetownUnitTest
     }
   end
 
-  def default_config_fixture(overrides = {})
+  def default_config_fixture(**overrides)
     Bridgetown.configuration(test_config.merge(overrides)).tap do |config|
       config.autoload_paths = config.eager_load_paths = []
       config.plugins_use_zeitwerk = false
@@ -359,7 +359,7 @@ class TestConfiguration < BridgetownUnitTest
           "baseurl" => "http://example.com",
           "config"  => @paths[:other]
         ),
-        default_config_fixture({ "config" => @paths[:other] })
+        default_config_fixture("config" => @paths[:other])
     end
 
     should "load different config if specified with symbol key" do
@@ -374,7 +374,7 @@ class TestConfiguration < BridgetownUnitTest
           "baseurl" => "http://example.com",
           "config"  => @paths[:other]
         ),
-        default_config_fixture({ config: @paths[:other] })
+        default_config_fixture(config: @paths[:other])
     end
 
     should "load default config if path passed is empty" do
@@ -382,7 +382,7 @@ class TestConfiguration < BridgetownUnitTest
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       assert_equal \
         site_configuration("config" => [@paths[:empty]]),
-        default_config_fixture({ "config" => [@paths[:empty]] })
+        default_config_fixture("config" => [@paths[:empty]])
     end
 
     should "load multiple config files" do
@@ -394,7 +394,7 @@ class TestConfiguration < BridgetownUnitTest
         site_configuration(
           "config" => [@paths[:default], @paths[:other]]
         ),
-        default_config_fixture({ "config" => [@paths[:default], @paths[:other]] })
+        default_config_fixture("config" => [@paths[:default], @paths[:other]])
       )
     end
 
@@ -418,7 +418,7 @@ class TestConfiguration < BridgetownUnitTest
           "baseurl" => "http://example.com",
           "config"  => [@paths[:default], @paths[:other]]
         ),
-        default_config_fixture({ "config" => [@paths[:default], @paths[:other]] })
+        default_config_fixture("config" => [@paths[:default], @paths[:other]])
     end
   end
 

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -23,8 +23,8 @@ class TestFilters < BridgetownUnitTest
     end
   end
 
-  def make_filter_mock(opts = {})
-    BridgetownFilter.new(site_configuration(opts.merge("skip_config_files" => true)))
+  def make_filter_mock(**opts)
+    BridgetownFilter.new(site_configuration(**{ **opts, "skip_config_files" => true }))
   end
 
   class SelectDummy

--- a/bridgetown-core/test/test_front_matter_defaults.rb
+++ b/bridgetown-core/test/test_front_matter_defaults.rb
@@ -202,13 +202,13 @@ class TestFrontMatterDefaults < BridgetownUnitTest
 
   context "A site with front matter defaults with quoted date" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "values" => {
             "date" => "2015-01-01 00:00:01",
           },
-        }],
-      })
+        }]
+      )
     end
 
     should "parse date" do

--- a/bridgetown-core/test/test_kramdown.rb
+++ b/bridgetown-core/test/test_kramdown.rb
@@ -4,15 +4,15 @@ require "helper"
 require "rouge"
 
 class TestKramdown < BridgetownUnitTest
-  def fixture_converter(config)
-    site = fixture_site(
-      Utils.deep_merge_hashes(
-        {
-          "markdown" => "kramdown",
-        },
-        config
-      )
+  def fixture_converter(**config)
+    overrides = Utils.deep_merge_hashes(
+      {
+        "markdown" => "kramdown",
+      },
+      config
     )
+
+    site = fixture_site(**overrides)
     Bridgetown::Cache.clear
     site.find_converter_instance(
       Bridgetown::Converters::Markdown
@@ -44,7 +44,7 @@ class TestKramdown < BridgetownUnitTest
       @syntax_highlighter_opts_config_keys = \
         @config["kramdown"]["syntax_highlighter_opts"].keys
 
-      @converter = fixture_converter(@config)
+      @converter = fixture_converter(**@config)
     end
 
     should "not break kramdown" do
@@ -81,7 +81,7 @@ class TestKramdown < BridgetownUnitTest
 
     context "when asked to convert smart quotes" do
       should "convert" do
-        converter = fixture_converter(@config)
+        converter = fixture_converter(**@config)
         assert_match(
           %r!<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)</p>!,
           converter.convert(%("Pit'hy")).strip
@@ -95,7 +95,7 @@ class TestKramdown < BridgetownUnitTest
             "smart_quotes" => "lsaquo,rsaquo,laquo,raquo",
           },
         }
-        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
+        converter = fixture_converter(**Utils.deep_merge_hashes(@config, override))
         assert_match %r!<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)</p>!, \
                      converter.convert(%("Pit'hy")).strip
       end

--- a/bridgetown-core/test/test_model.rb
+++ b/bridgetown-core/test/test_model.rb
@@ -17,7 +17,7 @@ class TestModel < BridgetownUnitTest
       model.origin = @origin
       model.save
 
-      new_model = Bridgetown::Model::Base.new(@origin.read)
+      new_model = Bridgetown::Model::Base.new(**@origin.read)
 
       assert_equal model.title, new_model.title
       assert_equal model.layout, new_model.layout.to_sym

--- a/bridgetown-core/test/test_relations.rb
+++ b/bridgetown-core/test/test_relations.rb
@@ -5,7 +5,7 @@ require "helper"
 class TestRelations < BridgetownUnitTest
   context "belongs_to and has_many" do
     setup do
-      @site = resources_site({
+      @site = resources_site(
         "collections" => {
           "noodles" => {
             "output"    => true,
@@ -18,8 +18,8 @@ class TestRelations < BridgetownUnitTest
               "belongs_to" => "noodle",
             },
           },
-        },
-      })
+        }
+      )
       @site.process
       # @type [Bridgetown::Resource::Base]
       @resource = @site.collections.posts.resources[0]

--- a/bridgetown-core/test/test_resource.rb
+++ b/bridgetown-core/test/test_resource.rb
@@ -232,7 +232,7 @@ class TestResource < BridgetownUnitTest
 
     context "a resource in the posts collection" do
       setup do
-        @site = resources_site({ slugify_mode: "latin" })
+        @site = resources_site(slugify_mode: "latin")
         @site.process
         @resource = @site.collections.posts.resources[0]
         @dest_file = dest_dir("2019/09/09/blog-post/index.html")

--- a/bridgetown-core/test/test_tags.rb
+++ b/bridgetown-core/test/test_tags.rb
@@ -7,8 +7,8 @@ class TestTags < BridgetownUnitTest
     FileUtils.mkdir_p("tmp")
   end
 
-  def create_post(content, override = {}, converter_class = Bridgetown::Converters::Markdown) # rubocop:disable Metrics/AbcSize
-    site = fixture_site({ "highlighter" => "rouge" }.merge(override))
+  def create_post(content, converter_class = Bridgetown::Converters::Markdown, **override) # rubocop:disable Metrics/AbcSize
+    site = fixture_site(**{ "highlighter" => "rouge", **override })
 
     site.collections.posts.read if override["read_posts"]
     Reader.new(site).read_collections if override["read_collections"]
@@ -25,7 +25,7 @@ class TestTags < BridgetownUnitTest
     @result = @converter.convert(@result)
   end
 
-  def fill_post(code, override = {})
+  def fill_post(code, **override)
     content = <<~CONTENT
       ---
       title: This is a test
@@ -40,7 +40,7 @@ class TestTags < BridgetownUnitTest
       #{code}
       {% endhighlight %}
     CONTENT
-    create_post(content, override)
+    create_post(content, **override)
   end
 
   def highlight_block_with_opts(options_string)

--- a/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
+++ b/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
@@ -6,8 +6,8 @@ require_relative "../../bridgetown-routes/flash_additions"
 Roda::RodaPlugins::Flash::FlashHash.include Bridgetown::Routes::FlashHashAdditions,
                                             Bridgetown::Routes::FlashHashIndifferent
 Roda::RodaPlugins::Flash::FlashHash.class_eval do
-  def initialize(hash = {})
-    super(hash || {})
+  def initialize(**hash)
+    super(hash)
     now.singleton_class.include Bridgetown::Routes::FlashHashAdditions,
                                 Bridgetown::Routes::FlashNowHashIndifferent
     @next = {}
@@ -24,7 +24,7 @@ class Roda
         app.plugin :route_csrf
       end
 
-      def self.configure(app, _opts = {})
+      def self.configure(app, **_opts)
         return unless app.opts[:bridgetown_site].nil?
 
         raise "Roda app failure: the bridgetown_ssr plugin must be registered before " \
@@ -55,7 +55,7 @@ class Roda
             data
           end
 
-          Bridgetown::Model::Base.new(data).to_resource.tap do |resource|
+          Bridgetown::Model::Base.new(**data).to_resource.tap do |resource|
             resource.roda_app = self
           end.read!.transform!.output
         end


### PR DESCRIPTION
## Summary

Convert many methods and calls to use keyword arguments instead of hashes.

Methods which take a `Configuration` haven't been converted, such as `Bridgetown::Site.new`, or initializers of the `Converter` classes. I started to attempt this but then ran into difficulty, particularly with the converters. I think it's related to `Configuration` being a `HashWithDotAccess::Hash`. I didn't want to go too deep down the rabbit hole, especially as there's a comment suggesting the [config may be refactored](https://github.com/bridgetownrb/bridgetown/blob/main/bridgetown-core/lib/bridgetown-core/configuration.rb#L6) at some point.

## Context

Supports resolving of #581
