### PR TITLE
Add main content skip link to website

### DIFF
--- a/bridgetown-website/frontend/styles/global.css
+++ b/bridgetown-website/frontend/styles/global.css
@@ -428,3 +428,17 @@ svg.logo .letter {
 .version-text {
   color: var(--sl-color-neutral-300);
 }
+
+skip-to-main-content-bar {
+  position: absolute;
+  transform: translateY(-150px);
+  padding: 0.7rem 0;
+  background-color: var(--color-lightest-orange);
+  display: flex;
+  justify-content: center;
+
+  &:focus-within {
+    position: static;
+    transform: initial;
+  }
+}

--- a/bridgetown-website/src/_layouts/default.serb
+++ b/bridgetown-website/src/_layouts/default.serb
@@ -4,11 +4,15 @@
     {%@ "head" %}
   </head>
   <body class="{{ data.layout }} {{ data.page_class }}">
+    <skip-to-main-content-bar>
+      <a href="#main">Skip to main content</a>
+    </skip-to-main-content-bar>
+
     <theme-picker></theme-picker>
 
     {%@ Shared::Navbar metadata: site.metadata, resource: resource %}
 
-    <main>
+    <main id="main">
       {%= yield %}
     </main>
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Adds a skip link which is visually hidden unless it receives focus.

## Context

Helps with resolving #724.

## Screenshot

![image](https://user-images.githubusercontent.com/1370570/224478739-9c072645-e817-49f4-a61f-336afdf9a452.png)