### PR TITLE
Issue 661 mixed locale types

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -285,7 +285,7 @@ module Bridgetown
         locales = model.locales || site.config.available_locales
 
         locales.each do |locale|
-          model.locale = locale
+          model.locale = locale.to_sym
           add_resource_from_model model
         end
 

--- a/bridgetown-core/lib/bridgetown-core/resource/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/base.rb
@@ -373,7 +373,7 @@ module Bridgetown
         found_locale = data.language || data.lang || basename_without_ext.split(".")[1..].last
         return unless found_locale && site.config.available_locales.include?(found_locale.to_sym)
 
-        found_locale
+        found_locale.to_sym
       end
 
       def format_url(url)

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -113,8 +113,7 @@ class TestLocales < BridgetownUnitTest
       @resources = @site.collections.pages.resources.select do |page|
         page.relative_path.to_s == "_pages/multi-page-with-specified-locales.multi.md"
       end
-      @english_resource = @resources.find { |page| page.data.locale == "en" }
-      @french_resource = @resources.find { |page| page.data.locale == "fr" }
+      @english_resource = @resources.find { |page| page.data.locale == :en }
     end
 
     should "have the correct permalink and locale in English" do
@@ -124,8 +123,8 @@ class TestLocales < BridgetownUnitTest
       assert_includes @english_resource.output, "<p>English: Multi-locale with specified locales page</p>"
     end
 
-    should "have not have a locale in French" do
-      assert_equal @french_resource, nil
+    should "not have generated any locales other than English" do
+      assert_equal 1, @resources.length
     end
   end
 

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -15,7 +15,7 @@ class TestLocales < BridgetownUnitTest
     I18n.fallbacks = nil if I18n.respond_to?(:fallbacks=)
   end
 
-  context "similar pages in different locales" do
+  context "similar pages in different locales as specified in filename" do
     setup do
       reset_i18n_config
       @site = resources_site
@@ -45,7 +45,7 @@ class TestLocales < BridgetownUnitTest
     end
   end
 
-  context "one page which is generated into multiple locales" do
+  context "one page which is generated into all available_locales" do
     setup do
       reset_i18n_config
       @site = resources_site
@@ -99,7 +99,7 @@ class TestLocales < BridgetownUnitTest
     end
   end
 
-  context "one page which is generated into multiple locales (as specified in locales key)" do
+  context "one page which is generated into a subset of available_locales (as specified in locales key)" do
     setup do
       reset_i18n_config
       @site = resources_site

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -29,6 +29,11 @@ class TestLocales < BridgetownUnitTest
       end
     end
 
+    should "return locales as symbols" do
+      assert_equal :en, @english_resource.data.locale
+      assert_equal :fr, @french_resource.data.locale
+    end
+
     should "have the correct permalink and locale in English" do
       assert_equal "/second-level-page/", @english_resource.relative_url
       assert_includes @english_resource.output, "<p>Locale: en</p>"


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This should make `resource.data.locale` consistently return symbols.

## Context

Resolves #661
