### PR TITLE
Simplify access to data syntax and Roda rendering

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -26,69 +26,70 @@ module Bridgetown
     # Strings rather than symbols are used for compatibility with YAML.
     DEFAULTS = {
       # Where things are
-      "root_dir"                   => Dir.pwd,
-      "plugins_dir"                => "plugins",
-      "source"                     => "src",
-      "destination"                => "output",
-      "collections_dir"            => "",
-      "cache_dir"                  => ".bridgetown-cache",
-      "layouts_dir"                => "_layouts",
-      "components_dir"             => "_components",
-      "islands_dir"                => "_islands",
-      "partials_dir"               => "_partials",
-      "collections"                => {},
-      "taxonomies"                 => {
+      "root_dir"                     => Dir.pwd,
+      "plugins_dir"                  => "plugins",
+      "source"                       => "src",
+      "destination"                  => "output",
+      "collections_dir"              => "",
+      "cache_dir"                    => ".bridgetown-cache",
+      "layouts_dir"                  => "_layouts",
+      "components_dir"               => "_components",
+      "islands_dir"                  => "_islands",
+      "partials_dir"                 => "_partials",
+      "collections"                  => {},
+      "taxonomies"                   => {
         category: { key: "categories", title: "Category" }, tag: { key: "tags", title: "Tag" },
       },
-      "autoload_paths"             => [],
-      "inflector"                  => nil,
-      "eager_load_paths"           => [],
-      "autoloader_collapsed_paths" => [],
-      "additional_watch_paths"     => [],
+      "autoload_paths"               => [],
+      "inflector"                    => nil,
+      "eager_load_paths"             => [],
+      "autoloader_collapsed_paths"   => [],
+      "additional_watch_paths"       => [],
 
       # Handling Reading
-      "include"                    => [".htaccess", "_redirects", ".well-known"],
-      "exclude"                    => [],
-      "keep_files"                 => [".git", ".svn", "_bridgetown"],
-      "encoding"                   => "utf-8",
-      "markdown_ext"               => "markdown,mkdown,mkdn,mkd,md",
-      "strict_front_matter"        => false,
-      "slugify_mode"               => "pretty",
+      "include"                      => [".htaccess", "_redirects", ".well-known"],
+      "exclude"                      => [],
+      "keep_files"                   => [".git", ".svn", "_bridgetown"],
+      "encoding"                     => "utf-8",
+      "markdown_ext"                 => "markdown,mkdown,mkdn,mkd,md",
+      "strict_front_matter"          => false,
+      "slugify_mode"                 => "pretty",
 
       # Filtering Content
-      "future"                     => false,
-      "unpublished"                => false,
-      "ruby_in_front_matter"       => true,
+      "future"                       => false,
+      "unpublished"                  => false,
+      "ruby_in_front_matter"         => true,
 
       # Conversion
-      "content_engine"             => "resource",
-      "markdown"                   => "kramdown",
-      "highlighter"                => "rouge",
+      "content_engine"               => "resource",
+      "markdown"                     => "kramdown",
+      "highlighter"                  => "rouge",
+      "support_data_as_view_methods" => true,
 
       # Serving
-      "port"                       => "4000",
-      "host"                       => "127.0.0.1",
-      "base_path"                  => "/",
-      "show_dir_listing"           => false,
+      "port"                         => "4000",
+      "host"                         => "127.0.0.1",
+      "base_path"                    => "/",
+      "show_dir_listing"             => false,
 
       # Output Configuration
-      "available_locales"          => [:en],
-      "default_locale"             => :en,
-      "prefix_default_locale"      => false,
-      "permalink"                  => nil, # default is set according to content engine
-      "timezone"                   => nil, # use the local timezone
+      "available_locales"            => [:en],
+      "default_locale"               => :en,
+      "prefix_default_locale"        => false,
+      "permalink"                    => nil, # default is set according to content engine
+      "timezone"                     => nil, # use the local timezone
 
-      "quiet"                      => false,
-      "verbose"                    => false,
-      "defaults"                   => [],
+      "quiet"                        => false,
+      "verbose"                      => false,
+      "defaults"                     => [],
 
-      "liquid"                     => {
+      "liquid"                       => {
         "error_mode"       => "warn",
         "strict_filters"   => false,
         "strict_variables" => false,
       },
 
-      "kramdown"                   => {
+      "kramdown"                     => {
         "auto_ids"                => true,
         "toc_levels"              => (1..6).to_a,
         "entity_output"           => "as_char",
@@ -102,7 +103,7 @@ module Bridgetown
         "mark_highlighting"       => true,
       },
 
-      "development"                => {
+      "development"                  => {
         "fast_refresh" => true,
       },
     }.each_with_object(Configuration.new) { |(k, v), hsh| hsh[k] = v.freeze }.freeze

--- a/bridgetown-core/lib/bridgetown-core/front_matter/loaders/ruby.rb
+++ b/bridgetown-core/lib/bridgetown-core/front_matter/loaders/ruby.rb
@@ -77,7 +77,7 @@ module Bridgetown
         def read(file_contents, file_path:)
           if (ruby_content = file_contents.match(BLOCK)) && should_execute_inline_ruby?
             Result.new(
-              content: ruby_content.post_match,
+              content: ruby_content.post_match.lstrip,
               front_matter: process_ruby_data(ruby_content[1], file_path, 2),
               line_count: ruby_content[1].lines.size - 1
             )

--- a/bridgetown-core/lib/bridgetown-core/front_matter/loaders/ruby.rb
+++ b/bridgetown-core/lib/bridgetown-core/front_matter/loaders/ruby.rb
@@ -62,8 +62,8 @@ module Bridgetown
       # %}~~~
       # ~~~~
       class Ruby < Base
-        HEADER = %r!\A[~`#-]{3,}(?:ruby|<%|{%)\s*\n!
-        BLOCK = %r!#{HEADER.source}(.*?\n?)^((?:%>|%})?[~`#-]{3,}\s*$\n?)!m
+        HEADER = %r!\A[~`#-]{3,}(?:ruby|<%|{%)[ \t]*\n!
+        BLOCK = %r!#{HEADER.source}(.*?\n?)^((?:%>|%})?[~`#-]{3,}[ \t]*$\n?)!m
 
         # Determines whether a given file has Ruby front matter
         #
@@ -79,7 +79,7 @@ module Bridgetown
             Result.new(
               content: ruby_content.post_match,
               front_matter: process_ruby_data(ruby_content[1], file_path, 2),
-              line_count: ruby_content[1].lines.size
+              line_count: ruby_content[1].lines.size - 1
             )
           elsif self.class.header?(file_path)
             Result.new(

--- a/bridgetown-core/lib/bridgetown-core/front_matter/loaders/yaml.rb
+++ b/bridgetown-core/lib/bridgetown-core/front_matter/loaders/yaml.rb
@@ -15,8 +15,8 @@ module Bridgetown
       # ---
       # ~~~
       class YAML < Base
-        HEADER = %r!\A---\s*\n!
-        BLOCK = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
+        HEADER = %r!\A---[ \t]*\n!
+        BLOCK = %r!#{HEADER.source}(.*?\n?)^((---|\.\.\.)[ \t]*$\n?)!m
 
         # Determines whether a given file has YAML front matter
         #

--- a/bridgetown-core/lib/bridgetown-core/front_matter/loaders/yaml.rb
+++ b/bridgetown-core/lib/bridgetown-core/front_matter/loaders/yaml.rb
@@ -31,7 +31,7 @@ module Bridgetown
           yaml_content = file_contents.match(BLOCK) or return
 
           Result.new(
-            content: yaml_content.post_match,
+            content: yaml_content.post_match.lstrip,
             front_matter: YAMLParser.load(yaml_content[1]),
             line_count: yaml_content[1].lines.size - 1
           )

--- a/bridgetown-core/lib/bridgetown-core/model/builder_origin.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/builder_origin.rb
@@ -34,13 +34,11 @@ module Bridgetown
         @data
       end
 
-      def front_matter_line_count
-        @data[:_front_matter_line_count_]
-      end
+      def front_matter_line_count = @data[:_front_matter_line_count_]
 
-      def exists?
-        false
-      end
+      def original_path = @data[:_original_path_] || relative_path
+
+      def exists? = false
 
       def read_data_from_builder
         builder = Kernel.const_get(url.host.gsub(".", "::"))

--- a/bridgetown-core/lib/bridgetown-core/model/builder_origin.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/builder_origin.rb
@@ -34,6 +34,10 @@ module Bridgetown
         @data
       end
 
+      def front_matter_line_count
+        @data[:_front_matter_line_count_]
+      end
+
       def exists?
         false
       end

--- a/bridgetown-core/test/resources/src/_layouts/default.erb
+++ b/bridgetown-core/test/resources/src/_layouts/default.erb
@@ -2,7 +2,9 @@
 ---
 <!doctype html>
 <html>
-<head></head>
+<head>
+  <title><%= title %></title>
+</head>
 <body>
 <%= yield %>
 </body>

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.en.md
@@ -1,5 +1,5 @@
 ~~~ruby
-{ title: "I'm a Second Level Page" }
+{ title: "I'm a Second Level Page", layout: :default }
 ~~~
 
 That's **nice**.

--- a/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
+++ b/bridgetown-core/test/resources/src/_pages/second-level-page.fr.md
@@ -1,5 +1,5 @@
 ~~~ruby
-{ title: "I'm a Second Level Page in French" }
+{ title: "I'm a Second Level Page in French", layout: :default }
 ~~~
 
 C'est **bien**.

--- a/bridgetown-core/test/test_locales.rb
+++ b/bridgetown-core/test/test_locales.rb
@@ -24,11 +24,13 @@ class TestLocales < BridgetownUnitTest
 
     should "have the correct permalink and locale in English" do
       assert_equal "/second-level-page/", @english_resource.relative_url
+      assert_includes @english_resource.output, "<title>I&#39;m a Second Level Page</title>"
       assert_includes @english_resource.output, "<p>Locale: en</p>"
     end
 
     should "have the correct permalink and locale in French" do
       assert_equal "/fr/second-level-page/", @french_resource.relative_url
+      assert_includes @french_resource.output, "<title>I&#39;m a Second Level Page in French</title>"
       assert_includes @french_resource.output, "<p>C’est <strong>bien</strong>.</p>\n\n<p>Locale: fr</p>"
 
       assert_includes @french_resource.output, <<-HTML

--- a/bridgetown-routes/.rubocop.yml
+++ b/bridgetown-routes/.rubocop.yml
@@ -4,4 +4,4 @@ inherit_from: ../.rubocop.yml
 AllCops:
   Exclude:
     - "*.gemspec"
-    - "test/ssr/src/_islands/**/*.rb"
+    - "test/ssr/src/**/*.rb"

--- a/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
@@ -37,7 +37,7 @@ module Bridgetown
           front_matter_line_count = nil
           if ruby_content
             code = ruby_content[1]
-            code_postmatch = ruby_content.post_match
+            code_postmatch = ruby_content.post_match.lstrip
             front_matter_line_count = code.lines.count - 1
             code.concat("\nrender_with {}") unless code.match?(%r!^\s*render_with\s|\(!)
           end

--- a/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
@@ -38,7 +38,7 @@ module Bridgetown
           if ruby_content
             code = ruby_content[1]
             code_postmatch = ruby_content.post_match
-            front_matter_line_count = code.lines.count
+            front_matter_line_count = code.lines.count - 1
             code.concat("\nrender_with {}") unless code.match?(%r!^\s*render_with\s|\(!)
           end
 

--- a/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
@@ -6,8 +6,11 @@ module Bridgetown
       class << self
         attr_accessor :blocks
 
-        def add_route(name, file_code = nil, &block)
+        def add_route(name, file_code = nil, front_matter_line_count = nil, &block)
           block.instance_variable_set(:@_route_file_code, file_code) if file_code
+          if front_matter_line_count
+            block.instance_variable_set(:@_front_matter_line_count, front_matter_line_count)
+          end
 
           @blocks ||= {}
           @blocks[name] = block
@@ -31,18 +34,20 @@ module Bridgetown
           code = File.read(file)
           code_postmatch = nil
           ruby_content = code.match(Bridgetown::FrontMatter::Loaders::Ruby::BLOCK)
+          front_matter_line_count = nil
           if ruby_content
             code = ruby_content[1]
             code_postmatch = ruby_content.post_match
+            front_matter_line_count = code.lines.count
             code.concat("\nrender_with {}") unless code.match?(%r!^\s*render_with\s|\(!)
           end
 
-          code = <<~RUBY
-            add_route(#{file_slug.inspect}, #{code_postmatch.inspect}) do |r|
-              #{code}
-            end
-          RUBY
-          instance_eval(code, file, ruby_content ? 1 : 0)
+          # rubocop:disable Style/DocumentDynamicEvalDefinition, Style/EvalWithLocation
+          code_proc = Kernel.eval(
+            "proc {|r| #{code} }", TOPLEVEL_BINDING, file, ruby_content ? 2 : 1
+          )
+          add_route(file_slug, code_postmatch, front_matter_line_count, &code_proc)
+          # rubocop:enable Style/DocumentDynamicEvalDefinition, Style/EvalWithLocation
         end
       end
     end

--- a/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
+++ b/bridgetown-routes/lib/bridgetown-routes/code_blocks.rb
@@ -34,6 +34,7 @@ module Bridgetown
           if ruby_content
             code = ruby_content[1]
             code_postmatch = ruby_content.post_match
+            code.concat("\nrender_with {}") unless code.match?(%r!^\s*render_with\s|\(!)
           end
 
           code = <<~RUBY

--- a/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
+++ b/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
@@ -65,12 +65,16 @@ class Roda
           response.instance_variable_set(
             :@_route_file_code, route_block.instance_variable_get(:@_route_file_code)
           ) # could be nil
+          response.instance_variable_set(
+            :@_front_matter_line_count,
+            route_block.instance_variable_get(:@_front_matter_line_count)
+          ) # could be nil
           instance_exec(request, &route_block)
         end
 
         def front_matter(&block)
           b = block.binding
-          denylisted = %i(r app code ruby_content code_postmatch)
+          denylisted = %i(r argv)
           data = b.local_variables.filter_map do |key|
             next if denylisted.any? key
 
@@ -100,6 +104,7 @@ class Roda
           ).read do
             data[:_collection_] = bridgetown_site.collections.pages
             data[:_relative_path_] = source_path
+            data[:_front_matter_line_count_] = response._front_matter_line_count
             data[:_content_] = code
             data
           end
@@ -149,9 +154,10 @@ class Roda
 
       module ResponseMethods
         # template string provided, if available, by the saved code block
-        def _route_file_code
-          @_route_file_code
-        end
+        def _route_file_code = @_route_file_code
+
+        # we need to know where the real template starts for good error reporting
+        def _front_matter_line_count = @_front_matter_line_count
 
         def _fake_resource_view(view_class:, roda_app:, bridgetown_site:)
           @_fake_resource_views ||= {}

--- a/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
+++ b/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
@@ -103,6 +103,7 @@ class Roda
             )
           ).read do
             data[:_collection_] = bridgetown_site.collections.pages
+            data[:_original_path_] = path
             data[:_relative_path_] = source_path
             data[:_front_matter_line_count_] = response._front_matter_line_count
             data[:_content_] = code

--- a/bridgetown-routes/test/ssr/src/_routes/bare_route.rb
+++ b/bridgetown-routes/test/ssr/src/_routes/bare_route.rb
@@ -1,0 +1,18 @@
+module DoubleNumbers
+  def double
+    self * 2
+  end
+end
+Numeric.include DoubleNumbers
+
+class DoublingArray < Array
+  def double_map
+    map(&:double)
+  end
+end
+
+r.get Integer do |num|
+  numbers = DoublingArray.new([1, 2, 3, num]).double_map
+
+  { numbers: }
+end

--- a/bridgetown-routes/test/ssr/src/_routes/howdy.erb
+++ b/bridgetown-routes/test/ssr/src/_routes/howdy.erb
@@ -1,7 +1,7 @@
 ---<%
-render_with data: {
+render_with(data: {
   title: "#{params[:yo]} #{@answer_to_life}"
-}
+})
 %>---
 
 <h1><%= resource.data.title %></h1>

--- a/bridgetown-routes/test/ssr/src/_routes/localized.erb
+++ b/bridgetown-routes/test/ssr/src/_routes/localized.erb
@@ -4,4 +4,4 @@ render_with do
 end
 %>---
 
-<h1><%= data.title %> for <%= r.params[:locale] %> - <%= I18n.locale %></h1>
+<h1><%= title %> for <%= r.params[:locale] %> - <%= I18n.locale %></h1>

--- a/bridgetown-routes/test/ssr/src/_routes/nested/[slug].erb
+++ b/bridgetown-routes/test/ssr/src/_routes/nested/[slug].erb
@@ -1,8 +1,6 @@
 ---<%
 slug_param = params[:slug]
 title = "Nested Page with Slug"
-
-render_with {}
 %>---
 
-<h1><%= data.title %>: <%= data.slug_param %></h1>
+<h1><%= title %>: <%= slug_param %></h1>

--- a/bridgetown-routes/test/test_routes.rb
+++ b/bridgetown-routes/test/test_routes.rb
@@ -66,6 +66,11 @@ class TestRoutes < BridgetownUnitTest
       assert_equal "<h1>Nested Page with Slug: 123-abc</h1>\n", last_response.body
     end
 
+    should "return JSON for a base route (no template)" do
+      get "/bare_route/4"
+      assert_equal({ numbers: [2, 4, 6, 8] }.to_json, last_response.body)
+    end
+
     should "return the proper route within an island" do
       get "/paradise" do
         assert_equal "Living in paradise =)", last_response.body

--- a/bridgetown-routes/test/test_routes.rb
+++ b/bridgetown-routes/test/test_routes.rb
@@ -26,7 +26,7 @@ class TestRoutes < BridgetownUnitTest
       FileUtils.cp(index_file, index_file.sub("test_index.erb", "index.erb"))
       get "/"
       assert last_response.ok?
-      assert_equal "<h1>Dynamic Index</h1>", last_response.body
+      assert_equal "\n<h1>Dynamic Index</h1>", last_response.body
       FileUtils.remove_file(index_file.sub("test_index.erb", "index.erb"))
     end
 
@@ -38,32 +38,32 @@ class TestRoutes < BridgetownUnitTest
 
     should "return HTML for the howdy route" do
       get "/howdy?yo=joe&happy=pleased"
-      assert_equal "<h1>joe 42</h1>\n\n<p>I am pleasedpleased.</p>\n", last_response.body
+      assert_equal "\n<h1>joe 42</h1>\n\n<p>I am pleasedpleased.</p>\n", last_response.body
     end
 
     should "return HTML for a route in an arbitrary folder" do
       get "/yello/my-friend"
-      assert_equal "<p>So arbitrary!</p>\n", last_response.body
+      assert_equal "\n<p>So arbitrary!</p>\n", last_response.body
     end
 
     should "return HTML for a route localized in english" do
       get "/localized"
-      assert_equal "<h1>Localized for en - en</h1>\n", last_response.body
+      assert_equal "\n<h1>Localized for en - en</h1>\n", last_response.body
     end
 
     should "return HTML for a route localized in italian" do
       get "/it/localized"
-      assert_equal "<h1>Localized for it - it</h1>\n", last_response.body
+      assert_equal "\n<h1>Localized for it - it</h1>\n", last_response.body
     end
 
     should "return HTML for nested index RESTful route" do
       get "/nested"
-      assert_equal "<h1>Nested Index</h1>\n", last_response.body
+      assert_equal "\n<h1>Nested Index</h1>\n", last_response.body
     end
 
     should "return HTML for nested item RESTful route" do
       get "/nested/123-abc"
-      assert_equal "<h1>Nested Page with Slug: 123-abc</h1>\n", last_response.body
+      assert_equal "\n<h1>Nested Page with Slug: 123-abc</h1>\n", last_response.body
     end
 
     should "return JSON for a base route (no template)" do

--- a/bridgetown-routes/test/test_routes.rb
+++ b/bridgetown-routes/test/test_routes.rb
@@ -26,7 +26,7 @@ class TestRoutes < BridgetownUnitTest
       FileUtils.cp(index_file, index_file.sub("test_index.erb", "index.erb"))
       get "/"
       assert last_response.ok?
-      assert_equal "\n<h1>Dynamic Index</h1>", last_response.body
+      assert_equal "<h1>Dynamic Index</h1>", last_response.body
       FileUtils.remove_file(index_file.sub("test_index.erb", "index.erb"))
     end
 
@@ -38,32 +38,32 @@ class TestRoutes < BridgetownUnitTest
 
     should "return HTML for the howdy route" do
       get "/howdy?yo=joe&happy=pleased"
-      assert_equal "\n<h1>joe 42</h1>\n\n<p>I am pleasedpleased.</p>\n", last_response.body
+      assert_equal "<h1>joe 42</h1>\n\n<p>I am pleasedpleased.</p>\n", last_response.body
     end
 
     should "return HTML for a route in an arbitrary folder" do
       get "/yello/my-friend"
-      assert_equal "\n<p>So arbitrary!</p>\n", last_response.body
+      assert_equal "<p>So arbitrary!</p>\n", last_response.body
     end
 
     should "return HTML for a route localized in english" do
       get "/localized"
-      assert_equal "\n<h1>Localized for en - en</h1>\n", last_response.body
+      assert_equal "<h1>Localized for en - en</h1>\n", last_response.body
     end
 
     should "return HTML for a route localized in italian" do
       get "/it/localized"
-      assert_equal "\n<h1>Localized for it - it</h1>\n", last_response.body
+      assert_equal "<h1>Localized for it - it</h1>\n", last_response.body
     end
 
     should "return HTML for nested index RESTful route" do
       get "/nested"
-      assert_equal "\n<h1>Nested Index</h1>\n", last_response.body
+      assert_equal "<h1>Nested Index</h1>\n", last_response.body
     end
 
     should "return HTML for nested item RESTful route" do
       get "/nested/123-abc"
-      assert_equal "\n<h1>Nested Page with Slug: 123-abc</h1>\n", last_response.body
+      assert_equal "<h1>Nested Page with Slug: 123-abc</h1>\n", last_response.body
     end
 
     should "return JSON for a base route (no template)" do


### PR DESCRIPTION
After writing `data.xyz` a zillion times, you start to wonder if you can just write `xyz`. 😂

And in the continuing saga of questioning boilerplate, I wondered if I could get rid of `render_with {}` (which works due to copying local block variables down to the template) while at it.

So this is now possible in a dynamic Roda route:

```erb
---<%
name = "World"
%>---

Hello <%= name %>
```

Nice! 😌

Of course this will still work equally well:

```erb
---<%
render_with do
  name "World"
end
%>---

Hello <%= name %>
```

And regular front matter in static resources:

```md
---
title: My Page
---

# <%= title %>
```

For folks who for whatever reason don't like this simplified syntax, the `support_data_as_view_methods` option can be set to `false` in the Bridgetown config, and then `data.foo` syntax is still mandatory.

----

For the Ruby nerds out there, the previous `instance_eval` code I'd written turned out to have a very strange side effect: even though the procs are eventually executed in the context of a Roda app instance, any modules/classes defined would actually be attached to the _singleton class_ of `Bridgetown::Routes::CodeBlocks`. Weird, right? The likelihood of a file-based route needing to define a standalone module/class is low, but if it's supported it might as well work like any standard Ruby file being `require`d at runtime. So I switched it up to use `Kernel.eval` and `TOPLEVEL_BINDING` instead of `Bridgetown::Routes::CodeBlocks.instance_eval`. Works! 😅

Also I _finally_ got proper line number error reporting working as expected. This has been an ongoing frustration…turns out part of the reason why this has been inconsistent is our front matter regexps were swallowing a variable amount of newlines as whitespace around the template boundaries via `\s`. Changing that to `[ \t]` resolves the issue, and then calling `lstrip` restores the previous whitespace behavior after regexp parsing.