### PR TITLE
WIP: Exclude init initializer from plugins list command count

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/plugins.rb
@@ -27,15 +27,16 @@ module Bridgetown
 
         pm = site.plugin_manager
 
-        plugins_list += pm.class.registered_plugins.reject do |plugin|
-          plugin.to_s.end_with? "site_builder.rb"
+        plugins_list += pm.class.registered_plugins.to_a
+
+        plugins_list.reject! do |plugin|
+          plugin.to_s.end_with?("site_builder.rb") || plugin.to_s == "init (Initializer)"
         end
 
         Bridgetown.logger.info("Registered Plugins:", plugins_list.length.to_s.yellow.bold)
 
         plugins_list.each do |plugin|
           plugin_desc = plugin.to_s
-          next if plugin_desc.ends_with?("site_builder.rb") || plugin_desc == "init (Initializer)"
 
           if plugin.is_a?(Bridgetown::Configuration::Initializer)
             Bridgetown.logger.info("", plugin_desc)

--- a/bridgetown-core/test/test_plugins_command.rb
+++ b/bridgetown-core/test/test_plugins_command.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "helper"
+require_all "bridgetown-core/commands/concerns"
+require "bridgetown-core/commands/plugins"
+
+class TestPluginsCommand < BridgetownUnitTest
+  context "list registered plugins" do
+    setup do
+      fixture_site
+      @cmd = Bridgetown::Commands::Plugins.new
+    end
+
+    should "exclude init (Initializer) from registered plugins list" do
+      out, err = capture_io do
+        @cmd.invoke(:list)
+      end
+
+      assert_nil err
+      refute_includes "init (Initializer)", out
+    end
+
+    should "exclude init (Initializer) from registered plugins count" do
+      out, err = capture_io do
+        @cmd.invoke(:list)
+      end
+
+      assert_nil err
+      assert_includes "Registered Plugins: 3", out
+    end
+  end
+end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This PR excludes `init (Initializer)` from the count of registered plugins when the `bin/bridgetown plugins list` command is run. See #770 for details.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Fixes #770 
