### PR TITLE
Add details for importing Shoelace

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Bridgetown is built by:
 |London, UK|Ohio, US|Amsterdam, The Netherlands|Milan, IT|Europe|
 
 |<img src="https://avatars.githubusercontent.com/michaelherold?s=256" alt="michaelherold" width="128" />|<img src="https://avatars.githubusercontent.com/joemasilotti?s=256" alt="joemasilotti" width="128" />|<img src="https://avatars.githubusercontent.com/ikass?s=256" alt="ikass" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
-|:---:|:---:|:---:|
+|:---:|:---:|:---:|:---:|
 |<a href="https://github.com/michaelherold">@michaelherold</a>|<a href="https://github.com/joemasilotti">@joemasilotti</a>|<a href="https://github.com/Ikass">@ikass</a>|You Next?|
 |Omaha, NE|Portland, OR|Latvia|Anywhere|
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Bridgetown is built by:
 |<a href="https://github.com/vvveebs">@vvveebs</a>|<a href="https://github.com/rickychilcott">@rickychilcott</a>|<a href="https://github.com/tommasongr">@tommasongr</a>|<a href="https://github.com/tombruijn">@tombruijn</a>|<a href="https://github.com/svoop">@svoop</a>|
 |London, UK|Ohio, US|Amsterdam, The Netherlands|Milan, IT|Europe|
 
-|<img src="https://avatars.githubusercontent.com/michaelherold?s=256" alt="michaelherold" width="128" />|<img src="https://avatars.githubusercontent.com/joemasilotti?s=256" alt="joemasilotti" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
+|<img src="https://avatars.githubusercontent.com/michaelherold?s=256" alt="michaelherold" width="128" />|<img src="https://avatars.githubusercontent.com/joemasilotti?s=256" alt="joemasilotti" width="128" />|<img src="https://avatars.githubusercontent.com/ikass?s=256" alt="ikass" width="128" />|<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
 |:---:|:---:|:---:|
-|<a href="https://github.com/michaelherold">@michaelherold</a>|<a href="https://github.com/joemasilotti">@joemasilotti</a>|You Next?|
-|Omaha, NE|Portland, OR|Anywhere|
+|<a href="https://github.com/michaelherold">@michaelherold</a>|<a href="https://github.com/joemasilotti">@joemasilotti</a>|<a href="https://github.com/Ikass">@ikass</a>|You Next?|
+|Omaha, NE|Portland, OR|Latvia|Anywhere|
 
 Interested in joining the Bridgetown Core Team? Send a DM to Jared in [Discord](https://discord.gg/4E6hktQGz4) and let's chat!
 

--- a/bridgetown-website/src/_docs/bundled-configurations.md
+++ b/bridgetown-website/src/_docs/bundled-configurations.md
@@ -89,6 +89,10 @@ Read our full [Lit Components documentation here](/docs/components/lit).
 
 👟 Installs [Shoelace](https://shoelace.style) for an instant design system and UI component library at your fingertips. Use CSS variables and shadow parts to customize the look and feel of Shoelace components in any way you like. This very website uses Shoelace for example.
 
+Individual components can be imported by adding the `import` statement to the `./frontend/javascript/index.js` file. Refer to Shoelace documentation Importing section for each individual component, and copy the `import` statement under the Bundler tab.
+
+Read more at [Frontend Bundling (CSS/JS/etc.)](/docs/frontend-assets#javascript). 
+
 🛠 **Configure using:**
 
 ```sh


### PR DESCRIPTION
This is a 🔦 documentation change.

 - I've adjusted the documentation (if it's a feature or enhancement)


## Summary

Added details to Shoelace section on the [Bundled Configuration](https://www.bridgetownrb.com/docs/bundled-configurations#shoelace) page for adding additional Shoelace components, like `card`.

## Context

Could not get a `card` component working on a new site. Turns out I needed to `import` it via the `./frontend/javascript/index.js` file. So added the details to the website documentation, to help out other noobs like me.

Also added myself to the contributors section of the README file. Congrats to myself for my first open-source contribution. :)
