### PR TITLE
Fix the readability of namespaces in dark mode

### DIFF
--- a/bridgetown-website/frontend/styles/theme-dark.css
+++ b/bridgetown-website/frontend/styles/theme-dark.css
@@ -69,7 +69,8 @@
   }
 
   & .highlight .no,
-  & .highlight .nc {
+  & .highlight .nc,
+  & .highlight .nn {
     color: var(--color-dark-brick);
   }
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Without this, namespaces end up the same color as the background so they are unreadable. This change makes namespaces the same color as classes and constants.

```ruby
module Foo
    #  ^------ this is a namespace
  class Bar
    #   ^----- and it will be the same color as this
  end
end
```

## Context

None.
