### PR TITLE
Update GitLab Pages deploy example to use !reference tag

### DIFF
--- a/bridgetown-website/src/_docs/deployment.md
+++ b/bridgetown-website/src/_docs/deployment.md
@@ -100,47 +100,39 @@ cache:
   paths:
   - vendor
 
+.setup:
+  script:
+    - apt-get update -yqqq
+    - curl -sL https://deb.nodesource.com/setup_12.x | bash -
+    - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+    - echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+    - apt update
+    - apt-get install -y nodejs yarn
+    - export GEM_HOME=$PWD/gems
+    - export PATH=$PWD/gems/bin:$PATH
+    - gem install bundler
+    - gem install bridgetown -N
+    - bundle install
+    - yarn install
+
 test:
   script:
-  - apt-get update -yqqq
-  - curl -sL https://deb.nodesource.com/setup_12.x | bash -
-  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-  - echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-  - apt update
-  - apt-get install -y nodejs yarn
-  - export GEM_HOME=$PWD/gems
-  - export PATH=$PWD/gems/bin:$PATH
-  - gem install bundler
-  - gem install bridgetown -N
-  - bundle install
-  - yarn install
-  - bin/bridgetown deploy
-  - bin/bridgetown clean
+    - !reference [.setup, script]
+    - bin/bridgetown deploy
+    - bin/bridgetown clean
   except:
     - main
 
 pages:
   script:
-  - apt-get update -yqqq
-  - curl -sL https://deb.nodesource.com/setup_12.x | bash -
-  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-  - echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-  - apt update
-  - apt-get install -y nodejs yarn
-  - export GEM_HOME=$PWD/gems
-  - export PATH=$PWD/gems/bin:$PATH
-  - gem install bundler
-  - gem install bridgetown -N
-  - bundle install
-  - yarn install
-  - bin/bridgetown deploy
-  - mv output public
+    - !reference [.setup, script]
+    - bin/bridgetown deploy
+    - mv output public
   artifacts:
     paths:
-    - public
+      - public
   only:
-  - main
-
+    - main
 ```
 Once this file has been created, add it and the other files and folders to the repository, and then push them to GitLab:
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This updates the GitLab Pages section of the deploy documentation to use [`!reference` tags][1] to reuse the shared config between the `pages` and `test` jobs.

## Context

I'm working on getting a bridgetown project setup to deploy on GitLab Pages and I copied the provided example to get started with. It did work, but I noticed that there was a lot of duplicate "setup" code and wanted to combine that so that for example, if I want to update the node version I only have to do that in one place instead of two.

It's worth noting that the linked GitLab docs say to use the special `extends` keyword over built-in yaml features. The reason I'm using `!reference` instead is because:
> You can use `extends` to merge hashes **but not arrays**

[1]: https://docs.gitlab.com/ee/ci/yaml/yaml_optimization.html#reference-tags
