### PR TITLE
684-restore-localhost-url-with-initializers

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -130,7 +130,7 @@ module Bridgetown
       end
     end
 
-    def run_initializers!(context:)
+    def run_initializers!(context:) # rubocop:todo Metrics/AbcSize, Metrics/CyclomaticComplexity
       initializers_file = File.join(root_dir, "config", "initializers.rb")
       return unless File.file?(initializers_file)
 
@@ -144,9 +144,11 @@ module Bridgetown
       Bridgetown.logger.debug "Initializing:", "Running initializers with `#{context}' context in:"
       Bridgetown.logger.debug "", initializers_file
       self.init_params = {}
+      cached_url = url&.include?("//localhost") ? url : nil
       dsl = ConfigurationDSL.new(scope: self, data: self)
       dsl.instance_variable_set(:@context, context)
       dsl.instance_exec(dsl, &init_init.block)
+      self.url = cached_url if cached_url # restore local development URL if need be
 
       setup_load_paths! appending: true
 

--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -310,7 +310,8 @@ module Bridgetown
       next_config
     rescue SystemCallError
       if @default_config_file ||= nil
-        Bridgetown.logger.warn "Configuration file:", "none"
+        initializers_file = File.join(root_dir, "config", "initializers.rb")
+        Bridgetown.logger.warn "Configuration file:", "none" unless File.file?(initializers_file)
         {}
       else
         Bridgetown.logger.error "Fatal:", "The configuration file '#{file}' could not be found."


### PR DESCRIPTION
Fixes issue #684

Also removes the missing configuration file warning if an initializers-based config is available