### PR TITLE
Move site and collections console commands to locals

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/console.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/console.rb
@@ -2,16 +2,10 @@
 
 module Bridgetown
   module ConsoleMethods
-    def site
-      Bridgetown::Current.site
-    end
-
-    def collections
-      site.collections
-    end
-
     def reload!
       Bridgetown.logger.info "Reloading site..."
+
+      site = Bridgetown::Current.site
 
       I18n.reload! # make sure any locale files get read again
       Bridgetown::Hooks.trigger :site, :pre_reload, site
@@ -98,7 +92,14 @@ module Bridgetown
 
         IRB::ExtendCommandBundle.include ConsoleMethods
         IRB.setup(nil)
-        workspace = IRB::WorkSpace.new
+        workspace = IRB::WorkSpace.new(
+          begin
+            site = Bridgetown::Current.site
+            collections = site.collections
+
+            binding
+          end
+        )
         irb = IRB::Irb.new(workspace)
         IRB.conf[:IRB_RC]&.call(irb.context)
         IRB.conf[:MAIN_CONTEXT] = irb.context


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Move the `site` and `collections` console commands to be local variables in the IRB shell.

<!--
  Provide a description of what your pull request changes.
-->

## Context

Console methods have precedence over Ruby methods with the same name. This means that any method name or local variable will be clobbered by the IRB commands `site` and `collections`. This presents an issue when using the IRB or Pry object navigation features, e.g.

```
3.0.6 :001 > cws site
irb: warn: can't alias source from irb_source.
#<Bridgetown::Site >
3.0.6 :002 > render
/Users/mattpace/.rvm/gems/ruby-3.0.6/gems/activesupport-7.1.2/lib/active_support/isolated_execution_state.rb:70:in `state': stack level too deep (SystemStackError)
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/activesupport-7.1.2/lib/active_support/isolated_execution_state.rb:38:in `[]'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/activesupport-7.1.2/lib/active_support/current_attributes.rb:173:in `current_instances'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/activesupport-7.1.2/lib/active_support/current_attributes.rb:100:in `instance'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/activesupport-7.1.2/lib/active_support/current_attributes.rb:127:in `sites'
        from /Users/mattpace/dev/mpace965/bridgetown/bridgetown-core/lib/bridgetown-core/current.rb:11:in `site'
        from /Users/mattpace/dev/mpace965/bridgetown/bridgetown-core/lib/bridgetown-core/commands/console.rb:6:in `site'
        from /Users/mattpace/dev/mpace965/bridgetown/bridgetown-core/lib/bridgetown-core/commands/console.rb:10:in `collections'
        from /Users/mattpace/dev/mpace965/bridgetown/bridgetown-core/lib/bridgetown-core/commands/console.rb:10:in `collections'
         ... 11890 levels...
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/bundler-2.5.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/gems/bundler-2.5.3/exe/bundle:20:in `<top (required)>'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/bin/bundle:23:in `load'
        from /Users/mattpace/.rvm/gems/ruby-3.0.6/bin/bundle:23:in `<main>'
```

In this example, I've tried to execute `Bridgetown::Site#render` after setting the IRB workspace to `site`.  This results in a `SystemStackError` because when calling `collections` on [this line](https://github.com/bridgetownrb/bridgetown/blob/854eca8d83f5bfa4910ed54c154cac7daccfc373/bridgetown-core/lib/bridgetown-core/concerns/site/renderable.rb#L78), the `collections` IRB command is executed instead of the `collections` instance method on `site`.

This PR moves `site` and `collections` to local variables that are passed into the main IRB workspace as a binding. This does mean that over the course of an IRB session, a user is free to initialize `site` or `collections` to something else. The upshot is that there's no longer a risk of clobbering these method names.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
