### PR TITLE
Clarify gem based plugin initializer instructions

### DIFF
--- a/bridgetown-website/src/_docs/plugins.md
+++ b/bridgetown-website/src/_docs/plugins.md
@@ -108,12 +108,12 @@ module MyNiftyPlugin
   end
 end
 
-# my_nifty_plugin.rb
+# lib/my_nifty_plugin.rb
 Bridgetown.initializer :my_nifty_plugin do |config|
   config.my_nifty_plugin ||= {}
   config.my_nifty_plugin.this_goes_to_11 ||= 11
 
-  builder MyNiftyPlugin::Builder
+  config.builder MyNiftyPlugin::Builder
 end
 ```
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Updated a section of the gem based plugin's documentation.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

I struggled to get my plugin to work.
It was unclear where I needed to add the plugin's initializer.

I referred to this plugin to figure out where to put the initializer.
https://github.com/ayushn21/bridgetown-sitemap/blob/main/lib/bridgetown-sitemap.rb

I also then saw an error: `undefined method `builder' for main:Object` which I fixed by updating that line to `config.builder`.
