### PR TITLE
Add image formats to esbuild.defaults.js.erb

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
+++ b/bridgetown-core/lib/bridgetown-core/commands/esbuild/esbuild.defaults.js.erb
@@ -323,9 +323,13 @@ module.exports = async (esbuildOptions, ...args) => {
     bundle: true,
     loader: {
       ".jpg": "file",
+      ".jpeg": "file",
       ".png": "file",
       ".gif": "file",
       ".svg": "file",
+      ".avif": "file",
+      ".jxl": "file",
+      ".webp": "file",
       ".woff": "file",
       ".woff2": "file",
       ".ttf": "file",


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Follow up to https://github.com/bridgetownrb/bridgetown/pull/863#issuecomment-2003220088
This adds support for additional image file extensions to the bridgetown esbuild configuration.

## Context

@matiaskorhonen pointed out that the previous change missed the change to the `esbuild.defaults.js.erb` file.