### PR TITLE
Fix typo in confirmation prompt

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/bt-postcss.rb
@@ -11,7 +11,7 @@ unless File.exist?("postcss.config.js")
   return
 end
 
-confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
+confirm = ask "This configuration will overwrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
 return unless confirm.casecmp?("Y")
 
 plugins = %w(postcss-mixins postcss-color-mod-function cssnano)


### PR DESCRIPTION
This is a 🔦 documentation change. (not really, but this is the closest option)

## Summary

Fixes a typo in a command line prompt that is shown while configuring tailwind.
