### PR TITLE
fix Lint/ConstantDefinitionInBlock and Style/StructInheritance

### DIFF
--- a/bridgetown-core/.rubocop.yml
+++ b/bridgetown-core/.rubocop.yml
@@ -25,7 +25,6 @@ AllCops:
 
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - test/test_filters.rb
     - test/test_liquid_extensions.rb
     - test/test_site.rb
 

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -31,6 +31,23 @@ class TestFilters < BridgetownUnitTest
     def select; end
   end
 
+  M = Struct.new(:message) do
+    def to_liquid
+      [message]
+    end
+  end
+
+  T = Struct.new(:name) do
+    def to_liquid
+      {
+        "name" => name,
+        :v     => 1,
+        :thing => M.new(kay: "jewelers"),
+        :stuff => true,
+      }
+    end
+  end
+
   context "filters" do
     setup do
       @sample_time = Time.utc(2013, 3, 27, 11, 22, 33)
@@ -753,24 +770,6 @@ class TestFilters < BridgetownUnitTest
         assert_equal expected, JSON.parse(actual)["bridgetown"]
       end
 
-      # rubocop:disable Style/StructInheritance
-      class M < Struct.new(:message)
-        def to_liquid
-          [message]
-        end
-      end
-
-      class T < Struct.new(:name)
-        def to_liquid
-          {
-            "name" => name,
-            :v     => 1,
-            :thing => M.new(kay: "jewelers"),
-            :stuff => true,
-          }
-        end
-      end
-
       should "call #to_liquid " do
         expected = [
           {
@@ -797,7 +796,6 @@ class TestFilters < BridgetownUnitTest
         result = @filter.jsonify([T.new("Jeremiah"), T.new("Smathers")])
         assert_equal expected, JSON.parse(result)
       end
-      # rubocop:enable Style/StructInheritance
 
       should "handle hashes with all sorts of weird keys and values" do
         my_hash = { "posts" => Array.new(3) { |i| T.new(i) } }


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This PR addresses 2 Rubocop violations that existed in `bridgetown-core/test/test_filters.rb`

## Context

* Moving Struct definitions outside a block resolves the `Lint/ConstantDefinitionInBlock` violation.
* At the same time `Style/StructInheritance` could be resolved by using `Foo = Struct.new {}` instead of `class Foo < Struct.new; end`