### PR TITLE
Make OutputBuffer more performant for 3.2+ YJIT

### DIFF
--- a/bridgetown-core/test/bridgetown/test_output_buffer.rb
+++ b/bridgetown-core/test/bridgetown/test_output_buffer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "helper"
+
+module Bridgetown
+  class OutputBufferTest < BridgetownUnitTest
+    def setup
+      super
+      @buffer = Bridgetown::OutputBuffer.new
+    end
+
+    should "be able to be duped" do
+      @buffer << "Hello"
+      copy = @buffer.dup
+      copy << " world!"
+
+      assert_equal "Hello", @buffer.to_s
+      assert_equal "Hello world!", copy.to_s
+    end
+
+    context "#<<" do
+      should "maintain HTML safety" do
+        @buffer << "<p>Nothing bad to see here.</p>"
+
+        assert_predicate @buffer, :html_safe?
+        assert_predicate @buffer.to_s, :html_safe?
+        assert_equal "&lt;p&gt;Nothing bad to see here.&lt;/p&gt;", @buffer.to_s
+      end
+    end
+
+    context "#safe_append=" do
+      should "bypass HTML safety" do
+        @buffer.safe_append = "<p>Nothing bad to see here.</p>"
+
+        assert_predicate @buffer, :html_safe?
+        assert_predicate @buffer.to_s, :html_safe?
+        assert_equal "<p>Nothing bad to see here.</p>", @buffer.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This change ports Jean Boussier's Rails change over to Bridgetown with a few tweaks.

1. Using `instance_of?` against the constant is faster than the alternative `self.class == other.class` construct
2. Linear, comparable logic for `<<`
3. An expanded set of delegated methods to include `#empty?`, `#encode`, `#lines`, `#reverse`, `#strip`, and `#valid_encoding?` because these are all called in the test suite.

In the current test suite, this is a count of how many times each method is called:

```
2794 empty?
  54 encode
  54 encoding
 381 lines
 127 reverse
 127 strip
  54 valid_encoding?
```

It's unclear to me which, if any, of these should be public API so I kept all of the delegated methods as well as the ones Jean picked for Rails.

## Context

Closes #599
