### PR TITLE
doc: GitLab Pages serving compressed assets

### DIFF
--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -172,6 +172,8 @@ This can be achieved by including a `script:` command like this in your
 pages:
   # Other directives
   script:
+    # Add this ligne just after apt update
+    - apt-get install -y brotli
     # Build the public/ directory first
     - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec gzip -f -k {} \;
     - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec brotli -f -k {} \;

--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -156,6 +156,27 @@ git push -u origin main
 
 After the build the site should be live at https://bridgetownrb.gitlab.io/mysite
 
+#### Enable GZip & Brotli compression for GitLab Pages
+
+Most modern browsers support downloading files in a compressed format. This
+speeds up downloads by reducing the size of files.
+
+Before serving an uncompressed file, Gitlab Pages checks if the same file exists
+with a `.br` or `.gz` extension. If it does, and the browser supports receiving
+compressed files, it serves that version instead of the uncompressed one.
+
+This can be achieved by including a `script:` command like this in your
+`.gitlab-ci.yml` pages job:
+
+```yaml
+pages:
+  # Other directives
+  script:
+    # Build the public/ directory first
+    - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec gzip -f -k {} \;
+    - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec brotli -f -k {} \;
+```
+
 ### GitHub Pages
 
 Much like with GitLab, you can also deploy static sites to [GitHub Pages](https://pages.github.com/). You can make use of [GitHub Actions](https://github.com/features/actions) to automate building and deploying your site to GitHub Pages. 

--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -177,6 +177,8 @@ pages:
     - find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec brotli -f -k {} \;
 ```
 
+For more details, [see the documentation](https://docs.gitlab.com/ee/user/project/pages/introduction.html#serving-compressed-assets).
+
 ### GitHub Pages
 
 Much like with GitLab, you can also deploy static sites to [GitHub Pages](https://pages.github.com/). You can make use of [GitHub Actions](https://github.com/features/actions) to automate building and deploying your site to GitHub Pages. 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Add documentation about serving compressed assets for GitLab Pages.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

GitLab pages can serve compressed files if they are present and if the browser supports receiving compressed files. Both [GZip] & [Brotli] are exposed here. Brotli has a better compression ratio. GZip is more widely supported.

[GZip]: https://fr.wikipedia.org/wiki/Gzip
[Brotli]: https://fr.wikipedia.org/wiki/Brotli

You can see an up & running example on my personal blog repository:  
https://gitlab.com/strigocc/code/-/blob/main/.gitlab-ci.yml