### PR TITLE
Use rack 3 proc responses for SSE live reload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ PATH
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 5.0)
       listen (~> 3.0)
+      rack (>= 3.0)
       rake (>= 13.0)
       roda (~> 3.46)
       rouge (>= 3.0, < 5.0)

--- a/bridgetown-core/bridgetown-core.gemspec
+++ b/bridgetown-core/bridgetown-core.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown-parser-gfm",       "~> 1.0")
   s.add_runtime_dependency("liquid",                    "~> 5.0")
   s.add_runtime_dependency("listen",                    "~> 3.0")
+  s.add_runtime_dependency("rack",                      ">= 3.0")
   s.add_runtime_dependency("rake",                      ">= 13.0")
   s.add_runtime_dependency("roda",                      "~> 3.46")
   s.add_runtime_dependency("rouge",                     [">= 3.0", "< 5.0"])

--- a/bridgetown-core/lib/bridgetown-core/rack/routes.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/routes.rb
@@ -154,7 +154,7 @@ module Bridgetown
 
         # @param app [Roda]
         def setup_live_reload(app) # rubocop:disable Metrics
-          sleep_interval = 1
+          sleep_interval = 0.5
           file_to_check = File.join(Bridgetown::Current.preloaded_configuration.destination,
                                     "index.html")
           errors_file = Bridgetown.build_errors_path
@@ -185,8 +185,8 @@ module Bridgetown
             end
 
             app.request.halt [200, {
-              "Content-Type" =>   "text/event-stream",
-              "cache-control" =>  "no-cache"
+              "Content-Type"  => "text/event-stream",
+              "cache-control" => "no-cache",
             }, event_stream,]
           end
         end

--- a/bridgetown-core/lib/bridgetown-core/rack/routes.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/routes.rb
@@ -2,12 +2,6 @@
 
 module Bridgetown
   module Rack
-    @interrupted = false
-
-    class << self
-      attr_accessor :interrupted
-    end
-
     class Routes
       include Bridgetown::Prioritizable
 
@@ -160,33 +154,36 @@ module Bridgetown
 
         # @param app [Roda]
         def setup_live_reload(app) # rubocop:disable Metrics
-          sleep_interval = 0.2
+          sleep_interval = 1
           file_to_check = File.join(Bridgetown::Current.preloaded_configuration.destination,
                                     "index.html")
           errors_file = Bridgetown.build_errors_path
 
           app.request.get "_bridgetown/live_reload" do
-            app.response["Content-Type"] = "text/event-stream"
-
             @_mod = File.exist?(file_to_check) ? File.stat(file_to_check).mtime.to_i : 0
-            app.stream async: true do |out|
-              # 5 second intervals so Puma's threads aren't all exausted
-              (5 / sleep_interval).to_i.times do
-                break if Bridgetown::Rack.interrupted
-
+            event_stream = proc do |stream|
+              loop
                 new_mod = File.exist?(file_to_check) ? File.stat(file_to_check).mtime.to_i : 0
+
                 if @_mod < new_mod
-                  out << "data: reloaded!\n\n"
+                  stream.write "data: reloaded!\n\n"
                   break
                 elsif File.exist?(errors_file)
-                  out << "event: builderror\ndata: #{File.read(errors_file).to_json}\n\n"
+                  stream.write "event: builderror\ndata: #{File.read(errors_file).to_json}\n\n"
                 else
-                  out << "data: #{new_mod}\n\n"
+                  stream.write "data: #{new_mod}\n\n"
                 end
 
                 sleep sleep_interval
               end
+            ensure
+              stream.close
             end
+
+            app.request.halt [200, {
+              "Content-Type" =>   "text/event-stream",
+              "cache-control" =>  "no-cache"
+            }, event_stream,]
           end
         end
       end
@@ -216,18 +213,6 @@ module Bridgetown
       def respond_to_missing?(method_name, include_private = false)
         @_roda_app.respond_to?(method_name.to_sym, include_private) || super
       end
-    end
-  end
-end
-
-if defined?(Puma) && Bridgetown.env.development? &&
-    !Bridgetown::Current.preloaded_configuration.skip_live_reload
-  Puma::Launcher.class_eval do
-    alias_method :_old_stop, :stop
-    def stop
-      Bridgetown::Rack.interrupted = true
-
-      _old_stop
     end
   end
 end

--- a/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
@@ -20,7 +20,6 @@ class Roda
         app.plugin :json_parser
         app.plugin :indifferent_params
         app.plugin :cookies
-        app.plugin :streaming
         app.plugin :public, root: Bridgetown::Current.preloaded_configuration.destination
         app.plugin :not_found do
           output_folder = Bridgetown::Current.preloaded_configuration.destination


### PR DESCRIPTION
 This is a 🙋 feature or enhancement.

## Summary

Rack 3 formalised bi-directional connections into the spec and implementations. This allows us to pass a proc instead of an array of strings in the Rack response.

Using this method, we can significantly simplify the code for live reloads. 

## Context

This was a result of my spontaneous deep dive into Ruby fibers, the Async gem, and by extension, Rack 3 and Falcon.

Background info:

https://youtu.be/yXyj9wlkJKM?si=prkP1nNCfA8WNBSU&t=1396

## Caveats

This will only work in Rack 3. I think we should set that as a minimum requirement for BT2.0 unless there's a good reason not to?

Fixes https://github.com/bridgetownrb/bridgetown/issues/861