### PR TITLE
typo: delimeters => delimiters

### DIFF
--- a/bridgetown-paginate/lib/bridgetown-paginate/pagination_indexer.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/pagination_indexer.rb
@@ -43,7 +43,7 @@ module Bridgetown
 
           Array(document_data).each do |key|
             key = key.to_s.downcase.strip
-            # If the key is a delimetered list of values
+            # If the key is a delimitered list of values
             # (meaning the user didn't use an array but a string with commas)
             key.split(%r!;|,!).each do |k_split|
               k_split = k_split.to_s.downcase.strip # Clean whitespace and junk

--- a/bridgetown-website/src/_docs/front-matter.md
+++ b/bridgetown-website/src/_docs/front-matter.md
@@ -269,9 +269,9 @@ or
 I'm a **Markdown** file.
 ```
 
-For ERB or Serbea files, you can use `---<%` / `%>---` or {% raw %}`---{%` / `%}---`{% endraw %} delimeters respectively. (You can substitute `~` instead of `-` if you prefer.)
+For ERB or Serbea files, you can use `---<%` / `%>---` or {% raw %}`---{%` / `%}---`{% endraw %} delimiters respectively. (You can substitute `~` instead of `-` if you prefer.)
 
-For all-Ruby files, you can use `---ruby` / `---` or `###ruby` / `###` delimeters.
+For all-Ruby files, you can use `---ruby` / `---` or `###ruby` / `###` delimiters.
 
 However you define your rbfm, bear in mind that the front matter code is executed _prior_ to any processing of the template file itself and within a different context. (rbfm will be executed initially within either `Bridgetown::Model::RepoOrigin` or `Bridgetown::Layout`.)
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

I think this is just a tiny typo. It's called [delimiter](https://www.oxfordlearnersdictionaries.com/definition/english/delimit), right?
Because it's the character that limits strings. Or do I misunderstand something here?
I'm not a native speaker so I might be wrong here.

