### PR TITLE
Display build error on the page in a dialog in dev

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -377,6 +377,18 @@ module Bridgetown
         File.join(base_directory, clean_path)
       end
     end
+
+    # When there's a build error, error details will be logged to a file which the dev server
+    #   can read and pass along to the browser.
+    #
+    # @return [String] the path to the cached errors file
+    def build_errors_path
+      File.join(
+        (Bridgetown::Current.site&.config || Bridgetown::Current.preloaded_configuration).root_dir,
+        ".bridgetown-cache",
+        "build_errors.txt"
+      )
+    end
   end
 end
 

--- a/bridgetown-core/lib/bridgetown-core/errors.rb
+++ b/bridgetown-core/lib/bridgetown-core/errors.rb
@@ -15,9 +15,12 @@ module Bridgetown
     InvalidURLError             = Class.new(FatalException)
     InvalidConfigurationError   = Class.new(FatalException)
 
-    def self.print_build_error(exc, trace: false, logger: Bridgetown.logger)
+    def self.print_build_error(exc, trace: false, logger: Bridgetown.logger, server: false) # rubocop:disable Metrics
       logger.error "Exception raised:", exc.class.to_s.bold
       logger.error exc.message.reset_ansi
+
+      build_errors_file = Bridgetown.build_errors_path if !server && Bridgetown::Current.site
+      build_errors_data = "#{exc.class}: #{exc.message}"
 
       trace_args = ["-t", "--trace"]
       print_trace_msg = true
@@ -29,6 +32,12 @@ module Bridgetown
                end
       traces.each_with_index do |backtrace_line, index|
         logger.error "#{index + 1}:", backtrace_line.reset_ansi
+        build_errors_data << "\n#{backtrace_line}" if index < 2
+      end
+
+      if build_errors_file
+        FileUtils.mkdir_p(File.dirname(build_errors_file))
+        File.write(build_errors_file, build_errors_data, mode: "w")
       end
 
       return unless print_trace_msg

--- a/bridgetown-core/lib/bridgetown-core/rack/routes.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/routes.rb
@@ -159,10 +159,11 @@ module Bridgetown
         end
 
         # @param app [Roda]
-        def setup_live_reload(app) # rubocop:disable Metrics/AbcSize
+        def setup_live_reload(app) # rubocop:disable Metrics
           sleep_interval = 0.2
           file_to_check = File.join(Bridgetown::Current.preloaded_configuration.destination,
                                     "index.html")
+          errors_file = Bridgetown.build_errors_path
 
           app.request.get "_bridgetown/live_reload" do
             app.response["Content-Type"] = "text/event-stream"
@@ -177,6 +178,8 @@ module Bridgetown
                 if @_mod < new_mod
                   out << "data: reloaded!\n\n"
                   break
+                elsif File.exist?(errors_file)
+                  out << "event: builderror\ndata: #{File.read(errors_file).to_json}\n\n"
                 else
                   out << "data: #{new_mod}\n\n"
                 end

--- a/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
@@ -13,6 +13,8 @@ module Bridgetown
         @config = config
         @loaders = {}
         @root_dir = config.root_dir
+
+        FileUtils.rm_f(Bridgetown.build_errors_path)
       end
 
       def unload_loaders
@@ -75,6 +77,8 @@ module Bridgetown
       end
 
       def reload_loaders
+        FileUtils.rm_f(Bridgetown.build_errors_path)
+
         @loaders.each do |load_path, loader|
           next unless reloading_enabled?(load_path)
 

--- a/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
@@ -31,7 +31,7 @@ class Roda
         app.plugin :exception_page
         app.plugin :error_handler do |e|
           Bridgetown::Errors.print_build_error(
-            e, logger: Bridgetown::LogAdapter.new(self.class.opts[:common_logger])
+            e, logger: Bridgetown::LogAdapter.new(self.class.opts[:common_logger]), server: true
           )
           next exception_page(e) if ENV.fetch("RACK_ENV", nil) == "development"
 


### PR DESCRIPTION
## Summary

When there's an exception which would normally get logged to the terminal, now that error is also surfaced on the website itself through the dev reload process. By seeing the error show in a dialog on the page, you're altered to check your logs which is much nicer than just having to "guess" there's a problem if the logs aren't immediately visible on your desktop.

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/658496/233142073-59c01df7-fde3-4545-b5be-bc48d0e4429d.png">

## Context

Resolves #718