### PR TITLE
Fix relative translation keys for views with dash

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -158,7 +158,7 @@ module Bridgetown
 
         if key&.start_with?(".")
           view_path = view&.page&.relative_path&.to_s&.split(".")&.first
-          key = "#{view_path.tr("/", ".")}#{key}" if view_path.present?
+          key = "#{view_path.tr("/", ".").tr("-", "_")}#{key}" if view_path.present?
         end
 
         ActiveSupport::HtmlSafeTranslation.translate(key, **options)

--- a/bridgetown-core/test/source/src/_locales/en.yml
+++ b/bridgetown-core/test/source/src/_locales/en.yml
@@ -6,3 +6,5 @@ en:
   contacts:
     bar:
       foo: foo
+  deal_with_dashes:
+    foo: foo

--- a/bridgetown-core/test/source/src/deal-with-dashes.html
+++ b/bridgetown-core/test/source/src/deal-with-dashes.html
@@ -1,0 +1,5 @@
+---
+title: Deal with dashes
+---
+
+Let's test if bridgetown deals with dashes.

--- a/bridgetown-core/test/test_ruby_helpers.rb
+++ b/bridgetown-core/test/test_ruby_helpers.rb
@@ -114,6 +114,16 @@ class TestRubyHelpers < BridgetownUnitTest
       assert_equal "foo", helpers.translate(".foo")
     end
 
+    should "return relative translation when key starts with period and view has a dash in it" do
+      helpers = Bridgetown::RubyTemplateView::Helpers.new(
+        Bridgetown::ERBView.new(
+          @site.collections.pages.resources.find { |p| p.basename_without_ext == "deal-with-dashes" }
+        ),
+        @site
+      )
+      assert_equal "foo", helpers.translate(".foo")
+    end
+
     should "return translation missing if key doesn't exist" do
       assert_equal "Translation missing: en.about.not_here", @helpers.translate(".not_here")
     end


### PR DESCRIPTION
When your view has a dash in the name, the key is getting a dash in it as well. I think it's likely that most times a dash in the view is for nice URLs and having to mix dashes with underscores in your translation keys is not ideal. This PR replaces all dashes in the view name with underscores.

This is a 🐛 bug fix. 