### PR TITLE
Set timezone from initializer Ruby DSL

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -276,6 +276,14 @@ module Bridgetown
     def set_timezone(timezone)
       ENV["TZ"] = timezone
     end
+
+    # Get the current TZ environment variable
+    #
+    # @return [String]
+    def timezone
+      ENV["TZ"]
+    end
+
     # rubocop:enable Naming/AccessorMethodName
 
     # Fetch the logger instance for this Bridgetown process.

--- a/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
@@ -72,6 +72,10 @@ module Bridgetown
         @scope.roda_initializers << block
       end
 
+      def timezone(tz) # rubocop:disable Naming/MethodParameterName
+        Bridgetown.set_timezone(tz)
+      end
+
       def method_missing(key, *value, &block) # rubocop:disable Style/MissingRespondToMissing
         return get(key) if value.empty? && block.nil?
 

--- a/bridgetown-core/test/test_configuration.rb
+++ b/bridgetown-core/test/test_configuration.rb
@@ -543,5 +543,16 @@ class TestConfiguration < BridgetownUnitTest
 
       assert @config.init_params.key?("something")
     end
+
+    should "set the global timezone" do
+      dsl = Configuration::ConfigurationDSL.new(scope: @config, data: @config)
+
+      dsl.instance_variable_set(:@context, :testing)
+      dsl.instance_exec(dsl) do
+        timezone "GMT"
+      end
+
+      assert_equal "GMT", Bridgetown.timezone
+    end
   end
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

While running tests for the `bridgetown-sitemap` plugin, I found that the timezone wasn't being set if it was defined ONLY in the Ruby initializers file. I have no idea why this wasn't a problem yesterday, but it is today.

Upon investigation, I found that the timezone is set as an environment variable but this only happens when the configuration object is instantiated. The initializers run after the object is instantiated. Hence, the timezone value was set in the configuration object, but not in the environment variable meaning it wasn't used in the build.

I've added a `timezone` method to the DSL which sets this value.


