### PR TITLE
Add method to reset config for test suites

### DIFF
--- a/bridgetown-core/test/helper.rb
+++ b/bridgetown-core/test/helper.rb
@@ -152,7 +152,7 @@ class BridgetownUnitTest < Minitest::Test
   end
 
   def site_configuration(overrides = {})
-    Bridgetown::Current.preloaded_configuration = Bridgetown::Configuration::Preflight.new
+    Bridgetown.reset_configuration!
 
     load_plugin_content(Bridgetown::Current.preloaded_configuration)
 


### PR DESCRIPTION
This adds a `Bridgetown.reset_configuration!` method which test suites can call before creating new configuration objects prior to site instantiation. This is required so that previously-defined initializers (other than for the site itself i.e. loaded via `config/*`) / source manifests are available once again to a new site config.