### PR TITLE
esbuild: Add webp to the file endings loaded as files

### DIFF
--- a/bridgetown-website/config/esbuild.defaults.js
+++ b/bridgetown-website/config/esbuild.defaults.js
@@ -318,9 +318,13 @@ module.exports = async (esbuildOptions, ...args) => {
     bundle: true,
     loader: {
       ".jpg": "file",
+      ".jpeg": "file",
       ".png": "file",
       ".gif": "file",
       ".svg": "file",
+      ".avif": "file",
+      ".jxl": "file",
+      ".webp": "file",
       ".woff": "file",
       ".woff2": "file",
       ".ttf": "file",


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This PR adds a few file extensions as a file type to the list in `esbuild.defaults.js`:

* `.jpeg`
* `.avif`
* `.jxl`
* `.webp`

With this change, [WebP](https://en.wikipedia.org/wiki/WebP), [AVIF](https://en.wikipedia.org/wiki/AVIF) and [JPEG-XL](https://en.wikipedia.org/wiki/JPEG_XL) images are supported in the same way that PNG and JPEG are supported. It also adds `.jpeg` as the alternative file extension for JPEG files.

## Context

[This is from a discussion about me failing to fingerprint images](https://github.com/bridgetownrb/bridgetown/discussions/835)