### PR TITLE
Use Global Regex for Stimulus Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Use global regex for Stimulus Configuration
 
 ## [1.3.2] - 2024-01-01
 
@@ -705,7 +706,7 @@ Final release of 0.21.0! See below for full changelog.
 ## 0.11.1 - 2020-04-24
 
 * Add a git init step to `bridgetown new` command [#18](https://github.com/bridgetownrb/bridgetown/pull/18)
-* Update sass-loader webpack config to support .sass [#14](https://github.com/bridgetownrb/bridgetown/pull/14) ([jaredmoody](https://github.com/jaredmoody)) 
+* Update sass-loader webpack config to support .sass [#14](https://github.com/bridgetownrb/bridgetown/pull/14) ([jaredmoody](https://github.com/jaredmoody))
 * Add customizable permalinks to Prototype Pages (aka `/path/to/:term/and/beyond`). Use hooks and in-memory caching to speed up Pagination. _Inspired by [use cases like this](https://annualbeta.com/blog/dynamic-social-sharing-images-with-eleventy/)…_ [#12](https://github.com/bridgetownrb/bridgetown/pull/12)
 
 ## 0.11.0 - 2020-04-21

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Bridgetown is built by:
 |<a href="https://github.com/vvveebs">@vvveebs</a>|<a href="https://github.com/rickychilcott">@rickychilcott</a>|<a href="https://github.com/tommasongr">@tommasongr</a>|<a href="https://github.com/tombruijn">@tombruijn</a>|<a href="https://github.com/svoop">@svoop</a>|
 |London, UK|Ohio, US|Amsterdam, The Netherlands|Milan, IT|Europe|
 
-|<img src="https://avatars.githubusercontent.com/michaelherold?s=256" alt="michaelherold" width="128" />|<img src="https://avatars.githubusercontent.com/joemasilotti?s=256" alt="joemasilotti" width="128" />|<img src="https://avatars.githubusercontent.com/ikass?s=256" alt="ikass" width="128" />|<img src="https://avatars.githubusercontent.com/jw81?s=256" alt="jw81" width="128" />|
-|:---:|:---:|:---:|:---:|
-|<a href="https://github.com/michaelherold">@michaelherold</a>|<a href="https://github.com/joemasilotti">@joemasilotti</a>|<a href="https://github.com/Ikass">@ikass</a>|<a href="https://github.com/jw81">@jw81</a>|
-|Omaha, NE|Portland, OR|Latvia|Kansas City, MO|
+|<img src="https://avatars.githubusercontent.com/michaelherold?s=256" alt="michaelherold" width="128" />|<img src="https://avatars.githubusercontent.com/joemasilotti?s=256" alt="joemasilotti" width="128" />|<img src="https://avatars.githubusercontent.com/ikass?s=256" alt="ikass" width="128" />|<img src="https://avatars.githubusercontent.com/jw81?s=256" alt="jw81" width="128" />|<img src="https://avatars.githubusercontent.com/MSILycanthropy?s=256" alt="jw81" width="128" />
+|:---:|:---:|:---:|:---:|:---:|
+|<a href="https://github.com/michaelherold">@michaelherold</a>|<a href="https://github.com/joemasilotti">@joemasilotti</a>|<a href="https://github.com/Ikass">@ikass</a>|<a href="https://github.com/jw81">@jw81</a>|<a href="https://github.com/MSILycanthropy">@MSILycanthropy</a>|
+|Omaha, NE|Portland, OR|Latvia|Kansas City, MO|Kansas City, MO|
 
 |<img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&s=128&" alt="" width="128" />|
 |:---:|

--- a/bridgetown-core/lib/bridgetown-core/configurations/stimulus.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/stimulus.rb
@@ -38,7 +38,7 @@ append_to_file(File.join(javascript_dir, "index.js")) do
           const identifier = filename.replace("./controllers/", "")
             .replace(/[_-]controller\\..*$/, "")
             .replace(/_/g, "-")
-            .replace(/\//g, "--")
+            .replace(/\\//g, "--")
 
           Stimulus.register(identifier, controller.default)
         }

--- a/bridgetown-core/lib/bridgetown-core/configurations/stimulus.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/stimulus.rb
@@ -37,8 +37,8 @@ append_to_file(File.join(javascript_dir, "index.js")) do
         if (filename.includes("_controller.") || filename.includes("-controller.")) {
           const identifier = filename.replace("./controllers/", "")
             .replace(/[_-]controller\\..*$/, "")
-            .replace("_", "-")
-            .replace("/", "--")
+            .replace(/_/g, "-")
+            .replace(/\//g, "--")
 
           Stimulus.register(identifier, controller.default)
         }


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
When using the Stimulus Configuration, the generated code for loading Stimulus controllers makes a couple `replace` calls to translate a path to a Stimulus identifier. 

This means that if you have a controller whose filename is `do_a_thing_controller.js`, this gets translated into the Stimulus identifier `do-a_thing`, when one would expect it to have been `do-a-thing`. There case for controllers nested in directories is similar.

With the way Stimulus currently works, it's incredibly annoying to debug this, because there are no warnings. Your controller just seemingly _doesn't work_.

## Context
When building my personal site with Bridgetown and Hotwire, I added a controller that used multiple underscores, and then spent an embarrassing amount of time trying to figure out what I had done wrong. Was surprised to see that only one replacement had taken place.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
