### PR TITLE
Add warning to prototype-pages.md

### DIFF
--- a/bridgetown-website/src/_docs/prototype-pages.md
+++ b/bridgetown-website/src/_docs/prototype-pages.md
@@ -52,6 +52,12 @@ prototype:
 
 You'd get `Posts in category Cool Vacation` as the page title.
 
+{%@ Note type: "warning" do %}
+  #### Unspecified Class: Symbol Warning
+
+  If you would like `:prototype-term` or `:prototype-term-titleize` to appear first in the title, you must wrap the _whole_ title in quotes to avoid a parsing error.
+{% end %}
+
 In addition, the search term used for each generated page is placed into a Liquid
 variable, so you can use that as well in your template: `page.data.category`, or `page.data.tag`,
 etc.


### PR DESCRIPTION
Add warning regarding the placement of `:prototype-term` symbol at the beginning of the title on a prototype page. Quotes are needed to avoid a parsing error.

This is a 🔦 documentation change.

## Summary

Added a warning note to prototype-pages.md specifying that quotes must be used around the entire title if the special symbols `:prototype-term` or `:prototype-term-titleize` are to appear first in the title.

## Context

  Resolves #707
