### PR TITLE
Fix `link_to` when passed block

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -98,10 +98,10 @@ module Bridgetown
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
       def link_to(text, relative_path = nil, options = {}, &block)
-        if block_given?
+        if block.present?
           options = relative_path || {}
           relative_path = text
-          text = view.respond_to?(:capture) ? view.capture(&block) : block.call
+          text = view.respond_to?(:capture) ? view.capture(&block) : yield
         elsif relative_path.nil?
           raise ArgumentError, "You must provide a relative path"
         end

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -99,6 +99,7 @@ module Bridgetown
       # @raise [ArgumentError] if the file cannot be found
       def link_to(text, relative_path = nil, options = {})
         if block_given?
+          options = relative_path || {}
           relative_path = text
           text = yield
         elsif relative_path.nil?

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -97,11 +97,11 @@ module Bridgetown
       # @param options [Hash] key-value pairs of HTML attributes to add to the tag
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
-      def link_to(text, relative_path = nil, options = {})
+      def link_to(text, relative_path = nil, options = {}, &block)
         if block_given?
           options = relative_path || {}
           relative_path = text
-          text = yield
+          text = view.respond_to?(:capture) ? view.capture(&block) : block.call
         elsif relative_path.nil?
           raise ArgumentError, "You must provide a relative path"
         end

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -31,6 +31,7 @@ class TestRubyHelpers < BridgetownUnitTest
 
     should "accept additional attributes" do
       assert_equal "<a href=\"/foo/bar\" class=\"classes\" data-test=\"abc123\">Label</a>", @helpers.link_to("Label", "/foo/bar", class: "classes", data_test: "abc123")
+      assert_equal "<a href=\"/foo/bar\" class=\"classes\" data-test=\"abc123\">Label</a>", @helpers.link_to("/foo/bar", class: "classes", data_test: "abc123") { "Label" }
     end
 
     should "accept hash attributes" do


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

- When passing a block to `link_to` the additional options were being dropped. 
- When passing a block to `link_to` in ERB, the block needs to be captured or the block is not inside the link element.