### PR TITLE
Feature/i18n localize

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -7,6 +7,7 @@ module Bridgetown
     include URLFilters
     include GroupingFilters
     include DateFilters
+    include LocalizationFilters
     include ConditionHelpers
 
     # Convert a Markdown string into HTML output.

--- a/bridgetown-core/lib/bridgetown-core/filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters.rb
@@ -8,6 +8,7 @@ module Bridgetown
     include GroupingFilters
     include DateFilters
     include LocalizationFilters
+    include TranslationFilters
     include ConditionHelpers
 
     # Convert a Markdown string into HTML output.
@@ -433,7 +434,4 @@ end
 
 Liquid::Template.register_filter(
   Bridgetown::Filters
-)
-Liquid::Template.register_filter(
-  Bridgetown::Filters::TranslationFilters
 )

--- a/bridgetown-core/lib/bridgetown-core/filters/localization_filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters/localization_filters.rb
@@ -3,8 +3,34 @@
 module Bridgetown
   module Filters
     module LocalizationFilters
-      def l(input)
-        I18n.l(input.to_s)
+      def l(input, format = nil, locale = nil)
+        date = Liquid::Utils.to_date(input)
+        return input if date.nil?
+
+        format = maybe_symbolized(format, date)
+        locale ||= maybe_locale(format)
+        format = nil if locale == format
+
+        I18n.l(date, format: format, locale: locale)
+      end
+
+      private
+
+      def maybe_locale(format)
+        return if format.nil?
+
+        Bridgetown::Current.site.config.available_locales.include?(format.to_sym) ? format : nil
+      end
+
+      def maybe_symbolized(format, object)
+        return if format.nil?
+
+        type = type_of(object)
+        I18n.t("#{type}.formats").key?(format.to_sym) ? format.to_sym : format
+      end
+
+      def type_of(object)
+        object.respond_to?(:sec) ? "time" : "date"
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/filters/translation_filters.rb
+++ b/bridgetown-core/lib/bridgetown-core/filters/translation_filters.rb
@@ -3,8 +3,21 @@
 module Bridgetown
   module Filters
     module TranslationFilters
-      def t(input)
-        I18n.t(input.to_s)
+      def t(input, options = "")
+        options = string_to_hash(options)
+        locale = options.delete(:locale)
+        count = options.delete(:count)
+        options[:count] = count.to_i unless count.nil?
+
+        I18n.t(input.to_s, locale: locale, **options)
+      rescue ArgumentError
+        input
+      end
+
+      private
+
+      def string_to_hash(options)
+        options.split(",").to_h { |e| e.split(":").map(&:strip) }.symbolize_keys
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/l.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/l.rb
@@ -3,9 +3,11 @@
 module Bridgetown
   module Tags
     class LocalizationTag < Liquid::Tag
+      include Bridgetown::Filters::LocalizationFilters
+
       def render(_context)
-        key = @markup.strip
-        I18n.l(key)
+        input, format, locale = @markup.split.map(&:strip)
+        l(input, format, locale)
       end
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/tags/t.rb
+++ b/bridgetown-core/lib/bridgetown-core/tags/t.rb
@@ -3,9 +3,13 @@
 module Bridgetown
   module Tags
     class TranslationTag < Liquid::Tag
+      include Bridgetown::Filters::TranslationFilters
+
       def render(_context)
-        key = @markup.strip
-        I18n.t(key)
+        input, options = @markup.split.map(&:strip)
+        options ||= ""
+
+        t(input, options).to_s
       end
     end
   end

--- a/bridgetown-core/test/helper.rb
+++ b/bridgetown-core/test/helper.rb
@@ -111,6 +111,10 @@ class BridgetownUnitTest < Minitest::Test
       .bind_call(self, *args)
   end
 
+  def store_translations(locale, data, options = I18n::EMPTY_HASH)
+    I18n.backend.store_translations(locale, data, options)
+  end
+
   def before_setup
     RSpec::Mocks.setup
     super

--- a/bridgetown-core/test/helper.rb
+++ b/bridgetown-core/test/helper.rb
@@ -111,10 +111,6 @@ class BridgetownUnitTest < Minitest::Test
       .bind_call(self, *args)
   end
 
-  def store_translations(locale, data, options = I18n::EMPTY_HASH)
-    I18n.backend.store_translations(locale, data, options)
-  end
-
   def before_setup
     RSpec::Mocks.setup
     super

--- a/bridgetown-core/test/source/src/_locales/eo.yml
+++ b/bridgetown-core/test/source/src/_locales/eo.yml
@@ -1,0 +1,69 @@
+eo:
+  date:
+    abbr_day_names:
+    - dim
+    - lun
+    - mar
+    - mer
+    - ĵaŭ
+    - ven
+    - sab
+    abbr_month_names:
+    -
+    - jan.
+    - feb.
+    - mar.
+    - apr.
+    - majo
+    - jun.
+    - jul.
+    - aŭg.
+    - sep.
+    - okt.
+    - nov.
+    - dec.
+    day_names:
+    - dimanĉo
+    - lundo
+    - mardo
+    - merkredo
+    - ĵaŭdo
+    - vendredo
+    - sabato
+    formats:
+      default: "%Y/%m/%d"
+      long: "%d %B %Y"
+      short: "%-d %b"
+    month_names:
+    -
+    - januaro
+    - februaro
+    - marto
+    - aprilo
+    - majo
+    - junio
+    - julio
+    - aŭgusto
+    - septembro
+    - oktobro
+    - novembro
+    - decembro
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: "ĉirkaŭ unu horo"
+        other: "ĉirkaŭ %{count} horoj"
+  errors:
+    messages:
+      not_a_number: "ne estas nombro"
+  time:
+    am: am
+    formats:
+      default: "%d %B %Y %H:%M:%S"
+      long: "%A %d %B %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/bridgetown-core/test/source/src/_locales/fr.yml
+++ b/bridgetown-core/test/source/src/_locales/fr.yml
@@ -1,0 +1,69 @@
+fr:
+  date:
+    abbr_day_names:
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
+    abbr_month_names:
+    -
+    - jan.
+    - fév.
+    - mars
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
+    day_names:
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
+    formats:
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      short: "%-d %b"
+    month_names:
+    -
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: "environ une heure"
+        other: "environ %{count} heures"
+  errors:
+    messages:
+      not_a_number: "n'est pas un nombre"
+  time:
+    am: am
+    formats:
+      default: "%e %B %Y %Hh %Mmin %Ss"
+      long: "%A %e %B %Y %Hh%M"
+      short: "%d %b %Hh%M"
+    pm: pm

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -59,6 +59,7 @@ class TestFilters < BridgetownUnitTest
       )
       @sample_date = Date.parse("2013-03-02")
       @time_as_string = "September 11, 2001 12:46:30 -0000"
+      @date_as_string = "1995-12-21"
       @time_as_numeric = 1_399_680_607
       @integer_as_string = "142857"
       @array_of_objects = [
@@ -370,6 +371,204 @@ class TestFilters < BridgetownUnitTest
         should "return input" do
           assert_nil(@filter.date_to_xmlschema(nil))
           assert_equal("", @filter.date_to_xmlschema(""))
+        end
+      end
+    end
+
+    context "localization filters" do
+      setup do
+        eo_translations = {
+          date: {
+            abbr_month_names: [
+              "",
+              "jan.",
+              "feb.",
+              "mar.",
+              "apr.",
+              "majo",
+              "jun.",
+              "jul.",
+              "aŭg.",
+              "sep.",
+              "okt.",
+              "nov.",
+              "dec.",
+            ],
+            formats: {
+              default: "%d-%m-%Y",
+              short: "%-d %b",
+            },
+            month_names: [
+              "",
+              "januaro",
+              "februaro",
+              "marto",
+              "aprilo",
+              "majo",
+              "junio",
+              "julio",
+              "aŭgusto",
+              "septembro",
+              "oktobro",
+              "novembro",
+              "decembro",
+            ],
+          },
+          time: {
+            formats: {
+              default: "%d %B %Y %H:%M:%S",
+              short: "%d %b %H:%M",
+            },
+          },
+        }
+
+        fr_translations = {
+          date: {
+            abbr_month_names: [
+              "",
+              "jan.",
+              "fév.",
+              "mars",
+              "avr.",
+              "mai",
+              "juin",
+              "juil.",
+              "août",
+              "sept.",
+              "oct.",
+              "nov.",
+              "déc.",
+            ],
+            formats: {
+              default: "%d/%m/%Y",
+              short: "%-d %b",
+            },
+            month_names: [
+              "",
+              "janvier",
+              "février",
+              "mars",
+              "avril",
+              "mai",
+              "juin",
+              "juillet",
+              "août",
+              "septembre",
+              "octobre",
+              "novembre",
+              "décembre",
+            ],
+          },
+          time: {
+            formats: {
+              default: "%e %B %Y %Hh %Mmin %Ss",
+              short: "%d %b %Hh%M",
+            },
+          },
+        }
+
+        @filter.site.config.available_locales = I18n.available_locales = [:eo, :fr]
+        @filter.site.config.default_locale = I18n.locale = :eo
+        store_translations(:eo, eo_translations)
+        store_translations(:fr, fr_translations)
+      end
+
+      context "with Time object" do
+        should "format a datetime with default format" do
+          assert_equal "27 marto 2013 11:22:33", @filter.l(@sample_time)
+        end
+
+        should "format a datetime with short format" do
+          assert_equal "27 mar. 11:22", @filter.l(@sample_time, "short")
+        end
+
+        should "format a datetime with short format in french locale" do
+          assert_equal "27 mars 11h22", @filter.l(@sample_time, "short", "fr")
+        end
+
+        should "format a datetime with default format in french locale" do
+          assert_equal "27 mars 2013 11h 22min 33s", @filter.l(@sample_time, "fr")
+        end
+      end
+
+      context "with Date object" do
+        should "format a date with default format" do
+          assert_equal "2013/03/02", @filter.l(@sample_date)
+        end
+
+        should "format a date with short format" do
+          assert_equal "2 mar.", @filter.l(@sample_date, "short")
+        end
+
+        should "format a date with short format in french locale" do
+          assert_equal "2 mars", @filter.l(@sample_date, "short", "fr")
+        end
+
+        should "format a date with default format in french locale" do
+          assert_equal "02/03/2013", @filter.l(@sample_date, "fr")
+        end
+      end
+
+      context "with String object" do
+        context "representing a time" do
+          should "format a datetime with default format" do
+            assert_equal "11 septembro 2001 12:46:30", @filter.l(@time_as_string)
+          end
+
+          should "format a datetime with short format" do
+            assert_equal "11 sep. 12:46", @filter.l(@time_as_string, "short")
+          end
+
+          should "format a datetime with short format in french locale" do
+            assert_equal "11 sept. 12h46", @filter.l(@time_as_string, "short", "fr")
+          end
+
+          should "format a datetime with default format in french locale" do
+            assert_equal "11 septembre 2001 12h 46min 30s", @filter.l(@time_as_string, "fr")
+          end
+        end
+
+        context "representing a date" do
+          should "format a date with default format" do
+            assert_equal "21 decembro 1995 00:00:00", @filter.l(@date_as_string)
+          end
+
+          should "format a date with short format" do
+            assert_equal "21 dec. 00:00", @filter.l(@date_as_string, "short")
+          end
+
+          should "format a date with short format in french locale" do
+            assert_equal "21 déc. 00h00", @filter.l(@date_as_string, "short", "fr")
+          end
+
+          should "format a date with default format in french locale" do
+            assert_equal "21 décembre 1995 00h 00min 00s", @filter.l(@date_as_string, "fr")
+          end
+        end
+      end
+
+      context "with a Numeric object" do
+        should "format a datetime with default format" do
+          assert_equal "10 majo 2014 00:10:07", @filter.l(@time_as_numeric)
+        end
+
+        should "format a datetime with short format" do
+          assert_equal "10 majo 00:10", @filter.l(@time_as_numeric, "short")
+        end
+
+        should "format a datetime with short format in french locale" do
+          assert_equal "10 mai 00h10", @filter.l(@time_as_numeric, "short", "fr")
+        end
+
+        should "format a datetime with default format in french locale" do
+          assert_equal "10 mai 2014 00h 10min 07s", @filter.l(@time_as_numeric, "fr")
+        end
+      end
+
+      context "without input" do
+        should "return input" do
+          assert_nil(@filter.l(nil))
+          assert_equal("", @filter.l(""))
         end
       end
     end

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -377,42 +377,8 @@ class TestFilters < BridgetownUnitTest
 
     context "translation filters" do
       setup do
-        eo_translations = {
-          datetime: {
-            distance_in_words: {
-              about_x_hours: {
-                one: "ĉirkaŭ unu horo",
-                other: "ĉirkaŭ %<count>s horoj",
-              },
-            },
-          },
-          errors: {
-            messages: {
-              not_a_number: "ne estas nombro",
-            },
-          },
-        }
-
-        fr_translations = {
-          datetime: {
-            distance_in_words: {
-              about_x_hours: {
-                one: "environ une heure",
-                other: "environ %<count>s heures",
-              },
-            },
-          },
-          errors: {
-            messages: {
-              not_a_number: "n'est pas un nombre",
-            },
-          },
-        }
-
         @filter.site.config.available_locales = I18n.available_locales = [:eo, :fr]
         @filter.site.config.default_locale = I18n.locale = :eo
-        store_translations(:eo, eo_translations)
-        store_translations(:fr, fr_translations)
       end
 
       context "lookup" do
@@ -473,100 +439,8 @@ class TestFilters < BridgetownUnitTest
 
     context "localization filters" do
       setup do
-        eo_translations = {
-          date: {
-            abbr_month_names: [
-              "",
-              "jan.",
-              "feb.",
-              "mar.",
-              "apr.",
-              "majo",
-              "jun.",
-              "jul.",
-              "aŭg.",
-              "sep.",
-              "okt.",
-              "nov.",
-              "dec.",
-            ],
-            formats: {
-              default: "%d-%m-%Y",
-              short: "%-d %b",
-            },
-            month_names: [
-              "",
-              "januaro",
-              "februaro",
-              "marto",
-              "aprilo",
-              "majo",
-              "junio",
-              "julio",
-              "aŭgusto",
-              "septembro",
-              "oktobro",
-              "novembro",
-              "decembro",
-            ],
-          },
-          time: {
-            formats: {
-              default: "%d %B %Y %H:%M:%S",
-              short: "%d %b %H:%M",
-            },
-          },
-        }
-
-        fr_translations = {
-          date: {
-            abbr_month_names: [
-              "",
-              "jan.",
-              "fév.",
-              "mars",
-              "avr.",
-              "mai",
-              "juin",
-              "juil.",
-              "août",
-              "sept.",
-              "oct.",
-              "nov.",
-              "déc.",
-            ],
-            formats: {
-              default: "%d/%m/%Y",
-              short: "%-d %b",
-            },
-            month_names: [
-              "",
-              "janvier",
-              "février",
-              "mars",
-              "avril",
-              "mai",
-              "juin",
-              "juillet",
-              "août",
-              "septembre",
-              "octobre",
-              "novembre",
-              "décembre",
-            ],
-          },
-          time: {
-            formats: {
-              default: "%e %B %Y %Hh %Mmin %Ss",
-              short: "%d %b %Hh%M",
-            },
-          },
-        }
-
         @filter.site.config.available_locales = I18n.available_locales = [:eo, :fr]
         @filter.site.config.default_locale = I18n.locale = :eo
-        store_translations(:eo, eo_translations)
-        store_translations(:fr, fr_translations)
       end
 
       context "with Time object" do

--- a/bridgetown-core/test/test_filters.rb
+++ b/bridgetown-core/test/test_filters.rb
@@ -375,6 +375,102 @@ class TestFilters < BridgetownUnitTest
       end
     end
 
+    context "translation filters" do
+      setup do
+        eo_translations = {
+          datetime: {
+            distance_in_words: {
+              about_x_hours: {
+                one: "ĉirkaŭ unu horo",
+                other: "ĉirkaŭ %<count>s horoj",
+              },
+            },
+          },
+          errors: {
+            messages: {
+              not_a_number: "ne estas nombro",
+            },
+          },
+        }
+
+        fr_translations = {
+          datetime: {
+            distance_in_words: {
+              about_x_hours: {
+                one: "environ une heure",
+                other: "environ %<count>s heures",
+              },
+            },
+          },
+          errors: {
+            messages: {
+              not_a_number: "n'est pas un nombre",
+            },
+          },
+        }
+
+        @filter.site.config.available_locales = I18n.available_locales = [:eo, :fr]
+        @filter.site.config.default_locale = I18n.locale = :eo
+        store_translations(:eo, eo_translations)
+        store_translations(:fr, fr_translations)
+      end
+
+      context "lookup" do
+        should "translate error message with default locale" do
+          assert_equal "ne estas nombro", @filter.t("errors.messages.not_a_number")
+        end
+
+        should "translate error message with french locale" do
+          assert_equal "n'est pas un nombre", @filter.t("errors.messages.not_a_number", "locale:fr")
+        end
+      end
+
+      context "pluralization" do
+        should "translate distance message with default locale" do
+          assert_equal "ĉirkaŭ unu horo", @filter.t("datetime.distance_in_words.about_x_hours", "count:1")
+        end
+
+        should "translate pluralized distance message with default locale" do
+          assert_equal "ĉirkaŭ 3 horoj", @filter.t("datetime.distance_in_words.about_x_hours", "count:3")
+        end
+
+        should "translate distance message with french locale" do
+          assert_equal "environ une heure", @filter.t("datetime.distance_in_words.about_x_hours", "count:1, locale:fr")
+        end
+
+        should "translate pluralized distance message with french locale" do
+          assert_equal "environ 3 heures", @filter.t("datetime.distance_in_words.about_x_hours", "locale:fr,  count:3")
+        end
+      end
+
+      context "defaults" do
+        should "translate missing message with default locale" do
+          assert_equal "foo", @filter.t("missing", "default:foo")
+        end
+
+        should "translate missing message with french locale" do
+          assert_equal "foo", @filter.t("missing", "locale:fr, default:foo")
+        end
+      end
+
+      context "scope" do
+        should "translate error message with default locale" do
+          assert_equal "ne estas nombro", @filter.t("messages.not_a_number", "scope:errors")
+        end
+
+        should "translate error message with french locale" do
+          assert_equal "n'est pas un nombre", @filter.t("messages.not_a_number", "locale:fr, scope:errors")
+        end
+      end
+
+      context "without input" do
+        should "return input" do
+          assert_nil(@filter.t(nil))
+          assert_equal("", @filter.t(""))
+        end
+      end
+    end
+
     context "localization filters" do
       setup do
         eo_translations = {


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
This is a 🙋 feature or enhancement.


<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This pull request fixes, enhances and tests i18n liquid tags & filters.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

### Localization

The newly introduced localization (#759) liquid filter & tag does not work, because `I18n.l` [requires an argument that responds to `#strftime`][i18n], which is not the case for String.


[i18n]: https://github.com/ruby-i18n/i18n/blob/7cf09474b77fd41e65d979134b0525f67cf371b0/lib/i18n/backend/base.rb#L79

This PR relies on [`Liquid::Utils.to_date`][to_date] to handle date strings.

[to_date]: https://github.com/Shopify/liquid/blob/5e92b3a89a112ea6d932b503410a3336404673dc/lib/liquid/utils.rb#L65

And localization filter & tag now support arguments and are fully tested.

Usage:

```markdown
- {{ data.date | l }}
- {{ data.date | l: "short" }}
- {{ data.date | l: "short", "eo" }}
- {{ data.date | l: "eo" }}

- {{ "now" | l }}
- {{ "now" | l: "short" }}
- {{ "now" | l: "short", "eo" }}
- {{ "now" | l: "eo" }}

- {{ "today" | l }}
- {{ "today" | l: "short" }}
- {{ "today" | l: "short", "eo" }}
- {{ "today" | l: "eo" }}

- {{ 1234567890 | l }}
- {{ 1234567890 | l: "short" }}
- {{ 1234567890 | l: "short", "eo" }}
- {{ 1234567890 | l: "eo" }}
```

```markdown
- {% l 1995-12-21 %}
- {% l 1995-12-21 short %}
- {% l 1995-12-21 short eo %}
- {% l 1995-12-21 eo %}

- {% l now %}
- {% l now short %}
- {% l now short eo %}
- {% l now eo %}

- {% l today %}
- {% l today short %}
- {% l today short eo %}
- {% l today eo %}

- {% l 11:22:33 %}
- {% l 11:22:33 short %}
- {% l 11:22:33 short eo %}
- {% l 11:22:33 eo %}

- {% l 1995-12-21T11:22:33 %}
- {% l 1995-12-21T11:22:33 short %}
- {% l 1995-12-21T11:22:33 short eo %}
- {% l 1995-12-21T11:22:33 eo %}

- {% l 1234567890 %}
- {% l 1234567890 short %}
- {% l 1234567890 short eo %}
- {% l 1234567890 eo %}
```

Note: `l` tag arguments are split by a space, so datetime must not contain a space character.

### Translation

Translation tag & filter now accept arguments too, and are fully tested.

Usage:

```markdown
- {{ "date.day_names" | t | last }}
- {{ "date.day_names" | t: "locale:eo" | last }}
- {{ "day_names" | t: "scope:date,locale:eo" | last }}
- {{ "missing" | t: "default:oops" }}
- {{ "datetime.distance_in_words.about_x_hours" | t: "count:3" }}
- {{ "datetime.distance_in_words.about_x_hours" | t: "count:1,locale:eo" }}

- {% t errors.messages.not_a_number %}
- {% t errors.messages.not_a_number locale:eo %}
- {% t messages.not_a_number scope:errors,locale:eo %}
- {% t missing default:oops %}
- {% t datetime.distance_in_words.about_x_hours count:3 %}
- {% t datetime.distance_in_words.about_x_hours count:1,locale:eo %}
```

Note: `t` tag & filter arguments are `key:value` pairs separated by commas.