### PR TITLE
Clarify adding keyword args to plugin initializers

### DIFF
--- a/bridgetown-website/src/_docs/plugins.md
+++ b/bridgetown-website/src/_docs/plugins.md
@@ -109,12 +109,28 @@ module MyNiftyPlugin
 end
 
 # lib/my_nifty_plugin.rb
-Bridgetown.initializer :my_nifty_plugin do |config|
+Bridgetown.initializer :my_nifty_plugin do |config, nifty_api: ''|
   config.my_nifty_plugin ||= {}
   config.my_nifty_plugin.this_goes_to_11 ||= 11
+  config.my_nifty_plugin.api_key = nifty_api
 
   config.builder MyNiftyPlugin::Builder
 end
+```
+
+Accepting keyword arguments is optional. The above example shows how you can use a keyword parameter to allow users to pass information from their initializers.rb file into your plugin. This example allows users to provide a `nifty_api` parameter from their `initializer.rb` file, but by default it is set to an empty string.
+
+Below is an example showing how a user could set the `nifty_api` parameter from within their `initializers.rb`.
+[Refer to the initializers documentation for more about initializers.](/docs/configuration/initializers).
+
+```ruby
+# config/initializers.rb
+Bridgetown.configure do |config|
+  init :my_nifty_plugin do
+    api_key "some-api-key"
+  end
+end
+
 ```
 
 [Read further instructions below on how to create and publish a gem.](#creating-a-gem)

--- a/bridgetown-website/src/_docs/plugins.md
+++ b/bridgetown-website/src/_docs/plugins.md
@@ -109,18 +109,18 @@ module MyNiftyPlugin
 end
 
 # lib/my_nifty_plugin.rb
-Bridgetown.initializer :my_nifty_plugin do |config, nifty_api: ''|
+Bridgetown.initializer :my_nifty_plugin do |config, api_key: ''|
   config.my_nifty_plugin ||= {}
   config.my_nifty_plugin.this_goes_to_11 ||= 11
-  config.my_nifty_plugin.api_key = nifty_api
+  config.my_nifty_plugin.api_key = api_key 
 
   config.builder MyNiftyPlugin::Builder
 end
 ```
 
-Accepting keyword arguments is optional. The above example shows how you can use a keyword parameter to allow users to pass information from their initializers.rb file into your plugin. This example allows users to provide a `nifty_api` parameter from their `initializer.rb` file, but by default it is set to an empty string.
+Accepting keyword arguments is optional. The above example shows how you can use a keyword parameter to allow users to pass information from their `initializers.rb` file into your plugin. This example allows users to provide a `api_key` parameter from their `initializer.rb` file, and for this example it defaults to an empty string.
 
-Below is an example showing how a user could set the `nifty_api` parameter from within their `initializers.rb`.
+Below shows how a user could set the `api_key` parameter from within their `initializers.rb`.
 [Refer to the initializers documentation for more about initializers.](/docs/configuration/initializers).
 
 ```ruby


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 


<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This PR adds some context to how we can use keyword arguments to pass values from an end user's initializers.rb file into our plugin's initializer.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
Closes: https://github.com/bridgetownrb/bridgetown/issues/716
