### PR TITLE
Parse using JSON.parse for more resilient parsing

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/repo_origin.rb
@@ -111,7 +111,7 @@ module Bridgetown
           collection.data?
       end
 
-      def read_file_data # rubocop:todo Metrics/MethodLength
+      def read_file_data # rubocop:todo Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
         case original_path.extname.downcase
         when ".csv"
           {
@@ -130,6 +130,9 @@ module Bridgetown
           }
         when ".rb"
           process_ruby_data(File.read(original_path), original_path, 1)
+        when ".json"
+          json_data = JSON.parse(File.read(original_path))
+          json_data.is_a?(Array) ? { rows: json_data } : json_data
         else
           yaml_data = YAMLParser.load_file(original_path)
           yaml_data.is_a?(Array) ? { rows: yaml_data } : yaml_data


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

YAMLParser (which is backed by Ruby's YAML parser) appears to have a problem with larger json files.

On one source file, I ran into `Error: YAML Exception reading ../src/_data/posts.json: control characters are not allowed at line 1 column 1`. But when patched to use JSON.parse, it works well.

No tests are needed because it's hit heavily throughout the test suite

## Context

A project that I have has a rather large json file as it's data source (2.3M JSON file) and it appears that these larger files have some issues being parsed by the ruby YAML parser (aka. `YAML.load`)  which can also parse json. This data file has been validated with `jq` and `JSON.parse`.
