### PR TITLE
Update to esbuild 0.17

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -307,5 +307,6 @@ module.exports = async (outputFolder, esbuildOptions) => {
         context.dispose()
       })
     }
+    process.on('SIGINT', () => process.exit())
   }).catch(() => process.exit(1))
 }

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -49,7 +49,9 @@ const importGlobPlugin = () => ({
         return; // Ignore unresolvable paths
       }
 
-      const adjustedPath = args.path.replace(/^bridgetownComponents\//, "../../src/_components/")
+      const adjustedPath = args.path
+        .replace(/^\$components\/\*\*/, "../../src/_components/**")
+        .replace(/^bridgetownComponents\//, "../../src/_components/") // legacy
 
       return {
         path: adjustedPath,
@@ -64,7 +66,7 @@ const importGlobPlugin = () => ({
     build.onLoad({ filter: /.*/, namespace: "import-glob" }, async (args) => {
       const files = glob.sync(args.pluginData.path, {
         cwd: args.pluginData.resolveDir,
-      }).sort()
+      }).sort().map(module => module.replace("../../src/_components/", "$components/"))
 
       const importerCode = `
         ${files
@@ -72,7 +74,7 @@ const importGlobPlugin = () => ({
           .join(';')}
         const modules = {${files
           .map((module, index) => `
-            "${module.replace("../../src/_components/", "")}": module${index},`)
+            "${module.replace("$components/", "")}": module${index},`)
           .join("")}
         };
         export default modules;
@@ -271,8 +273,9 @@ module.exports = async (outputFolder, esbuildOptions) => {
   // Add the Bridgetown preset
   esbuildOptions.plugins.push(bridgetownPreset(outputFolder))
 
-  // esbuild, take it away!
-  require("esbuild").build({
+  const esbuild = require("esbuild")
+
+  esbuild.context({
     bundle: true,
     loader: {
       ".jpg": "file",
@@ -285,16 +288,24 @@ module.exports = async (outputFolder, esbuildOptions) => {
       ".eot": "file",
     },
     resolveExtensions: [".tsx", ".ts", ".jsx", ".js", ".css", ".scss", ".sass", ".json", ".js.rb"],
-    nodePaths: ["frontend/javascript", "frontend/styles"],
-    watch: process.argv.includes("--watch"),
     minify: process.argv.includes("--minify"),
     sourcemap: true,
-    target: "es2016",
+    target: "es2020",
     entryPoints: ["./frontend/javascript/index.js"],
     entryNames: "[dir]/[name].[hash]",
     outdir: path.join(process.cwd(), `${outputFolder}/_bridgetown/static`),
     publicPath: "/_bridgetown/static",
     metafile: true,
     ...esbuildOptions,
+  }).then(context => {
+    if (process.argv.includes("--watch")) {
+      // Enable watch mode
+      context.watch()
+    } else {
+      // Build once and exit if not in watch mode
+      context.rebuild().then(result => {
+        context.dispose()
+      })
+    }
   }).catch(() => process.exit(1))
 }

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/jsconfig.json
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/jsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "paths": {
         "$styles/*": ["./frontend/styles/*"],
-        "$scripts/*": ["./frontend/javascript/*"],
+        "$javascript/*": ["./frontend/javascript/*"],
         "$components/*": ["./src/_components/*"]
     }
   }, 

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/jsconfig.json
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+        "$styles/*": ["./frontend/styles/*"],
+        "$scripts/*": ["./frontend/javascript/*"],
+        "$components/*": ["./src/_components/*"]
+    }
+  }, 
+}

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/setup.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/setup.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 template "esbuild.defaults.js.erb", "config/esbuild.defaults.js"
+copy_file "jsconfig.json"
 copy_file "esbuild.config.js", force: true

--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/update.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/update.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 template "esbuild.defaults.js.erb", "config/esbuild.defaults.js", force: true
+copy_file "jsconfig.json"
 say "🎉 esbuild configuration updated successfully!"
+say "You may need to add `$styles/` to the front of your main CSS imports."
+say "See https://www.bridgetownrb.com/docs/frontend-assets#esbuild-setup for details."

--- a/bridgetown-core/lib/bridgetown-core/utils/aux.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/aux.rb
@@ -29,6 +29,8 @@ module Bridgetown
           loop do
             line = rd.gets
             line.to_s.lines.map(&:chomp).each do |message|
+              next if name == "Frontend" && %r{ELIFECYCLE.*?Command failed}.match?(message)
+
               output = +""
               output << with_color(color, "[#{name}] ") if color
               output << message

--- a/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
+++ b/bridgetown-core/lib/site_template/frontend/javascript/index.js.erb
@@ -1,13 +1,22 @@
+<%- if frontend_bundling_option == "esbuild" -%>
+<%- if postcss_option -%>
+import "$styles/index.css"
+<%- else -%>
+import "$styles/index.scss"
+<%- end -%>
+import "$styles/syntax-highlighting.css"
+<%- else -%>
 <%- if postcss_option -%>
 import "index.css"
 <%- else -%>
 import "index.scss"
 <%- end -%>
 import "syntax-highlighting.css"
+<%- end -%>
 
 // Import all JavaScript & CSS files from src/_components
 <%- if frontend_bundling_option == "esbuild" -%>
-import components from "bridgetownComponents/**/*.{js,jsx,js.rb,css}"
+import components from "$components/**/*.{js,jsx,js.rb,css}"
 <%- else -%>
 const componentsContext = require.context("bridgetownComponents", true, /\.(js|css)$/)
 componentsContext.keys().forEach(componentsContext)

--- a/bridgetown-core/lib/site_template/package.json.erb
+++ b/bridgetown-core/lib/site_template/package.json.erb
@@ -15,29 +15,29 @@
     <%- if frontend_bundling_option == "webpack" -%>
     "css-loader": "^6.7.1",
     <%- end -%>
-    "esbuild": "^0.15.12",
+    "esbuild": "^0.17.19",
     <%- if frontend_bundling_option == "webpack" -%>
     "esbuild-loader": "^2.18.0",
     "mini-css-extract-plugin": "^2.6.0",
     <%- else -%>
-    "glob": "^8.0.1",
+    "glob": "^10.2.6",
     <%- end -%>
     <%- unless disable_postcss? -%>
-    "postcss": "^8.4.12",
+    "postcss": "^8.4.23",
     "postcss-flexbugs-fixes": "^5.0.2",
     <%- if frontend_bundling_option == "esbuild" -%>
-    "postcss-import": "^14.1.0",
+    "postcss-import": "^15.1.0",
     "postcss-load-config": "^4.0.1",
     <%- else -%>
     "postcss-loader": "^6.2.1",
     <%- end -%>
-    "postcss-preset-env": "^7.4.3",
+    "postcss-preset-env": "^8.4.1",
     <%- if frontend_bundling_option == "esbuild" -%>
     "read-cache": "^1.0.0"<%= "," unless postcss_option  %>
     <%- end -%>
     <%- end -%>
     <%- unless postcss_option -%>
-    "sass": "^1.50.1",
+    "sass": "^1.62.1",
     "sass-loader": "^12.6.0"<%= "," if frontend_bundling_option == "webpack" %>
     <%- end -%>
     <%- if frontend_bundling_option == "webpack" -%>

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -61,7 +61,7 @@ class TestNewCommand < BridgetownUnitTest
   end
 
   def esbuild_config_files
-    ["/esbuild.config.js", "/config/esbuild.defaults.js"]
+    ["/esbuild.config.js", "/jsconfig.json", "/config/esbuild.defaults.js"]
   end
 
   def webpack_config_files

--- a/bridgetown-website/src/_docs/frontend-assets.md
+++ b/bridgetown-website/src/_docs/frontend-assets.md
@@ -152,13 +152,9 @@ For instance, you could add [Ruby2JS](https://www.ruby2js.com/) support and swit
 const ruby2js = require("@ruby2js/esbuild-plugin")
 
 const esbuildOptions = {
-  entryPoints: ["frontend/javascript/index.js.rb"],
-  target: "es2020",
+  entryPoints: ["./frontend/javascript/index.js.rb"],
   plugins: [
-    ruby2js({
-      eslevel: 2020,
-      filters: ["camelCase", "functions", "lit", "esm", "return"]
-    }),
+    ruby2js(),
   ]
 }
 ```
@@ -167,6 +163,22 @@ const esbuildOptions = {
 
 {%@ Note do %}
   Check out the [Ruby2JS Bundled Configuration](/docs/bundled-configurations#ruby2js) for an automated way to install Ruby2JS.
+{% end %}
+
+### Path Aliases
+
+Starting in Bridgetown 1.3, there are several path aliases defined in the esbuild integration as well as `jsconfig.json` in your repo root. These are:
+
+```
+$styles: frontend/styles
+$javascript: frontend/javascript
+$components: src/_components
+```
+
+This allows you to conveniently write import statements such as `import "$styles/index.css"`. You can add additional path aliases if you'd like to import from other folders you've created in your project while maintaining terse paths.
+
+{%@ Note type: :warning do %}
+  When upgrading from older projects, make sure you've run `bin/bridgetown esbuild update` and then add `$styles/` in front of any CSS import statements in your main JavaScript files. You can also update the `bridgetownComponents/**` glob to `$components/**`.
 {% end %}
 
 ### Multiple Entry Points
@@ -179,8 +191,8 @@ You can specify multiple entry points (which result in multiple output bundles) 
 
 const esbuildOptions = {
   entryPoints: [
-    "frontend/javascript/index.js",
-    "frontend/javascript/pages/contact_form.js"
+    "./frontend/javascript/index.js",
+    "./frontend/javascript/pages/contact_form.js"
   ],
   format: "esm"
 }
@@ -226,7 +238,7 @@ Now you can dynamically and asynchronously import JavaScript code within any fun
 
 ```js
 const loadStuff = async () => {
-  const importantStuff = await import("important_stuff.js")
+  const importantStuff = await import("./important_stuff.js")
   return importantStuff.default()
 }
 


### PR DESCRIPTION
## Summary

In the process of upgrading esbuild to the latest version (along with PostCSS and other dependencies), I encountered some super weird issues with the watch process and CSS imports (aka index.css). Sometimes the files wouldn't rebuild at all when edited. Other times it would happen repeatedly.

I eventually tracked it down to some change back in 0.16.8+ around dependency resolution. There was a later change involving the `nodePaths` option, which seems not to have fully fixed this issue I saw.

I ended up going down a very different path. Rather than try to use esbuild's `nodePaths` config option in order to get nice imports like `import "index.css"` in `index.js`, I went with a more "standard" sort of path alias setup. esbuild can read in `jsconfig.json` and evaluate path aliases, which means you can add literally any alias you want. `import "foo/bar/file.js"` could resolve to "whatever/you/want/file.js" simply by adding aliases to `jsconfig.json`. Pretty sweet.

So…with this update we now have clearly defined path aliases for common frontend build paths. They are:

```
$styles: frontend/styles
$javascript: frontend/javascript
$components: src/_components
```

Thus in `index.js`, it should now have `import "$styles/index.css"`. The glob import can now have `import "$components/**/…"`, etc. And site devs can add their own additional path aliases if they want to! 🎉 

This also feels more future-compatible with other package managers and so forth.

> **Warning**
> This is a breaking change for existing Bridgetown sites, but **only** if they run the `esbuild update` command. And that command will point them to the need to update their CSS imports along with a link to the docs, so I can't imagine it's too big of an ask.

## Context

Resolves #697 and possibly #734 (not yet tested).
