### PR TITLE
fix: load `initializers.rb` instead of require for working tests

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -134,7 +134,7 @@ module Bridgetown
       initializers_file = File.join(root_dir, "config", "initializers.rb")
       return unless File.file?(initializers_file)
 
-      require initializers_file
+      load initializers_file
 
       return unless initializers # no initializers have been set up
 

--- a/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
@@ -132,7 +132,7 @@ module Bridgetown
 
         if require_initializer
           init_file_name = File.join(@scope.root_dir, "config", "#{name}.rb")
-          require(init_file_name) if File.exist?(init_file_name)
+          load(init_file_name) if File.exist?(init_file_name)
         end
 
         @scope.initializers[name.to_sym]

--- a/bridgetown-core/test/ssr/config/initializers.rb
+++ b/bridgetown-core/test/ssr/config/initializers.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 Bridgetown.configure do
-  init :ssr do
-    setup ->(site) do
-      site.data.iterations ||= 0
-      site.data.iterations += 1
-    end
-  end
+  # attempt multiple inits just to ensure it is idempotent
+  init :local_ssr_init, require_gem: false
+  init :local_ssr_init, require_gem: false
+  init :local_ssr_init, require_gem: false
 end

--- a/bridgetown-core/test/ssr/config/local_ssr_init.rb
+++ b/bridgetown-core/test/ssr/config/local_ssr_init.rb
@@ -1,0 +1,8 @@
+Bridgetown.initializer :local_ssr_init do |config|
+  config.init :ssr do
+    setup ->(site) do
+      site.data.iterations ||= 0
+      site.data.iterations += 1
+    end
+  end
+end

--- a/bridgetown-core/test/ssr/config/local_ssr_init.rb
+++ b/bridgetown-core/test/ssr/config/local_ssr_init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Bridgetown.initializer :local_ssr_init do |config|
   config.init :ssr do
     setup ->(site) do


### PR DESCRIPTION
## Summary

This changes the code which executes Bridgetown's Ruby configuration DSL so initializer files in `config` are loaded via `load` rather than `require`

## Context

In testing scenarios (such as plugin gems) when `run_initializers!` may be called many times across a series of tests, the available initializers were blank after the first run. That's because the file to set up those initializers wasn't getting executed by Ruby. We need to `load` rather than `require` those files.

I'm pretty sure this isn't a breaking change, but we'll want to keep an eye on any odd behavior (possibly due to some mistake in attempting to run initializers more than once on the same site config)