### PR TITLE
extend `link_to` helper to accept blocks

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -97,7 +97,13 @@ module Bridgetown
       # @param options [Hash] key-value pairs of HTML attributes to add to the tag
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
-      def link_to(text, relative_path, options = {})
+      def link_to(text, relative_path = nil, options = {})
+        if block_given?
+          relative_path = text
+          text = yield
+        elsif relative_path.nil?
+          raise ArgumentError, "You must provide a relative path"
+        end
         segments = attributes_from_options({ href: url_for(relative_path) }.merge(options))
 
         safe("<a #{segments}>#{text}</a>")

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -36,6 +36,16 @@ class TestRubyHelpers < BridgetownUnitTest
     should "accept hash attributes" do
       assert_equal "<a href=\"/foo/bar\" class=\"classes\" data-controller=\"test\" data-action=\"test#test\">Label</a>", @helpers.link_to("Label", "/foo/bar", class: "classes", data: { controller: "test", action: "test#test" })
     end
+
+    should "accept block syntax" do
+      assert_equal "<a href=\"/foo/bar\">Label</a>", @helpers.link_to("/foo/bar") { "Label" }
+    end
+
+    should "raise if only one argument was given" do
+      assert_raises ArgumentError do
+        @helpers.link_to("Label")
+      end
+    end
   end
 
   context "attributes_from_options" do


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This just adds the possibility to use block syntax as it is possible in `link_to` helpers of other frameworks / builders
<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

PS: It would be nice if you would add the `hacktoberfest-accepted` label to this issue if you find it worthy merging.