### PR TITLE
auto-detect package manager in the plugin manager

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -130,13 +130,15 @@ module Bridgetown
     end
 
     def self.package_manager
-      if File.exist?("yarn.lock")
-        "yarn"
-      elsif File.exist?("package-lock.json")
-        "npm"
-      elsif File.exist?("pnpm-lock.yaml")
-        "pnpm"
-      end
+      @package_manager ||= if File.exist?("yarn.lock")
+                              "yarn"
+                            elsif File.exist?("package-lock.json")
+                              "npm"
+                            elsif File.exist?("pnpm-lock.yaml")
+                              "pnpm"
+                            else
+                              ""
+                            end
     end
 
     def self.package_manager_install_command
@@ -167,7 +169,7 @@ module Bridgetown
         yarn_dependency = find_yarn_dependency(loaded_gem)
         next unless add_yarn_dependency?(yarn_dependency, package_json)
 
-        next if package_manager.nil?
+        next if package_manager.empty?
 
         cmd = "#{package_manager} #{package_manager_install_command} #{yarn_dependency.join("@")}"
         system cmd

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -138,6 +138,7 @@ module Bridgetown
 
       package_json = JSON.parse(File.read("package.json"))
 
+
       gems_to_search = if name
                          required_gems.select do |loaded_gem|
                            loaded_gem.to_spec&.name == name.to_s
@@ -146,24 +147,24 @@ module Bridgetown
                          required_gems
                        end
 
+      # all right, time to install the package
+      package_manager = if File.exist?("yarn.lock")
+                          "yarn"
+                        elsif File.exist?("package-lock.json")
+                          "npm"
+                        elsif File.exist?("pnpm-lock.yaml")
+                          "pnpm"
+                        else
+                          nil
+                        end
+
+      break if package_manager.nil?
+
+      command = package_manager == "npm" ? "install" : "add"
+
       gems_to_search.each do |loaded_gem|
         yarn_dependency = find_yarn_dependency(loaded_gem)
         next unless add_yarn_dependency?(yarn_dependency, package_json)
-
-        # all right, time to install the package
-        package_manager = if File.exist?("yarn.lock")
-                            "yarn"
-                          elsif File.exist?("package-lock.json")
-                            "npm"
-                          elsif File.exist?("pnpm-lock.yaml")
-                            "pnpm"
-                          else
-                            nil
-                          end
-
-        return if package_manager.nil?
-
-        command = package_manager === "npm" ? "install" : "add"
 
         cmd = "#{package_manager} #{command} #{yarn_dependency.join("@")}"
         system cmd

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -131,14 +131,14 @@ module Bridgetown
 
     def self.package_manager
       @package_manager ||= if File.exist?("yarn.lock")
-                              "yarn"
-                            elsif File.exist?("package-lock.json")
-                              "npm"
-                            elsif File.exist?("pnpm-lock.yaml")
-                              "pnpm"
-                            else
-                              ""
-                            end
+                             "yarn"
+                           elsif File.exist?("package-lock.json")
+                             "npm"
+                           elsif File.exist?("pnpm-lock.yaml")
+                             "pnpm"
+                           else
+                             ""
+                           end
     end
 
     def self.package_manager_install_command

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -151,7 +151,21 @@ module Bridgetown
         next unless add_yarn_dependency?(yarn_dependency, package_json)
 
         # all right, time to install the package
-        cmd = "yarn add #{yarn_dependency.join("@")}"
+        package_manager = if File.exist?("yarn.lock")
+                            "yarn"
+                          elsif File.exist?("package-lock.json")
+                            "npm"
+                          elsif File.exist?("pnpm-lock.yaml")
+                            "pnpm"
+                          else
+                            nil
+                          end
+
+        return if package_manager.nil?
+
+        command = package_manager === "npm" ? "install" : "add"
+
+        cmd = "#{package_manager} #{command} #{yarn_dependency.join("@")}"
         system cmd
       end
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Auto-detect how to install dependencies of plugins to improve the story of using any package manager

## Context

Related to #609 

This doesn't fix it. But this allows you to opt-out of yarn and use whatever package manager you want. We could also just bail if we can't find a `yarn.lock` or maybe check an ENV var like `NO_YARN_INSTALL` or something?
