### PR TITLE
feat: Localize file-based dynamic routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Localize file-based dynamic routes ([tommasongr](https://github.com/tommasongr))
+
 ## [1.2.0.beta3] - 2022-10-09
 
 - Updates to Lit and Tailwind configurations

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ Bridgetown is built by:
 |<a href="https://github.com/nachoal">@nachoal</a>|<a href="https://github.com/deivid-rodriguez">@deivid-rodriguez</a>|<a href="https://github.com/Eric-Guo">@Eric-Guo</a>|<a href="https://github.com/jacobherrington">@jacobherrington</a>|<a href="https://github.com/fpsvogel">@fpsvogel</a>|
 |CDMX, México|Madrid, Spain|Shanghai, China|Fayetteville, AR|Lexington, KY|
 
-|<img src="https://avatars.githubusercontent.com/vvveebs?s=256" alt="vvveebs" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
-|:---:|:---:|
-|<a href="https://github.com/vvveebs">@vvveebs</a>|You Next?|
-|London, UK|Anywhere|
+|<img src="https://avatars.githubusercontent.com/vvveebs?s=256" alt="vvveebs" width="128" />|<img src="https://avatars.githubusercontent.com/tommasongr?s=256" alt="tommasongr" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
+|:---:|:---:|:---:|
+|<a href="https://github.com/vvveebs">@vvveebs</a>|<a href="https://github.com/tommasongr">@tommasongr</a>|You Next?|
+|London, UK|Milan, IT|Anywhere|
 
 Interested in joining the Bridgetown Core Team? Send a DM to Jared in [Discord](https://discord.gg/4E6hktQGz4) and let's chat!
 

--- a/bridgetown-routes/lib/bridgetown-routes/manifest.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/manifest.rb
@@ -32,7 +32,19 @@ module Bridgetown
                 ":#{Regexp.last_match(1)}"
               end
 
-              [file, file_slug, segment_keys]
+              # generate localized file slugs
+              localized_file_slugs = []
+              site.config.available_locales.each do |locale|
+                localized_file_slugs.push(
+                  if locale == site.config.default_locale && !site.config.prefix_default_locale
+                    file_slug
+                  else
+                    "#{locale}/#{file_slug}"
+                  end
+                )
+              end
+
+              [file, localized_file_slugs, segment_keys]
             end
 
             new_manifest += sort_routes!(routes)
@@ -56,6 +68,16 @@ module Bridgetown
               weight1
             end
           end.reverse!
+        end
+
+        def locale_for(slug, site)
+          possible_locale_segment = slug.split("/").first.to_sym
+
+          if site.config.available_locales.include? possible_locale_segment
+            possible_locale_segment
+          else
+            site.config.default_locale
+          end
         end
       end
     end

--- a/bridgetown-routes/lib/bridgetown-routes/manifest.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/manifest.rb
@@ -33,15 +33,12 @@ module Bridgetown
               end
 
               # generate localized file slugs
-              localized_file_slugs = []
-              site.config.available_locales.each do |locale|
-                localized_file_slugs.push(
-                  if locale == site.config.default_locale && !site.config.prefix_default_locale
-                    file_slug
-                  else
-                    "#{locale}/#{file_slug}"
-                  end
-                )
+              localized_file_slugs = site.config.available_locales.map do |locale|
+                if locale == site.config.default_locale && !site.config.prefix_default_locale
+                  file_slug
+                else
+                  "#{locale}/#{file_slug}"
+                end
               end
 
               [file, localized_file_slugs, segment_keys]

--- a/bridgetown-routes/lib/bridgetown-routes/manifest.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/manifest.rb
@@ -33,13 +33,7 @@ module Bridgetown
               end
 
               # generate localized file slugs
-              localized_file_slugs = site.config.available_locales.map do |locale|
-                if locale == site.config.default_locale && !site.config.prefix_default_locale
-                  file_slug
-                else
-                  "#{locale}/#{file_slug}"
-                end
-              end
+              localized_file_slugs = generate_localized_file_slugs(site, file_slug)
 
               [file, localized_file_slugs, segment_keys]
             end
@@ -74,6 +68,18 @@ module Bridgetown
             possible_locale_segment
           else
             site.config.default_locale
+          end
+        end
+
+        private
+
+        def generate_localized_file_slugs(site, file_slug)
+          site.config.available_locales.map do |locale|
+            if locale == site.config.default_locale && !site.config.prefix_default_locale
+              file_slug
+            else
+              "#{locale}/#{file_slug}"
+            end
           end
         end
       end

--- a/bridgetown-routes/lib/bridgetown-routes/manifest_router.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/manifest_router.rb
@@ -19,30 +19,36 @@ module Bridgetown
           file, localized_file_slugs, segment_keys = route
 
           localized_file_slugs.each do |file_slug|
-            r.on file_slug do |*segment_values|
-              response["X-Bridgetown-SSR"] = "1"
-              # eval_route_file caches when Bridgetown.env.production?
-              Bridgetown::Routes::CodeBlocks.eval_route_file file, file_slug, @_roda_app
-
-              segment_values.each_with_index do |value, index|
-                r.params[segment_keys[index]] ||= value
-              end
-
-              # set route locale
-              locale = Bridgetown::Routes::Manifest.locale_for(file_slug, bridgetown_site)
-              I18n.locale       = locale
-              r.params[:locale] = locale
-
-              route_block = Bridgetown::Routes::CodeBlocks.route_block(file_slug)
-              response.instance_variable_set(
-                :@_route_file_code, route_block.instance_variable_get(:@_route_file_code)
-              ) # could be nil
-              @_roda_app.instance_exec(r, &route_block)
-            end
+            add_route(r, file, file_slug, segment_keys)
           end
         end
 
         nil
+      end
+
+      private
+
+      def add_route(route, file, file_slug, segment_keys)
+        route.on file_slug do |*segment_values|
+          response["X-Bridgetown-SSR"] = "1"
+          # eval_route_file caches when Bridgetown.env.production?
+          Bridgetown::Routes::CodeBlocks.eval_route_file file, file_slug, @_roda_app
+
+          segment_values.each_with_index do |value, index|
+            route.params[segment_keys[index]] ||= value
+          end
+
+          # set route locale
+          locale = Bridgetown::Routes::Manifest.locale_for(file_slug, bridgetown_site)
+          I18n.locale           = locale
+          route.params[:locale] = locale
+
+          route_block = Bridgetown::Routes::CodeBlocks.route_block(file_slug)
+          response.instance_variable_set(
+            :@_route_file_code, route_block.instance_variable_get(:@_route_file_code)
+          ) # could be nil
+          @_roda_app.instance_exec(route, &route_block)
+        end
       end
     end
   end

--- a/bridgetown-routes/lib/bridgetown-routes/manifest_router.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/manifest_router.rb
@@ -16,22 +16,29 @@ module Bridgetown
         end
 
         Bridgetown::Routes::Manifest.generate_manifest(bridgetown_site).each do |route|
-          file, file_slug, segment_keys = route
+          file, localized_file_slugs, segment_keys = route
 
-          r.on file_slug do |*segment_values|
-            response["X-Bridgetown-SSR"] = "1"
-            # eval_route_file caches when Bridgetown.env.production?
-            Bridgetown::Routes::CodeBlocks.eval_route_file file, file_slug, @_roda_app
+          localized_file_slugs.each do |file_slug|
+            r.on file_slug do |*segment_values|
+              response["X-Bridgetown-SSR"] = "1"
+              # eval_route_file caches when Bridgetown.env.production?
+              Bridgetown::Routes::CodeBlocks.eval_route_file file, file_slug, @_roda_app
 
-            segment_values.each_with_index do |value, index|
-              r.params[segment_keys[index]] ||= value
+              segment_values.each_with_index do |value, index|
+                r.params[segment_keys[index]] ||= value
+              end
+
+              # set route locale
+              locale = Bridgetown::Routes::Manifest.locale_for(file_slug, bridgetown_site)
+              I18n.locale       = locale
+              r.params[:locale] = locale
+
+              route_block = Bridgetown::Routes::CodeBlocks.route_block(file_slug)
+              response.instance_variable_set(
+                :@_route_file_code, route_block.instance_variable_get(:@_route_file_code)
+              ) # could be nil
+              @_roda_app.instance_exec(r, &route_block)
             end
-
-            route_block = Bridgetown::Routes::CodeBlocks.route_block(file_slug)
-            response.instance_variable_set(
-              :@_route_file_code, route_block.instance_variable_get(:@_route_file_code)
-            ) # could be nil
-            @_roda_app.instance_exec(r, &route_block)
           end
         end
 

--- a/bridgetown-routes/test/ssr/config/initializers.rb
+++ b/bridgetown-routes/test/ssr/config/initializers.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-Bridgetown.configure do
+Bridgetown.configure do |config|
   require "bridgetown-routes"
   init :"bridgetown-routes", require_gem: false
 
   routes.source_paths << File.expand_path("alt_routes", "#{root_dir}/../")
+
+  config.available_locales = [:en, :it]
+  config.default_locale = :en
+  config.prefix_default_locale = false
 end

--- a/bridgetown-routes/test/ssr/src/_routes/localized.erb
+++ b/bridgetown-routes/test/ssr/src/_routes/localized.erb
@@ -1,0 +1,7 @@
+---<%
+render_with data: {
+  title: "Localized"
+}
+%>---
+
+<h1>Localized for <%= r.params[:locale] %> - <%= I18n.locale %></h1>

--- a/bridgetown-routes/test/test_routes.rb
+++ b/bridgetown-routes/test/test_routes.rb
@@ -36,5 +36,15 @@ class TestRoutes < BridgetownUnitTest
       get "/yello/my-friend"
       assert_equal "<p>So arbitrary!</p>\n", last_response.body
     end
+
+    should "return HTML for a route localized in english" do
+      get "/localized"
+      assert_equal "<h1>Localized for en - en</h1>\n", last_response.body
+    end
+
+    should "return HTML for a route localized in italian" do
+      get "/it/localized"
+      assert_equal "<h1>Localized for it - it</h1>\n", last_response.body
+    end
   end
 end

--- a/bridgetown-routes/test/test_routes.rb
+++ b/bridgetown-routes/test/test_routes.rb
@@ -14,7 +14,7 @@ class TestRoutes < BridgetownUnitTest
     app.opts[:bridgetown_site]
   end
 
-  context "Roda-powered Bridgetown server" do
+  context "Roda-powered Bridgetown server" do # rubocop:todo Metrics/BlockLength
     should "return the index page" do
       get "/"
       assert last_response.ok?


### PR DESCRIPTION
## Summary

Adds localized routes under the `_routes` folder. This is done by creating all the possible slugs on the fly based on `site.config.available_locales`.

Every route will set `I18n.locale`  and `r.params[:locale]` to the corresponding value extracted from the url slug.

A possible missing piece might be a dedicated config for opting-in/out from the behavior. However, I think that forcing the locale on the file frontmatter could be a good enough alternative and possibly a more granular one.