### PR TITLE
Fix purgecss plugin crashing when using scss

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/purgecss.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/purgecss.rb
@@ -31,7 +31,7 @@ create_builder "purgecss.rb" do
             manifest = JSON.parse(File.read(manifest_file))
 
             if Bridgetown::Utils.frontend_bundler_type == :esbuild
-              css_file = manifest["styles/index.css"].split("/").last
+              css_file = (manifest["styles/index.css"] || manifest["styles/index.scss"]).split("/").last
               css_path = ["output", "_bridgetown", "static", css_file].join("/")
             else
               css_file = manifest["main.css"].split("/").last


### PR DESCRIPTION
When using SASS, the manifest key is `index.scss` instead of `index.css`, raising `undefined method 'split' for nil:NilClass`.
The crash happens at line 24 (`css_file = manifest["styles/index.css"].split("/").last`).

This is a 🐛 bug fix.

I haven't found tests for this plugin, let me know if there are that I can tweak to exercise this condition.

## Summary

When a project uses scss instead of plain css, the expected manifest key is slightly different, crashing the `purgecss` plugin to crash. By reading either `index.css` or `index.scss` the plugin handles both cases without erroring out.