### PR TITLE
Avoid invisible code highlight for bold text in dark mode

### DIFF
--- a/bridgetown-website/frontend/styles/global.css
+++ b/bridgetown-website/frontend/styles/global.css
@@ -27,6 +27,7 @@
   --color-syntax-beige: #8A786E;
   --color-syntax-charcoal: #67717E;
   --color-syntax-steel-teal: #568684;
+  --color-syntax-mid-blue: #4b83d4;
   --color-syntax-rose-vale: #b25658;
 
   --body-background: white;

--- a/bridgetown-website/frontend/styles/theme-dark.css
+++ b/bridgetown-website/frontend/styles/theme-dark.css
@@ -99,7 +99,7 @@
   & .highlight .vi,
   & .highlight .si {
     color: var(--color-syntax-dark-beige);
-    color: #568684;
+    color: var(--color-syntax-steel-teal);
   }
 
   & .highlight .ss {

--- a/bridgetown-website/frontend/styles/theme-dark.css
+++ b/bridgetown-website/frontend/styles/theme-dark.css
@@ -87,7 +87,7 @@
   & .highlight .k {
     color: var(--color-syntax-light-beige);
   }
-  
+
   & .highlight .kn {
     color: #4b83d4;
   }
@@ -105,7 +105,7 @@
   & .highlight .ss {
     color: var(--color-syntax-beige);
   }
-  
+
   & .highlight .s {
     color: var(--color-syntax-steel-teal);
   }
@@ -118,15 +118,15 @@
   & .highlight .kp {
     color: var(--color-syntax-steel-teal);
   }
-  
+
   & .highlight .n {
     color: var(--color-syntax-light-green);
   }
-  
+
   & .highlight .nb {
     color: #8aaee3;
   }
-  
+
   & .highlight .nc {
     color: var(--color-syntax-dark-red);
   }
@@ -134,15 +134,15 @@
   & .highlight .nb {
     color: var(--color-syntax-rose-vale);
   }
-  
+
   & .highlight .nf {
     color: var(--color-syntax-mid-green);
   }
-  
+
   & .highlight .nn {
     color: var(--color-dark-brick);
   }
-  
+
   & .highlight .no {
     color: var(--color-syntax-dark-red);
   }
@@ -154,13 +154,17 @@
   & .highlight .nv {
     color: var(--color-syntax-mid-green);
   }
-  
+
   & .highlight .o {
     color: var(--color-syntax-mid-green);
   }
 
   & .highlight .s2 {
     color: var(--color-syntax-steel-teal);
+  }
+
+  & .highlight .gs {
+    color: #4b83d4;
   }
 
   /* highlights end */

--- a/bridgetown-website/frontend/styles/theme-dark.css
+++ b/bridgetown-website/frontend/styles/theme-dark.css
@@ -89,7 +89,7 @@
   }
 
   & .highlight .kn {
-    color: #4b83d4;
+    color: var(--color-syntax-mid-blue);
   }
 
   & .highlight .sh {
@@ -164,7 +164,7 @@
   }
 
   & .highlight .gs {
-    color: #4b83d4;
+    color: var(--color-syntax-mid-blue);
   }
 
   /* highlights end */


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Avoids invisible bold text in dark mode.

Example docs page showing the issue (when in dark mode): https://www.bridgetownrb.com/docs/front-matter#the-power-of-ruby-in-front-matter

New styling example below:

![Screenshot 2023-03-13 at 17 33 10](https://user-images.githubusercontent.com/1370570/224677401-5e4a362f-75a9-44ee-a34d-07e766b0b605.png)
