### PR TITLE
Make it easy for Roda routes to render "callable" objects

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -380,9 +380,7 @@ module Bridgetown
       )
     end
   end
-end
 
-module Bridgetown
   module CoreExt; end
   module Model; end
 
@@ -394,6 +392,13 @@ module Bridgetown
       if mod.const_defined?(:RubyResource) # rubocop:disable Style/GuardClause
         Bridgetown::Resource::Base.include mod.const_get(:RubyResource)
       end
+    end
+  end
+
+  # mixin for identity so Roda knows to call renderable objects
+  module RodaCallable
+    def self.===(other)
+      other.class < self
     end
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/component.rb
+++ b/bridgetown-core/lib/bridgetown-core/component.rb
@@ -201,7 +201,7 @@ module Bridgetown
     # Subclasses can override this method to return a string from their own
     # template handling.
     def template
-      call || _renderer.render(self)
+      (method(:call).arity.zero? ? call : nil) || _renderer.render(self)
     end
 
     # Typically not used but here as a compatibility nod toward ViewComponent.

--- a/bridgetown-core/lib/bridgetown-core/model/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/base.rb
@@ -5,6 +5,7 @@ require "active_model"
 module Bridgetown
   module Model
     class Base
+      include Bridgetown::RodaCallable
       include ActiveModel::Model
       extend ActiveModel::Callbacks
       define_model_callbacks :load, :save, :destroy
@@ -101,6 +102,11 @@ module Bridgetown
       def render_as_resource
         to_resource.read!.transform!
       end
+
+      # Converts this model to a resource and returns the full output
+      #
+      # @return [String]
+      def call(*) = render_as_resource.output
 
       # override if need be
       # @return [Bridgetown::Site]

--- a/bridgetown-core/lib/bridgetown-core/resource/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/base.rb
@@ -4,6 +4,7 @@ module Bridgetown
   module Resource
     class Base # rubocop:todo Metrics/ClassLength
       include Comparable
+      include Bridgetown::RodaCallable
       include Bridgetown::Publishable
       include Bridgetown::LayoutPlaceable
       include Bridgetown::LiquidRenderable
@@ -170,6 +171,11 @@ module Bridgetown
 
         self
       end
+
+      # Transforms the resource and returns the full output
+      #
+      # @return [String]
+      def call(*) = transform!.output
 
       def trigger_hooks(hook_name, *args)
         Bridgetown::Hooks.trigger collection.label.to_sym, hook_name, self, *args if collection

--- a/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
@@ -41,17 +41,6 @@ class Roda
           "500 Internal Server Error"
         end
 
-        # This lets us return models or resources directly in Roda response blocks
-        app.plugin :custom_block_results
-
-        app.handle_block_result Bridgetown::Model::Base do |result|
-          result.render_as_resource.output
-        end
-
-        app.handle_block_result Bridgetown::Resource::Base do |result|
-          result.transform!.output
-        end
-
         # TODO: there may be a better way to do this, see `exception_page_css` instance method
         ExceptionPage.class_eval do # rubocop:disable Metrics/BlockLength
           def self.css

--- a/bridgetown-core/lib/roda/plugins/bridgetown_ssr.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_ssr.rb
@@ -9,6 +9,17 @@ class Roda
         def bridgetown_site
           self.class.opts[:bridgetown_site]
         end
+
+        alias_method :site, :bridgetown_site
+      end
+
+      def self.load_dependencies(app)
+        app.plugin :custom_block_results
+
+        # This lets us return callable objects directly in Roda response blocks
+        app.handle_block_result(Bridgetown::RodaCallable) do |callable|
+          callable.(self)
+        end
       end
 
       def self.configure(app, _opts = {}, &)

--- a/bridgetown-core/test/ssr/config.ru
+++ b/bridgetown-core/test/ssr/config.ru
@@ -10,4 +10,6 @@ require "bridgetown-core/rack/boot"
 
 Bridgetown::Rack.boot
 
+require_relative "src/_components/UseRoda" # normally Zeitwerk would take care of this for us
+
 run RodaApp.freeze.app # see server/roda_app.rb

--- a/bridgetown-core/test/ssr/server/routes/hello.rb
+++ b/bridgetown-core/test/ssr/server/routes/hello.rb
@@ -4,7 +4,7 @@ class Routes::Hello < Bridgetown::Rack::Routes
   priority :lowest
 
   route do |r|
-    saved_value = bridgetown_site.data.save_value
+    saved_value = site.data.save_value
 
     # route: GET /hello/:name
     r.get "hello", String do |name|

--- a/bridgetown-core/test/ssr/server/routes/render_resource.rb
+++ b/bridgetown-core/test/ssr/server/routes/render_resource.rb
@@ -5,7 +5,7 @@ class Routes::RenderResource < Bridgetown::Rack::Routes
     # route: GET /render_resource
     r.get "render_resource" do
       # Roda should know how to autorender the resource
-      bridgetown_site.collections.pages.resources.find { _1.id == "repo://pages.collection/index.md" }
+      site.collections.pages.find { _1.id == "repo://pages.collection/index.md" }
     end
 
     r.get "render_model" do

--- a/bridgetown-core/test/ssr/server/routes/render_resource.rb
+++ b/bridgetown-core/test/ssr/server/routes/render_resource.rb
@@ -12,5 +12,9 @@ class Routes::RenderResource < Bridgetown::Rack::Routes
       # Roda should know how to autorender the model as a resource
       Bridgetown::Model::Base.find("repo://pages.collection/test_doc.md")
     end
+
+    r.get "render_component", String do |title|
+      UseRoda.new(title:)
+    end
   end
 end

--- a/bridgetown-core/test/ssr/src/_components/UseRoda.rb
+++ b/bridgetown-core/test/ssr/src/_components/UseRoda.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class UseRoda < Bridgetown::Component
+  include Bridgetown::RodaCallable
+
+  def initialize(title:) # rubocop:disable Lint/MissingSuper
+    @title = title.upcase
+  end
+
+  def template
+    "<rss>#{@title} #{@testing}</rss>" # not real RSS =)
+  end
+
+  def call(app)
+    app.request => r
+    @testing = r.env["rack.test"]
+
+    app.response["Content-Type"] = "application/rss+xml"
+
+    render_in(app)
+  end
+end

--- a/bridgetown-core/test/test_ssr.rb
+++ b/bridgetown-core/test/test_ssr.rb
@@ -85,5 +85,13 @@ class TestSSR < BridgetownUnitTest
       assert last_response.ok?
       assert_includes last_response.body, "<p class=\"test\">THIS IS A <em>TEST</em>.</p>"
     end
+
+    should "return rendered component" do
+      get "/render_component/wow"
+
+      assert last_response.ok?
+      assert_equal "application/rss+xml", last_response["Content-Type"]
+      assert_equal "<rss>WOW true</rss>", last_response.body
+    end
   end
 end


### PR DESCRIPTION
Some cleanup and enhancements made possible by utilizing Roda's custom_block_results plugin more effectively…including even letting you return components as route results. There's some more cleanup I want to do that will enable #561 as well. This is also the start of a new evaluation of places in the framework where we can leverage the "callable" object pattern.

Oh yeah, also added in a `site` alias so no more having to remember `bridgetown_site` in Roda routes. Hurray!