### PR TITLE
Fix 30 repo limit on bridgetown-plugin github topic search

### DIFF
--- a/bridgetown-website/src/_pages/plugins.serb
+++ b/bridgetown-website/src/_pages/plugins.serb
@@ -4,7 +4,7 @@
   exclude_from_search: true,
   plugins: -> do
     ::Builders::Versions.cache.getset("plugins") do
-      endpoint = "https://api.github.com/search/repositories?q=topic:bridgetown-plugin%20archived:false"
+      endpoint = "https://api.github.com/search/repositories?q=topic:bridgetown-plugin%20archived:false&per_page=100"
 
       conn = Faraday.new(
         url: endpoint,


### PR DESCRIPTION
This is a 🔦 documentation change.

And it could also be considered a 🐛 fix.

## Summary

By default the github api returns [30 results per page](https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-repositories) on a repository search. At this time there are 36 repositories in github with the [`bridgetown-plugin`](https://github.com/topics/bridgetown-plugin) topic.

This temporarily fixes the issue by setting a `per_page=100` parameter on the api call. Once there are more than 100 plugins, the code will need to make multiple calls to get all the plugins. That will be a good problem to have 😺 