### PR TITLE
Let rubocop read .ruby-version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,9 +12,6 @@ Bridgetown/NoPutsAllowed:
   Exclude:
     - rake/*.rake
 
-AllCops:
-  TargetRubyVersion: 2.7
-
 Lint/NestedPercentLiteral:
   Exclude:
     - bridgetown-core/test/test_site.rb


### PR DESCRIPTION
Very minor thing, but I think we can remove this.

One less place to update when bumping ruby versions.

I ran rubocop locally before/after, and it seemed to work (there are some warnings, but I guess those seemed to be there regardless).

> RuboCop will then check your project for a series of files where the version may be specified already. The files that will be looked for are .ruby-version, .tool-versions, Gemfile.lock, and *.gemspec.
> 
> If Gemspec file has an array for required_ruby_version, the lowest version will be used. If none of the files are found a default version value will be used.
> 
> Source: 
> https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version