### PR TITLE
Changes link _to helper to use the options parameter when receiving a block

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -99,8 +99,8 @@ module Bridgetown
       # @raise [ArgumentError] if the file cannot be found
       def link_to(text, relative_path = nil, options = {})
         if block_given?
-          relative_path = text
           options = relative_path
+          relative_path = text
           text = yield
         elsif relative_path.nil?
           raise ArgumentError, "You must provide a relative path"

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -100,6 +100,7 @@ module Bridgetown
       def link_to(text, relative_path = nil, options = {})
         if block_given?
           relative_path = text
+          options = relative_path
           text = yield
         elsif relative_path.nil?
           raise ArgumentError, "You must provide a relative path"

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -50,7 +50,7 @@ class TestRubyHelpers < BridgetownUnitTest
     end
 
     should "accept block syntax" do
-      assert_equal "<a href=\"/foo/bar\">Label</a>", @helpers.link_to("/foo/bar") { "Label" }
+      assert_equal "<a href=\"/foo/bar\" classe=\"classes\">Label</a>", @helpers.link_to("/foo/bar", class: "classes") { "Label" }
     end
 
     should "raise if only one argument was given" do

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -50,7 +50,7 @@ class TestRubyHelpers < BridgetownUnitTest
     end
 
     should "accept block syntax" do
-      assert_equal "<a href=\"/foo/bar\" classe=\"classes\">Label</a>", @helpers.link_to("/foo/bar", class: "classes") { "Label" }
+      assert_equal "<a href=\"/foo/bar\" class=\"classes\">Label</a>", @helpers.link_to("/foo/bar", { class: "classes" }) { "Label" }
     end
 
     should "raise if only one argument was given" do


### PR DESCRIPTION
I believe this is a 🙋 feature or enhancement.

## Summary

Adds ability to receive options parameters to the link_to helper when it receives a block.

## Context

I've noticed this when attempting to personalize the link element while still giving a block to it.

I haven't found any issues reporting this behaviour or asking to change, but given this was exactly the behaviour I was expecting, I've decided to provide a Pull Request.

Please do let me know if further changes are needed. I'm happy to make any further changes deemed relevant.
