### PR TITLE
Fix locales warning bug

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -282,7 +282,7 @@ module Bridgetown
       if model_is_multi_locale?(model, model_relative_path)
         # If the model specifies a locales key, use that to determine the
         # the locale of each resource, otherwise fall back to `site.config.available_locales`
-        locales = model.locales || site.config.available_locales
+        locales = model.attributes[:locales] || site.config.available_locales
 
         locales.each do |locale|
           model.locale = locale.to_sym


### PR DESCRIPTION
For context:

> sandstrom Yeah, seems like a mistake. We could just switch from model.locales to model.attributes[:locales] which wouldn't trigger a warning. The warning is for the benefit of users, not for our internal purposes. -- jaredcwhite

More details in the issue below.

Fixes #744