### PR TITLE
Add ActiveSupport::Inflector to Zeitwerk

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
@@ -55,6 +55,7 @@ module Bridgetown
           next unless Dir.exist? load_path
 
           loader = Zeitwerk::Loader.new
+          loader.inflector = ActiveSupport::Inflector
           begin
             loader.push_dir(load_path)
           rescue Zeitwerk::Error

--- a/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/loaders_manager.rb
@@ -47,7 +47,7 @@ module Bridgetown
       end
 
       def setup_loaders(autoload_paths = []) # rubocop:todo Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        (autoload_paths.presence || config.autoload_paths).each do |load_path|
+        (autoload_paths.presence || config.autoload_paths).each do |load_path| # rubocop:todo Metrics/BlockLength
           if @loaders.key?(load_path)
             raise "Zeitwerk loader already added for `#{load_path}'. Please check your config"
           end

--- a/bridgetown-core/lib/site_template/config/initializers.rb
+++ b/bridgetown-core/lib/site_template/config/initializers.rb
@@ -10,6 +10,21 @@ Bridgetown.configure do |config|
   # config.autoload_paths << "models"
   #
 
+  # Add new inflection rules using the following format. Inflections
+  # are locale specific, and you may define rules for as many different
+  # locales as you wish. All of these examples are active by default:
+  # ActiveSupport::Inflector.inflections(:en) do |inflect|
+  #   inflect.plural /^(ox)$/i, "\\1en"
+  #   inflect.singular /^(ox)en/i, "\\1"
+  #   inflect.irregular "person", "people"
+  #   inflect.uncountable %w( fish sheep )
+  # end
+
+  # These inflection rules are supported but not enabled by default:
+  # ActiveSupport::Inflector.inflections(:en) do |inflect|
+  #   inflect.acronym "RESTful"
+  # end
+
   # You can use `init` to initialize various Bridgetown features or plugin gems.
   # For example, you can use the Dotenv gem to load environment variables from
   # `.env`. Just `bundle add dotenv` and then uncomment this:

--- a/bridgetown-website/src/_docs/configuration/initializers.md
+++ b/bridgetown-website/src/_docs/configuration/initializers.md
@@ -268,6 +268,16 @@ init :dotenv
 
 Now anywhere in your Ruby plugins, templates, etc., you can access environment variables via `ENV` once you've defined your `.env` file. Our integration also supports specially-named files such as `.env.development`, `.env.test`, etc.
 
+### Inflector
+
+Zeitwerk's inflector is configured by default to use ActiveSupport::Inflector. To add new inflection rules, use the following format.
+
+```ruby
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RESTful"
+end
+```
+
 ### Parse Roda Routes
 
 Because of how Roda works via its dynamic routing tree, there's no straightforward way to programmatically list out all the routes in your application.

--- a/bridgetown-website/src/_docs/resources.md
+++ b/bridgetown-website/src/_docs/resources.md
@@ -245,14 +245,7 @@ The three types of relations you can configure are:
 * **has_one**: a single resource you want to reference will define the slug of the current resource in _its_ front matter
 * **has_many**: multiple resources you want to reference will define the slug of the current resource in their front matter
 
-The "inflector" loaded in from Rails' ActiveSupport is used to convert between singular and plural collection names automatically. If you need to customize the inflector with words it doesn't specifically recognize, create a plugin and add your own:
-
-```ruby
-ActiveSuport::Inflector.inflections(:en) do |inflect|
-  inflect.plural /^(ox)$/i, '\1\2en'
-  inflect.singular /^(ox)en/i, '\1'
-end
-```
+The "inflector" is loaded from Rails' ActiveSupport and is used to convert between singular and plural collection names automatically. If you need to customize the inflector with words it doesn't specifically recognize, see configuring ActiveSupport::Inflector in the [`config/initializers.rb`](/docs/configuration/initializers#inflector) file.
 
 ## Configuring Permalinks
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement. 
This is a 🔦 documentation change.

## Summary

To make things easier I've made it so Zeitwerk uses ActiveSupport::Inflector out of the box. I'm not really sure how to add tests for this. Looking for assistance on that if required to merge this. I've testsed this in my own project and it works.

## Changes
- Configure Zeitwerk's inflector to use ActiveSupport::Inflector
- Add commented out example to config/initializer.rb
- Update existing documentation about ActiveSupport::Inflector to reference initializer configuration
- Add documentation for initializer
