### PR TITLE
Fix typo in initializers docs

### DIFF
--- a/bridgetown-website/src/_docs/configuration/initializers.md
+++ b/bridgetown-website/src/_docs/configuration/initializers.md
@@ -141,7 +141,7 @@ Initializing: The `insert_gem_name_here' initializer could not be found
 
 No worries! _You can write your own initializer._ 😎
 
-As in the example at the top of the page, you can place an initializer right alongside the configure block in `config/initializers.rb`. You can also place a file named the same as the initializer directly in `config`. In the use case of using the Stripe gem, you could add to `config/stripe.rb`:
+As in the example at the top of the page, you can place an initializer right alongside the configure block in `config/initializers.rb`. You can also place a file named the same as the gem or plugin directly in `config`. In the use case of using the Stripe gem, you could add to `config/stripe.rb`:
 
 ```rb
 Bridgetown.initializer :stripe do |api_key:|


### PR DESCRIPTION
A very simple typo fix.
But please let me know if I misunderstood the docs and this is not a typo after all.