### PR TITLE
Eager load to make DEFAULTS deterministic

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -77,7 +77,6 @@ module Bridgetown
   autoload :Cleaner,             "bridgetown-core/cleaner"
   autoload :Collection,          "bridgetown-core/collection"
   autoload :Component,           "bridgetown-core/component"
-  autoload :Configuration,       "bridgetown-core/configuration"
   autoload :DefaultsReader,      "bridgetown-core/readers/defaults_reader"
   autoload :Deprecator,          "bridgetown-core/deprecator"
   autoload :EntryFilter,         "bridgetown-core/entry_filter"
@@ -119,6 +118,7 @@ module Bridgetown
   require "bridgetown-core/liquid_extensions"
   require "bridgetown-core/filters"
 
+  require "bridgetown-core/configuration"
   require "bridgetown-core/drops/drop"
   require "bridgetown-core/drops/resource_drop"
   require_all "bridgetown-core/converters"


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

`Configuration::DEFAULTS` uses `Dir.pwd` to determine the root directory for the configuration. This means that lazy loading the file using `autoload` makes the root path for configuration non-deterministic depending on the directory location the first time you try to use `Bridgetown::Configuration`.

This has a knock-on effect of making tests fail nondeterministically.

By eager loading the configuration file, we can reduce this nondeterminism by ensuring the value is set the same way every time.

## Context

This can be reproduced with the following on 7ecd7f6ab8943fc0cb4562ed25d4ddfdb9442f21.

<details>
<summary>Reproduction</summary>

```bash
BYPASS_RESOURCE_TEST=true bundle exec ruby -Itest:lib -e 'require "./test/fixtures/test_automation.rb" ; require "./test/test_ansi.rb" ; require "./test/test_apply_command.rb" ; require "./test/test_cleaner.rb" ; require "./test/test_collections.rb" ; require "./test/test_components.rb" ; require "./test/test_configuration.rb" ; require "./test/test_configure_command.rb" ; require "./test/test_data_reader.rb" ; require "./test/test_defaults_reader.rb" ; require "./test/test_doctor_command.rb" ; require "./test/test_drop.rb" ; require "./test/test_entry_filter.rb" ; require "./test/test_erb.rb" ; require "./test/test_esbuild_command.rb" ; require "./test/test_filters.rb" ; require "./test/test_front_matter_defaults.rb" ; require "./test/test_generated_page.rb" ; require "./test/test_generated_site.rb" ; require "./test/test_kramdown.rb" ; require "./test/test_layout_reader.rb" ; require "./test/test_liquid_extensions.rb" ; require "./test/test_liquid_renderer.rb" ; require "./test/test_locales.rb" ; require "./test/test_log_adapter.rb" ; require "./test/test_model.rb" ; require "./test/test_new_command.rb" ; require "./test/test_path_sanitization.rb" ; require "./test/test_plugin_manager.rb" ; require "./test/test_relations.rb" ; require "./test/test_resource.rb" ; require "./test/test_ruby_helpers.rb" ; require "./test/test_serbea.rb" ; require "./test/test_site.rb" ; require "./test/test_site_drop.rb" ; require "./test/test_ssr.rb" ; require "./test/test_static_file.rb" ; require "./test/test_tags.rb" ; require "./test/test_utils.rb" ; require "./test/test_webpack_command.rb" ; require "./test/test_yaml_parser.rb"' -- -n "/^(?:TestEsbuildCommand#(?:test_: existing webpack project should migrate to esbuild. )|TestConfiguration#(?:test_: .from should merge input over defaults. ))$/" --seed 1234
```

</details>

Run this on that commit, then on this commit, and see that there's no longer a leak in the test. With this change, I think we can remove the `SEED=2345` in `script/test` and go back to using random testing.