### PR TITLE
fix: update broken initializers documentation link

### DIFF
--- a/bridgetown-core/lib/site_template/config/initializers.rb
+++ b/bridgetown-core/lib/site_template/config/initializers.rb
@@ -39,5 +39,5 @@ Bridgetown.configure do |config|
   #
 
   # For more documentation on how to configure your site using this initializers file,
-  # visit: https://edge.bridgetownrb.com/documentation/configuration/initializers/
+  # visit: https://edge.bridgetownrb.com/docs/configuration/initializers/
 end


### PR DESCRIPTION
This is a 🔦 documentation(ish) change.

## Summary

Replace documentation link in the initializers site template file that points to the wrong URL.

## Context

The site template initializer file points to `/documentation/` instead of `/docs/` resulting in a page not found error when clicking the link. 

As some added context, I couldn't actually find the initializers documentation for a moment, maybe it would be helpful to link to it in some predominate places/on the sidemenu?
