### PR TITLE
Fix typo in liquid.md

### DIFF
--- a/bridgetown-website/src/_docs/components/liquid.md
+++ b/bridgetown-website/src/_docs/components/liquid.md
@@ -155,7 +155,7 @@ Normally content inside of `with` tags is not processed as Markdown (unlike the 
 You can use the `liquid_render` helper from Ruby-based templates to render Liquid components.
 
 ```erb
-<%%= liquid_render "test_component", param: "Liquid FTW!" %>
+<%= liquid_render "test_component", param: "Liquid FTW!" %>
 ```
 
 If you pass a block to `liquid_render`, it will utilize the `rendercontent` Liquid tag and the block contents will be captured and made available via the `content` variable.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I think this is a typo in /docs/components/liquid#rendering-liquid-components-from-ruby-based-templates