### PR TITLE
Updated community.md - replaced non-working old website with new one

### DIFF
--- a/bridgetown-website/src/_pages/community.md
+++ b/bridgetown-website/src/_pages/community.md
@@ -68,9 +68,10 @@ There's also a growing number of companies which provide commercial support for 
 * [Fullstack Ruby](https://www.fullstackruby.dev){:target="_blank"}
 * [fslash42](https://fslash42.com){:target="_blank"}
 * [Helena's Nursery](https://helenas-nursery.com){:target="_blank"}
-* [Open Source KnowledgeBase](https://knowledgebase.redwebtigers.com){:target="_blank"}
+* [Best Financial Planners in India](https://bestfinancialplanners.in){:target="_blank"}
 * [APAC Agencies](https://www.apacagencies.com){:target="_blank"}
 * [Emailable](https://emailable.com){:target="_blank"}
+* [Best Financial Planners in Canada](https://bestfinancialplannerscanada.com){:target="_blank"}
 
 In addition, members of the Bridgetown Core Team have appeared in podcasts and presentations across the web promoting Bridgetown! Check it out:
 


### PR DESCRIPTION
I have updated the non-working website of mine to the working ones.

This is a 🔦 documentation change.

Summary
I had added the website of my now defunct business which has been now replaced and updated with new website(s). I have been using Bridgetown since 2021 and it currently powers 4 websites (2 in the pipeline).

Thanks and regards.

Context
