### PR TITLE
Lock Rubocop to latest version that passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ output/
 .byebug_history
 .ruby-gemset
 *.gem
-Gemfile.lock
 
 # Files
 .analysis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,253 @@
+PATH
+  remote: bridgetown-builder
+  specs:
+    bridgetown-builder (1.3.0)
+      bridgetown-core (= 1.3.0)
+
+PATH
+  remote: bridgetown-core
+  specs:
+    bridgetown-core (1.3.0)
+      activemodel (>= 6.0, < 8.0)
+      activesupport (>= 6.0, < 8.0)
+      addressable (~> 2.4)
+      amazing_print (~> 1.2)
+      colorator (~> 1.0)
+      erubi (~> 1.9)
+      faraday (~> 2.0)
+      faraday-follow_redirects (~> 0.3)
+      hash_with_dot_access (~> 1.2)
+      i18n (~> 1.0)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 5.0)
+      listen (~> 3.0)
+      rake (>= 13.0)
+      roda (~> 3.46)
+      rouge (~> 3.0)
+      serbea (~> 1.0)
+      thor (~> 1.1)
+      tilt (~> 2.0)
+      zeitwerk (~> 2.5)
+
+PATH
+  remote: bridgetown-paginate
+  specs:
+    bridgetown-paginate (1.3.0)
+      bridgetown-core (= 1.3.0)
+
+PATH
+  remote: bridgetown
+  specs:
+    bridgetown (1.3.0)
+      bridgetown-builder (= 1.3.0)
+      bridgetown-core (= 1.3.0)
+      bridgetown-paginate (= 1.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    amazing_print (1.5.0)
+    ansi (1.5.0)
+    ast (2.4.2)
+    backport (1.2.0)
+    backports (3.24.1)
+    benchmark (0.2.1)
+    benchmark-ips (2.12.0)
+    builder (3.2.4)
+    colorator (1.1.0)
+    concurrent-ruby (1.2.2)
+    cucumber (3.2.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    e2mmap (0.1.0)
+    erubi (1.12.0)
+    faraday (2.7.9)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
+    ffi (1.15.5)
+    gherkin (5.1.0)
+    hash_with_dot_access (1.2.0)
+      activesupport (>= 5.0.0, < 8.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.6)
+    json (2.6.3)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (5.4.0)
+    listen (3.8.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    memory_profiler (1.0.1)
+    minitest (5.18.1)
+    minitest-profile (0.0.2)
+    minitest-reporters (1.6.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    multi_json (1.15.0)
+    multi_test (1.1.0)
+    nokogiri (1.15.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
+    nokolexbor (0.5.0-x86_64-darwin)
+    nokolexbor (0.5.0-x86_64-linux)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    public_suffix (5.0.1)
+    racc (1.7.1)
+    rack (3.0.8)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbs (2.8.4)
+    regexp_parser (2.8.1)
+    reverse_markdown (2.1.1)
+      nokogiri
+    rexml (3.2.5)
+    roda (3.69.0)
+      rack
+    rouge (3.30.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (1.48.1)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    rubocop-bridgetown (0.3.2)
+      rubocop (~> 1.23)
+      rubocop-performance (~> 1.12)
+    rubocop-performance (1.18.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    serbea (1.0.1)
+      activesupport (>= 6.0)
+      erubi (>= 1.10)
+      tilt (~> 2.0)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    solargraph (0.49.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    thor (1.2.2)
+    tilt (2.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
+    yard (0.9.34)
+    zeitwerk (2.6.8)
+
+PLATFORMS
+  x86_64-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  benchmark-ips
+  bridgetown!
+  bridgetown-builder!
+  bridgetown-core!
+  bridgetown-paginate!
+  cucumber (~> 3.0)
+  memory_profiler
+  minitest
+  minitest-profile
+  minitest-reporters
+  nokogiri (~> 1.7)
+  nokolexbor
+  rack-test
+  rake (~> 13.0)
+  rspec
+  rspec-mocks
+  rubocop-bridgetown (~> 0.3.0)
+  shoulda
+  simplecov
+  solargraph
+  terminal-table
+  yard (~> 0.9)
+
+BUNDLED WITH
+   2.4.6

--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -102,7 +102,7 @@ module Bridgetown
     def obfuscate_link(input, prefix = "mailto")
       link = "<a href=\"#{prefix}:#{input}\">#{input}</a>"
       script = "<script type=\"text/javascript\">document.currentScript.insertAdjacentHTML('"
-      script += "beforebegin', '#{rot47(link).gsub(%r!\\!, '\\\\\\')}'.replace(/[!-~]/g," # rubocop:disable Style/StringLiteralsInInterpolation, Style/RedundantRegexpArgument
+      script += "beforebegin', '#{rot47(link).gsub(%r!\\!, '\\\\\\')}'.replace(/[!-~]/g," # rubocop:disable Style/StringLiteralsInInterpolation
       script += "function(c){{var j=c.charCodeAt(0);if((j>=33)&&(j<=126)){"
       script += "return String.fromCharCode(33+((j+ 14)%94));}"
       script += "else{return String.fromCharCode(j);}}}));</script>"


### PR DESCRIPTION
This is a 🔧 tooling change.

## Summary

This change stops ignoring the `Gemfile.lock` and checks it into the repository. This is a best practice to make contributing easier for new (and current) contributors.

One large paper cut is to get all of your changes to pass locally then have CI fail because of updates in the linting pipeline that aren't compatible with — in particular — code that you did not touch.

By checking `Gemfile.lock` in, it ensures that all contributors are working from the same versions of dependencies that the CI server is running.

In addition, this change also locks Rubocop to the newest version that relies on `rubocop-ast` <= 1.28.0. That version and 1.29.0 have a parsing bug in them that won't parse one of the files in Bridgetown's source code and error out. Also, newer versions fail due to new cops on source code that currently exists in the repository.

## Context

All recent PRs are failing due to issues that don't have to do with the changes within them.