### PR TITLE
Add I18n localization shortcut "l" alongside "t"

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/filters/localization_filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters/localization_filters.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Filters
+    module LocalizationFilters
+      def l(input)
+        I18n.l(input.to_s)
+      end
+    end
+  end
+end

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -135,6 +135,14 @@ module Bridgetown
         I18n.send :t, *args, **kwargs
       end
 
+      # Forward all arguments to I18n.l method
+      #
+      # @return [String] the localized string
+      # @see I18n
+      def l(*args, **kwargs)
+        I18n.send :l, *args, **kwargs
+      end
+
       # For template contexts where ActiveSupport's output safety is loaded, we
       # can ensure a string has been marked safe
       #

--- a/bridgetown-core/lib/bridgetown-core/tags/l.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/l.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Tags
+    class LocalizationTag < Liquid::Tag
+      def render(_context)
+        key = @markup.strip
+        I18n.l(key)
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("l", Bridgetown::Tags::LocalizationTag)

--- a/bridgetown-website/src/_docs/internationalization.md
+++ b/bridgetown-website/src/_docs/internationalization.md
@@ -96,6 +96,17 @@ There are many other useful features of the **i18n** gem, so feel free to peruse
 In Ruby, the `t` helper is simply shorthand for `I18n.t`, so if you find yourself in a context where `t` is not available—perhaps in a plugin—you can write `I18n.t` directly.
 {% end %}
 
+## Localizing dates
+
+To ensure dates are displayed using the active locale, you'll need to localize them using `I18n.l`, or use the provided shortcut: `l` (just like you would in a Rails project).
+
+By simply adding `gem "rails-i18n"` to your `Gemfile`, you'll get localized month and day names, along with standard date and time formats in each locale supported by that gem.
+You can also define your own localization for date and time.
+
+{%@ Note do %}
+In Ruby, the `l` helper is simply shorthand for `I18n.l`, so if you find yourself in a context where `l` is not available—perhaps in a plugin—you can write `I18n.l` directly.
+{% end %}
+
 ## Localizing Your Resources and Templates
 
 Beyond using simple translated strings, you will want to ensure you have translated variants of your content and that you can switch freely between the locale variants. There are two ways to do this:


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
This is a 🔦 documentation change.

Notes:
- I haven't found tests for `I18n.t` that I could duplicate, but maybe I haven't looked in the right places. I'm not familiar with minitest.
- I've adjusted the documentation.
- The ci/build script cannot run on my machine, rbenv refuses to compile ruby 2.7.2. 
- While browsing the code, I sumbled upon `date_to_string` and `date_to_long_string`, which could be rewritten using `I18n`. 

## Summary

Add `l` filter/tag/shortcut to `I18n.l`.

## Context

  Closes #753 