### PR TITLE
Change from master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
   you've done the following:
 
   - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
-  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/master/CODE_OF_CONDUCT.md
+  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
 -->
 
 <!--

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -655,7 +655,7 @@ Webpack rebuilds the bundles, Bridgetown regenerates the site.
 Going with a new `rendercontent` tag instead of `component`. It is based on
 Shopify's new Render tag which recently got introduced to Liquid. Note that the
 feature hasn't been officially released via the Liquid gem, so we need to use the
-master branch that's been forked on GitHub with a higher version number).
+main branch that's been forked on GitHub with a higher version number).
 
 [#5](https://github.com/bridgetownrb/bridgetown/pull/5)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ If you are the current maintainer of this gem:
 1. Add version heading/entries to `CHANGELOG.md`.
 1. Make sure your local dependencies are up to date: `bundle`
 1. Ensure that tests pass and build/release all monorepo gems: `bundle exec rake release_all`
-1. Push latest master along with new release tag: `git push --follow-tags`
+1. Push latest main along with new release tag: `git push --follow-tags`
 1. Create a GitHub release with the pushed tag (https://github.com/bridgetownrb/bridgetown/releases/new) and populate it with a list of the commits from `git log --pretty=format:"- %s" --reverse refs/tags/[OLD TAG]...refs/tags/[NEW TAG]`
 
 ## Attribution
 
-Special thanks to the **ViewComponent project** for [providing the language comprising most of this document](https://github.com/bridgetownrb/bridgetown/blob/master/CONTRIBUTING.md).
+Special thanks to the **ViewComponent project** for [providing the language comprising most of this document](https://github.com/bridgetownrb/bridgetown/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bridgetown is a next-generation, progressive site generator & fullstack framewor
 [![Gem Version](https://img.shields.io/gem/v/bridgetown.svg)](https://rubygems.org/gems/bridgetown)
 [![Licensed MIT](https://img.shields.io/badge/license-MIT-yellowgreen.svg)](LICENSE)
 [![Join the Discord Chat](https://img.shields.io/discord/711236503493148733?color=forestgreen&logo=discord)](https://discord.gg/4E6hktQGz4)
-[![PRs welcome!](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/bridgetownrb/bridgetown/blob/master/CONTRIBUTING.md)
+[![PRs welcome!](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/bridgetownrb/bridgetown/blob/main/CONTRIBUTING.md)
 
 ----
 

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -452,10 +452,10 @@ module Bridgetown
     def default_github_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Actions::GITHUB_REPO_REGEX.match(repo_url)
       api_endpoint = "https://api.github.com/repos/#{repo_match[1]}"
-      JSON.parse(Faraday.get(api_endpoint).body)["default_branch"] || "master"
+      JSON.parse(Faraday.get(api_endpoint).body)["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to GitHub API: #{e.message}")
-      "master"
+      "main"
     end
 
     def live_reload_js(site) # rubocop:disable Metrics/MethodLength

--- a/bridgetown-core/script/backport-pr
+++ b/bridgetown-core/script/backport-pr
@@ -5,7 +5,7 @@
 # Backports a PR into a release branch:
 #
 #   # backport PR #1023 into 1.1-stable-backport-1023
-#   $ git checkout master
+#   $ git checkout main
 #   $ git pull
 #   $ script/backport-pr 1.1 1023
 
@@ -45,7 +45,7 @@ git clean -q -fdx
 git pull -q
 git checkout -q -f -B $prbranch
 
-commit=`git log -1 --pretty=%H "--grep=Merge pull request $pr" "--grep=Merge branch '.*$headref'" master`
+commit=`git log -1 --pretty=%H "--grep=Merge pull request $pr" "--grep=Merge branch '.*$headref'" main`
 
 echo "Backporting:\n"
 

--- a/bridgetown-website/src/_docs/content/front-matter-defaults.md
+++ b/bridgetown-website/src/_docs/content/front-matter-defaults.md
@@ -58,7 +58,7 @@ defaults:
 {%@ Note type: :warning do %}
   #### Stop and rerun <code>bridgetown start</code>
 
-  The <code>bridgetown.config.yml</code> master configuration file contains global configurations and variable definitions that are read once at execution time. Changes made to <code>bridgetown.config.yml</code> will not trigger an automatic regeneration.
+  The <code>bridgetown.config.yml</code> main configuration file contains global configurations and variable definitions that are read once at execution time. Changes made to <code>bridgetown.config.yml</code> will not trigger an automatic regeneration.
 
   Use [Data Files](/docs/datafiles) to set up metadata variables and other structured content you can be sure will get reloaded during automatic regeneration.
 {% end %}

--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -118,7 +118,7 @@ test:
   - bin/bridgetown build --base_path mysite --url https://bridgetownrb.gitlab.io
   - bin/bridgetown clean
   except:
-    - master
+    - main
 
 pages:
   script:
@@ -141,7 +141,7 @@ pages:
     paths:
     - public
   only:
-  - master
+  - main
 
 ```
 Once this file has been created, add it and the other files and folders to the repository, and then push them to GitLab:
@@ -151,7 +151,7 @@ git add .gitlab-ci.yml
 git remote add origin https://gitlab.com/bridgetownrb/mysite
 git add .
 git commit -am "initial commit"
-git push -u origin master
+git push -u origin main
 ```
 
 After the build the site should be live at https://bridgetownrb.gitlab.io/mysite


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
In the documentation, there's a lot of references to old named branches `master`. This PR correct them by renaming them `main`. Noteworthy : I didnt' change any coding files (or if so, it was only things commented) in order not to break anything, but with review help I can also manage it if wanted.

## Context
Fix #642 