### PR TITLE
Catch error and log when PostCSS conversion fails

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -128,14 +128,19 @@ const importPostCssPlugin = (options, configuration) => ({
       })
 
       // Process the file through PostCSS
-      const result = await postcss([importPlugin, ...options.plugins]).process(css, {
-        map: true,
-        ...options.options,
-        from: args.path,
-      });
-
+      let outputCSS = ""
+      try {
+        const result = await postcss([importPlugin, ...options.plugins]).process(css, {
+          map: true,
+          ...options.options,
+          from: args.path,
+        })
+        outputCSS = result.css
+      } catch(err) {
+        console.error(`\nerror: "${err.reason}" while processing CSS file:\n${err.file}:${err.line}:${err.column}\n`)
+      }
       return {
-        contents: result.css,
+        contents: outputCSS,
         loader: "css",
         watchFiles: [args.path, ...additionalFilePaths],
       }


### PR DESCRIPTION
There's been an ongoing effort to ensure very few code changes to your project result in a crash when the dev server is running. We've made great strides, but certain PostCSS build errors were still resulting in an esbuild crash—and furthermore, it was hard even to tell why.

With this PR, esbuild won't crash, your site's stylesheet will temporarily go wonky (alerting you that something's off), and the exact nature of the error plus file path, line, and column numbers will explain where you should look to resolve the issue.