### PR TITLE
Support for gems.rb

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -16,6 +16,7 @@ end
 
 # rubygems
 require "rubygems"
+require "bundler/shared_helpers"
 
 # stdlib
 require "find"

--- a/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/concerns/actions.rb
@@ -56,8 +56,9 @@ module Bridgetown
         options = +""
         options += " -v \"#{version}\"" if version
         options += " -g #{group}" if group
+        # in_bundle? returns the path to the gemfile
         run "bundle add #{gemname}#{options}",
-            env: { "BUNDLE_GEMFILE" => File.join(destination_root, "Gemfile") }
+            env: { "BUNDLE_GEMFILE" => Bundler::SharedHelpers.in_bundle? }
       rescue SystemExit
         say_status :run, "Gem not added due to bundler error", :red
       end

--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -400,7 +400,7 @@ module Bridgetown
 
     DEFAULT_EXCLUDES = %w(
       .sass-cache .bridgetown-cache
-      gemfiles Gemfile Gemfile.lock
+      gemfiles Gemfile Gemfile.lock gems.rb gems.locked
       node_modules
       vendor/bundle/ vendor/cache/ vendor/gems/ vendor/ruby/
     ).freeze

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -61,7 +61,8 @@ module Bridgetown
     end
 
     def self.setup_bundler(skip_yarn: false)
-      if !ENV["BRIDGETOWN_NO_BUNDLER_REQUIRE"] && (File.file?("Gemfile") || Bridgetown.env.test?)
+      if !ENV["BRIDGETOWN_NO_BUNDLER_REQUIRE"] &&
+          (Bundler::SharedHelpers.in_bundle? || Bridgetown.env.test?)
         require "bundler"
 
         require_relative "utils/initializers"

--- a/bridgetown-core/test/test_plugin_manager.rb
+++ b/bridgetown-core/test/test_plugin_manager.rb
@@ -3,13 +3,6 @@
 require "helper"
 
 class TestPluginManager < BridgetownUnitTest
-  def with_no_gemfile
-    FileUtils.mv "../Gemfile", "../Gemfile.old"
-    yield
-  ensure
-    FileUtils.mv "../Gemfile.old", "../Gemfile"
-  end
-
   context "BRIDGETOWN_NO_BUNDLER_REQUIRE set to `nil`" do
     setup do
       FileUtils.cp "../Gemfile", "."
@@ -50,7 +43,7 @@ class TestPluginManager < BridgetownUnitTest
     should "not setup bundler" do
       with_env("BRIDGETOWN_NO_BUNDLER_REQUIRE", nil) do
         with_env("BRIDGETOWN_ENV", nil) do
-          with_no_gemfile do
+          Bundler::SharedHelpers.stub(:in_bundle?, nil) do
             refute Bridgetown::PluginManager.setup_bundler,
                    "Gemfile plugins were required but shouldn't have been"
             assert_nil ENV["BRIDGETOWN_NO_BUNDLER_REQUIRE"]


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

(Note: Rubocop errors prevent the tests to run, I've tested manually for now and wait for #644 to be merged. However, I create the PR now to get your comments on the changes already.)

## Summary

Bundler added `gems.rb`/`gems.locked` as alternatives to `Gemfile`/`Gemfile.lock` some years ago, mainly to have proper syntax coloring in editors.

Bridgetown has a few places where `Gemfile` is hardcoded, this PR adds support for `gems.rb`. However, in order to assure downwards compatibility, the fallback `Gemfile` is maintained.

Thanks for reviewing and commenting!