### PR TITLE
Fix passing headers and add passing parameters to HTTP DSL

### DIFF
--- a/bridgetown-builder/lib/bridgetown-builder/dsl/http.rb
+++ b/bridgetown-builder/lib/bridgetown-builder/dsl/http.rb
@@ -10,7 +10,7 @@ module Bridgetown
       module HTTP
         def get(url, headers: {}, parse_json: true)
           body = begin
-            connection(parse_json: parse_json).get(url, headers: headers).body
+            connection(parse_json: parse_json).get(url, nil, headers).body
           rescue Faraday::ParsingError
             Bridgetown.logger.error(
               "Faraday::ParsingError",

--- a/bridgetown-builder/lib/bridgetown-builder/dsl/http.rb
+++ b/bridgetown-builder/lib/bridgetown-builder/dsl/http.rb
@@ -8,9 +8,9 @@ module Bridgetown
   module Builders
     module DSL
       module HTTP
-        def get(url, headers: {}, parse_json: true)
+        def get(url, headers: {}, parse_json: true, **params)
           body = begin
-            connection(parse_json: parse_json).get(url, nil, headers).body
+            connection(parse_json: parse_json).get(url, params, headers).body
           rescue Faraday::ParsingError
             Bridgetown.logger.error(
               "Faraday::ParsingError",

--- a/bridgetown-builder/test/test_http_dsl.rb
+++ b/bridgetown-builder/test/test_http_dsl.rb
@@ -41,6 +41,12 @@ class HTTPBuilder < Builder
     end
   end
 
+  def test_parameters(**params)
+    get "/test_parameters.json", **params do |data|
+      @site.config[:received_parameters] = data
+    end
+  end
+
   def test_redirect
     get "/test_redirect.json" do |data|
       @site.config[:received_data] = data
@@ -133,6 +139,20 @@ class TestHTTPDSL < BridgetownUnitTest
       @builder.test_headers({ "X-Test" => "hello, world"})
 
       assert_equal "hello, world", @site.config[:received_headers]["X-Test"]
+    end
+
+    should "allows passing parameters to the GET request" do
+      @builder.stubs.get("/test_parameters.json") do |env|
+        [
+          200,
+          { "Content-Type": "application/javascript" },
+          env.params.to_json
+        ]
+      end
+
+      @builder.test_parameters(hello: "world")
+
+      assert_equal "world", @site.config[:received_parameters][:hello]
     end
   end
 end

--- a/bridgetown-builder/test/test_http_dsl.rb
+++ b/bridgetown-builder/test/test_http_dsl.rb
@@ -29,6 +29,12 @@ class HTTPBuilder < Builder
     end
   end
 
+  def test_headers(headers)
+    get "/test_headers.json", headers: headers do |data|
+      @site.config[:received_headers] = data
+    end
+  end
+
   def test_not_parsing_json
     get "/test_not_parsing.html", parse_json: false do |data|
       @site.config[:received_data] = data
@@ -113,6 +119,20 @@ class TestHTTPDSL < BridgetownUnitTest
       @builder.test_redirect
 
       assert_equal "received", @site.config[:received_data][:data][:was].first
+    end
+
+    should "correctly pass headers to the GET request" do
+      @builder.stubs.get("/test_headers.json") do |env|
+        [
+          200,
+          { "Content-Type": "application/javascript" },
+          env.request_headers
+        ]
+      end
+
+      @builder.test_headers({ "X-Test" => "hello, world"})
+
+      assert_equal "hello, world", @site.config[:received_headers]["X-Test"]
     end
   end
 end

--- a/bridgetown-website/src/_docs/plugins/external-apis.md
+++ b/bridgetown-website/src/_docs/plugins/external-apis.md
@@ -63,6 +63,18 @@ def build
 end
 ```
 
+### Adding parameters to the request
+
+To make it easier to pass query string parameters to the endpoint you're fetching, you may pass keyword arguments to the `get` method. For example:
+
+```ruby
+def build
+  get "https://example.com", test: 123 do |data|
+    # data from https://example.com?test=123
+  end
+end
+```
+
 ## Customizing the Connection Object
 
 Bridgetown uses the [Faraday gem](https://lostisland.github.io/faraday/) under the hood to make web requests. If you need to customize the default usage of Faraday—perhaps to set additional defaults or inject middleware to adjust the request or response logic—simply override the `connection` method in your builder class.


### PR DESCRIPTION
This is a 🐛 bug fix.
This is a 🙋 feature or enhancement.

## Summary

This change includes two related items:

1. Fixes the handling of headers for HTTP DSL requests. They were improperly being sent as a `headers` parameter and now will be sent as actual headers.
2. Adds sending parameters to the URL via keyword arguments. This is valuable because constructing the query string parameters directly is tedious and prone to typos.

## Context

Closes #630