### PR TITLE
Fix permalink file extensions, if basename contains "."

### DIFF
--- a/bridgetown-core/features/permalinks.feature
+++ b/bridgetown-core/features/permalinks.feature
@@ -92,6 +92,17 @@ Feature: Fancy permalinks
     And the output/custom/posts directory should exist
     And I should see "bla bla" in "output/custom/posts/some.html"
 
+  Scenario: Use per-post ending in .en.html
+    Given I have a _posts directory
+    And I have the following post:
+      | title     | date       | permalink                  | content |
+      | Some post | 2013-04-14 | /custom/posts/some.en.html | bla bla |
+    When I run bridgetown build
+    Then I should get a zero exit status
+    And the output directory should exist
+    And the output/custom/posts directory should exist
+    And I should see "bla bla" in "output/custom/posts/some.en.html"
+
   Scenario: Use pretty permalink schema with cased file name
     Given I have a _posts directory
     And I have an "_posts/2009-03-27-Pretty-Permalink-Schema.md" page that contains "Totally wordpress"

--- a/bridgetown-core/lib/bridgetown-core/filters/url_filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters/url_filters.rb
@@ -74,6 +74,14 @@ module Bridgetown
         end.to_s
       end
 
+      # Returns the extension of a path/URL
+      #
+      # @param input [Object] value which responds to `to_s`
+      # @return [String]
+      def extname(input)
+        File.extname(input.to_s)
+      end
+
       private
 
       def compute_absolute_url(input)

--- a/bridgetown-core/lib/bridgetown-core/resource/permalink_processor.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/permalink_processor.rb
@@ -85,8 +85,8 @@ module Bridgetown
         if permalink.ends_with?(".*") || !%r{\.html?$}.match?(final_ext)
           "/#{new_url}#{final_ext}"
         # If permalink includes the file extension, add it back in to the URL
-        elsif permalink =~ %r{\.[^/]*$}
-          "/#{new_url}#{Regexp.last_match[0]}"
+        elsif permalink.match?(%r{\.[^/]*$})
+          "/#{new_url}#{Bridgetown::Filters::URLFilters.extname(permalink)}"
         # Ensure index-style URLs get output correctly
         elsif permalink.ends_with?("/")
           "/#{new_url}/".sub(%r{^/index/$}, "/")


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

When the filename of a permalink contains more than one dot, e. g. `foo.bar.html`, we strip its file extension before processing it further. The basename without extension now is `foo.bar`.

https://github.com/bridgetownrb/bridgetown/blob/715cf3a4460952c2f7d7a17f2bde6c2e3d36d6dd/bridgetown-core/lib/bridgetown-core/resource/permalink_processor.rb#L35

https://github.com/bridgetownrb/bridgetown/blob/715cf3a4460952c2f7d7a17f2bde6c2e3d36d6dd/bridgetown-core/lib/bridgetown-core/filters/url_filters.rb#L71-L75

When the final permalink is built with all of its placeholders filled, the original file extension is added back. However, when the file extension to be re-added is determined, a regular expression is used.

https://github.com/bridgetownrb/bridgetown/blob/715cf3a4460952c2f7d7a17f2bde6c2e3d36d6dd/bridgetown-core/lib/bridgetown-core/resource/permalink_processor.rb#L87-L88

For a filename with multiple dots like the aforementioned `foo.bar.html`, that regular expression considers `.bar.html` the file extension. Putting the basename and the extension together thus results in `foo.bar.bar.html` instead of `foo.bar.html`.

This PR fixes that issue by determining the file extension through `File.extname` instead of using the aforementioned regular expression. This feels like the most robust way; updating the regular expression to `%r{\.[^./]*$}` would work, as well, but since `Bridgetown::Filters::URLFilters` is responsible for removing the file extension, it should also be responsible for telling us what the file extension is. This is why I opted against the more obvious

```ruby
elsif permalink.match?(%r{\.[^./]*$})
  "/#{new_url}#{File.extname(permalink)}"
```