### PR TITLE
Allow consistent permitting classes

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/yaml_parser.rb
+++ b/bridgetown-core/lib/bridgetown-core/yaml_parser.rb
@@ -6,12 +6,23 @@ module Bridgetown
 
     class << self
       def load_file(filename, **kwargs)
-        kwargs = { permitted_classes: PERMITTED_CLASSES }.merge(kwargs)
-        YAML.safe_load_file(filename, **kwargs)
+        YAML.safe_load_file filename, **merge_permitted_classes(kwargs)
       end
 
-      def load(yaml)
-        YAML.safe_load yaml, permitted_classes: PERMITTED_CLASSES
+      def load(yaml, **kwargs)
+        YAML.safe_load yaml, **merge_permitted_classes(kwargs)
+      end
+
+      private
+
+      def merge_permitted_classes(kwargs)
+        if kwargs.key?(:permitted_classes)
+          kwargs[:permitted_classes] |= PERMITTED_CLASSES
+        else
+          kwargs[:permitted_classes] = PERMITTED_CLASSES
+        end
+
+        kwargs
       end
     end
   end

--- a/bridgetown-core/test/fixtures/extra_yaml.yml
+++ b/bridgetown-core/test/fixtures/extra_yaml.yml
@@ -1,0 +1,6 @@
+---
+date: 2020-05-14
+time: 2019-07-14 19:22:00 +0100
+rb: !ruby/string:Rb |
+  21 * 2
+symbol: :symbol

--- a/bridgetown-core/test/test_yaml_parser.rb
+++ b/bridgetown-core/test/test_yaml_parser.rb
@@ -34,6 +34,21 @@ class TestYAMLParser < BridgetownUnitTest
       assert_equal Rb, parsed_yaml["rb"].class
     end
 
+    should "allows passing other permitted classes" do
+      parsed_yaml = Bridgetown::YAMLParser.load(<<~YAML, permitted_classes: [Symbol])
+        date: 2020-05-14
+        time: 2019-07-14 19:22:00 +0100
+        rb: !ruby/string:Rb |
+          21 * 2
+        symbol: :symbol
+      YAML
+
+      assert_equal Date, parsed_yaml["date"].class
+      assert_equal Time, parsed_yaml["time"].class
+      assert_equal Rb, parsed_yaml["rb"].class
+      assert_equal :symbol, parsed_yaml["symbol"]
+    end
+
     should "error when trying to parse types not on the allowlist" do
       assert_raises(Psych::DisallowedClass) do
         Bridgetown::YAMLParser.load(CustomYAMLSerializable.new.to_yaml)
@@ -49,6 +64,16 @@ class TestYAMLParser < BridgetownUnitTest
       assert_equal Date, parsed_yaml["date"].class
       assert_equal Time, parsed_yaml["time"].class
       assert_equal Rb, parsed_yaml["rb"].class
+    end
+
+    should "allows passing other permitted classes" do
+      yaml_file = test_dir("fixtures", "extra_yaml.yml")
+      parsed_yaml = Bridgetown::YAMLParser.load_file(yaml_file, permitted_classes: [Symbol])
+
+      assert_equal Date, parsed_yaml["date"].class
+      assert_equal Time, parsed_yaml["time"].class
+      assert_equal Rb, parsed_yaml["rb"].class
+      assert_equal :symbol, parsed_yaml["symbol"]
     end
 
     should "error when trying to parse types not on the allowlist" do


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

By default, Bridgetown expects to be able to load its special Rb class for YAML front matter. The original implementation made it hard to have extra permitted classes in front matter while retaining that expectation.

This change makes it so the default permitted classes are merged into any passed permitted classes across both string and file loading.

## Context

While digging into ways that we could have a consistent YAML store for #777, I discovered this papercut.