### PR TITLE
Add additional possible error for roda server

### DIFF
--- a/bridgetown-website/src/_docs/installation/upgrade.md
+++ b/bridgetown-website/src/_docs/installation/upgrade.md
@@ -41,9 +41,7 @@ You will need to do a search & replace for all uses of `webpack_path` and change
 
 ### Crashing Related to Roda 💥
 
-If you encounter a weird crash which contains `uninitialized constant Bridgetown::Rack::Roda` in the error log, you will need to update the syntax of your `server/roda_app.rb` file so that it's a direct subclass of `Roda` and configures the `bridgetown_server` plugin. 
-
-Here's a basic version of that file:
+If you encounter a weird crash which contains `uninitialized constant Bridgetown::Rack::Roda` in the error log, you will need to update the syntax of your `server/roda_app.rb` file so that it's a direct subclass of `Roda` and configures the `bridgetown_server` plugin. Here's a basic version of that file:
 
 ```rb
 class RodaApp < Roda

--- a/bridgetown-website/src/_docs/installation/upgrade.md
+++ b/bridgetown-website/src/_docs/installation/upgrade.md
@@ -57,29 +57,11 @@ class RodaApp < Roda
 end
 ```
 
-Additionally, you may hit this issue with the server and the error will look something like this:
+Additionally, you may also hit the following error:
 
 ```
-➜  docs git:(konnorrogers/major-overhaul) ✗ bin/bridgetown start
-[Bridgetown]           Starting: Bridgetown v2.0.0.beta2 (codename "(TBD!)")
-[Bridgetown]
-[Bridgetown]    Booting Puma at: http://0.0.0.0:4000
-[Bridgetown]
-/Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `set_encoding': Interrupt
-        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
-        [...]
-        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/bin/bridgetown:30:in `<top (required)>'
-        from bin/bridgetown:27:in `load'
-        from bin/bridgetown:27:in `<main>'
-[Bridgetown] Stopping auxiliary processes...
-[Bridgetown]   Exception raised: Errno::ENOENT
-[Bridgetown] No such file or directory @ rb_sysopen - /Users/konnor/projects/oss/doxxing-time-layouts/rhino-editor/docs/tmp/pids/aux.pid
-[Bridgetown]                  1: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `readlines'
-[Bridgetown]                  2: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `read_pidfile'
-[Bridgetown]                  3: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/utils/aux.rb:51:in `kill_processes'
-[Bridgetown]                  4: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:104:in `block (2 levels) in start'
-[Bridgetown]                  5: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:11:in `ensure in start'
-[Bridgetown]          Backtrace: Use the --trace option for complete information.
+Exception raised: Errno::ENOENT
+No such file or directory @ rb_sysopen - /tmp/pids/aux.pid
 ```
 
 In which case, refer to the above fix for configuring your Roda server.

--- a/bridgetown-website/src/_docs/installation/upgrade.md
+++ b/bridgetown-website/src/_docs/installation/upgrade.md
@@ -41,7 +41,9 @@ You will need to do a search & replace for all uses of `webpack_path` and change
 
 ### Crashing Related to Roda 💥
 
-If you encounter a weird crash which contains `uninitialized constant Bridgetown::Rack::Roda` in the error log, you will need to update the syntax of your `server/roda_app.rb` file so that it's a direct subclass of `Roda` and configures the `bridgetown_server` plugin. Here's a basic version of that file:
+If you encounter a weird crash which contains `uninitialized constant Bridgetown::Rack::Roda` in the error log, you will need to update the syntax of your `server/roda_app.rb` file so that it's a direct subclass of `Roda` and configures the `bridgetown_server` plugin. 
+
+Here's a basic version of that file:
 
 ```rb
 class RodaApp < Roda
@@ -56,6 +58,34 @@ class RodaApp < Roda
   end
 end
 ```
+
+Additionally, you may hit this issue with the server and the error will look something like this:
+
+```
+➜  docs git:(konnorrogers/major-overhaul) ✗ bin/bridgetown start
+[Bridgetown]           Starting: Bridgetown v2.0.0.beta2 (codename "(TBD!)")
+[Bridgetown]
+[Bridgetown]    Booting Puma at: http://0.0.0.0:4000
+[Bridgetown]
+/Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `set_encoding': Interrupt
+        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
+        [...]
+        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/bin/bridgetown:30:in `<top (required)>'
+        from bin/bridgetown:27:in `load'
+        from bin/bridgetown:27:in `<main>'
+[Bridgetown] Stopping auxiliary processes...
+[Bridgetown]   Exception raised: Errno::ENOENT
+[Bridgetown] No such file or directory @ rb_sysopen - /Users/konnor/projects/oss/doxxing-time-layouts/rhino-editor/docs/tmp/pids/aux.pid
+[Bridgetown]                  1: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `readlines'
+[Bridgetown]                  2: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `read_pidfile'
+[Bridgetown]                  3: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/utils/aux.rb:51:in `kill_processes'
+[Bridgetown]                  4: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:104:in `block (2 levels) in start'
+[Bridgetown]                  5: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:11:in `ensure in start'
+[Bridgetown]          Backtrace: Use the --trace option for complete information.
+```
+
+In which case, refer to the above fix for configuring your Roda server.
+
 
 ### Supporting Active Support Support 😏
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I had an error that didn't quite match the upgrade guide and didn't quite give enough info what was happening.


## Context

Full error (for anyone searching)

```

➜  docs git:(konnorrogers/major-overhaul) ✗ bin/bridgetown start
[Bridgetown]           Starting: Bridgetown v2.0.0.beta2 (codename "(TBD!)")
[Bridgetown]
[Bridgetown]    Booting Puma at: http://0.0.0.0:4000
[Bridgetown]
Progress: resolved 1, reused 0, downloaded 0, added 0
 WARN  deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
 WARN  deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
 WARN  2 deprecated subdependencies found: @material/mwc-icon@0.25.3, inflight@1.0.6
Packages: +1 -3
+---
 WARN  2 deprecated subdependencies found: @material/mwc-icon@0.25.3, inflight@1.0.6
Packages: +1 -3
+---
Progress: resolved 227, reused 205, downloaded 0, added 0, done

dependencies:
- bridgetown-quick-search 2.0.0
+ bridgetown-quick-search 3.0.3

Done in 2.1s
Done in 2.2s
Stopping Bridgetown server...
/Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `set_encoding': Interrupt
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/kernel.rb:34:in `require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake.rb:49:in `<top (required)>'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/kernel.rb:34:in `require'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/build.rb:53:in `build'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `block in invoke_all'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `each'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `map'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `invoke_all'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/group.rb:232:in `dispatch'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:93:in `block (2 levels) in start'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:93:in `fork'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:93:in `block in start'
        from <internal:kernel>:90:in `tap'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:86:in `start'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `block in invoke_all'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `each'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `map'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:134:in `invoke_all'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/group.rb:232:in `dispatch'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:116:in `invoke'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor.rb:40:in `block in register'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
        from /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/bin/bridgetown:30:in `<top (required)>'
        from bin/bridgetown:27:in `load'
        from bin/bridgetown:27:in `<main>'
[Bridgetown] Stopping auxiliary processes...
[Bridgetown]   Exception raised: Errno::ENOENT
[Bridgetown] No such file or directory @ rb_sysopen - /Users/konnor/projects/oss/doxxing-time-layouts/rhino-editor/docs/tmp/pids/aux.pid
[Bridgetown]                  1: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `readlines'
[Bridgetown]                  2: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-foundation-2.0.0.beta2/lib/bridgetown/foundation/packages/pid_tracker.rb:15:in `read_pidfile'
[Bridgetown]                  3: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/utils/aux.rb:51:in `kill_processes'
[Bridgetown]                  4: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:104:in `block (2 levels) in start'
[Bridgetown]                  5: /Users/konnor/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bridgetown-core-2.0.0.beta2/lib/bridgetown-core/commands/start.rb:11:in `ensure in start'
[Bridgetown]          Backtrace: Use the --trace option for complete information.


```
