### PR TITLE
Filter `Bridgetown::Localizable#all_locales` under the source's parent directory

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/localizable.rb
@@ -12,7 +12,11 @@ module Bridgetown
                      []
                    end
 
-      result_set.select { |item| item.data.slug == data.slug }.sort_by do |item|
+      matching_resources = result_set.select do |item|
+        item.relative_path.parent == relative_path.parent && item.data.slug == data.slug
+      end
+
+      matching_resources.sort_by do |item|
         site.config.available_locales.index item.data.locale
       end
     end

--- a/bridgetown-core/test/resources/src/_pages/my_directory/third-level-page.en.md
+++ b/bridgetown-core/test/resources/src/_pages/my_directory/third-level-page.en.md
@@ -1,0 +1,3 @@
+~~~ruby
+{ title: "I'm a Third Level Page" }
+~~~

--- a/bridgetown-core/test/resources/src/_pages/my_directory/third-level-page.fr.md
+++ b/bridgetown-core/test/resources/src/_pages/my_directory/third-level-page.fr.md
@@ -1,0 +1,3 @@
+~~~ruby
+{ title: "I'm a Third Level Page in French" }
+~~~

--- a/bridgetown-core/test/resources/src/_pages/my_other_directory/third-level-page.en.md
+++ b/bridgetown-core/test/resources/src/_pages/my_other_directory/third-level-page.en.md
@@ -1,0 +1,3 @@
+~~~ruby
+{ title: "I'm a Third Level Page" }
+~~~

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -78,6 +78,27 @@ class TestLocales < BridgetownUnitTest
     end
   end
 
+  context "a page with a slug that matches others in this directory and also another directory" do
+    setup do
+      @site = resources_site
+      @site.process
+      # @type [Bridgetown::Resource::Base]
+      @resource = @site.collections.pages.resources.find do |page|
+        page.relative_path.to_s == "_pages/my_directory/third-level-page.en.md"
+      end
+
+      @resource_with_matching_slug_in_same_directory = @site.collections.pages.resources.find do |page|
+        page.relative_path.to_s == "_pages/my_directory/third-level-page.fr.md"
+      end
+    end
+
+    context "#all_locales" do
+      should "list only the resources with the same slug and the same parent directory" do
+        assert_equal([@resource, @resource_with_matching_slug_in_same_directory], @resource.all_locales)
+      end
+    end
+  end
+
   context "one page which is generated into multiple locales (as specified in locales key)" do
     setup do
       reset_i18n_config

--- a/bridgetown-website/src/_docs/internationalization.md
+++ b/bridgetown-website/src/_docs/internationalization.md
@@ -106,7 +106,7 @@ Create a separate resource file for each locale. You can either use the `locale`
 
 ### Multi-Locale Files
 
-If the same resource should be available to multiple locales, use a single resource file in "multi locale" mode and use special front mater and template syntax to include translated content. You can switch to this mode by setting `locale: multi` in your front matter or using the `.multi` extension within your file name. For example: `about.multi.md`. This will generate resources in all of your `site.config.available_locales`.
+If the same resource should be available to multiple locales, use a single resource file in "multi locale" mode and use special front matter and template syntax to include translated content. You can switch to this mode by setting `locale: multi` in your front matter or using the `.multi` extension within your file name. For example: `about.multi.md`. This will generate resources in all of your `site.config.available_locales`.
 
 If you want to only output a limited set of locales, then use the `locales` front matter key to include only the locales that should be written.
 


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This is to avoid an issue where resources with the same slugs under different directories are included in the results.

## Context

Closes #660
