### PR TITLE
Support i18n with fast refresh (rerender multiple locales)

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/site/fast_refreshable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/fast_refreshable.rb
@@ -10,15 +10,16 @@ class Bridgetown::Site
       @fast_refresh_ordering = 0
       full_abort = false
       found_gen_pages = false
-      paths.each do |path|
-        res = resources.find do |resource|
+      paths.each do |path| # rubocop:todo Metrics
+        found_res = resources.select do |resource|
           resource.id.start_with?("repo://") && in_source_dir(resource.relative_path) == path
         end
 
         layouts_to_reload = Set.new
-        locate_resource_layouts_and_partials_for_fash_refresh(path, layouts_to_reload) unless res
+        locate_resource_layouts_and_partials_for_fash_refresh(path, layouts_to_reload) unless
+          found_res.any?
 
-        locate_components_for_fast_refresh(path) unless res
+        locate_components_for_fast_refresh(path) unless found_res.any?
 
         pages = locate_layouts_and_pages_for_fast_refresh(path, layouts_to_reload)
 
@@ -27,20 +28,22 @@ class Bridgetown::Site
             self, layout.instance_variable_get(:@base), layout.name
           )
         end
-        next unless res || !pages.empty?
+        next unless found_res.any? || pages.any?
 
-        unless pages.empty?
+        if pages.any?
           found_gen_pages = true
           mark_original_page_resources_for_fast_refresh(pages)
           next
         end
 
-        res.prepare_for_fast_refresh!.tap { full_abort = true unless _1 }
-        next unless res.collection.data?
+        found_res.each do |res|
+          res.prepare_for_fast_refresh!.tap { full_abort = true unless _1 }
+          next unless res.collection.data?
 
-        res.collection.merge_data_resources.each do |k, v|
-          data[k] = v
-          signals[k] = v
+          res.collection.merge_data_resources.each do |k, v|
+            data[k] = v
+            signals[k] = v
+          end
         end
       end
 
@@ -134,7 +137,11 @@ class Bridgetown::Site
     end
 
     def transform_resources_for_fast_refresh(marked_resources, found_gen_pages)
-      marked_resources.each { _1.transform!.write }
+      marked_resources.each do |res|
+        render_with_locale(res) do
+          res.transform!.write
+        end
+      end
       number_of_resources = marked_resources.length
       number_of_resources += 1 if found_gen_pages
       Bridgetown.logger.info(

--- a/bridgetown-core/lib/bridgetown-core/resource/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/base.rb
@@ -361,7 +361,10 @@ module Bridgetown
         past_values = @data.peek.select do |key|
           key == "categories" || key == "tags" || site.taxonomy_types.keys.any?(key)
         end
-        model.attributes = model.origin.read
+        origin_data = model.origin.read
+        correct_locale = origin_data["locale"] || origin_data[:locale] || data.locale
+        model.attributes = origin_data
+        model.attributes.locale = correct_locale
         @relative_url = @absolute_url = nil # wipe memoizations
         read!
         tax_diff = past_values.any? { |k, v| @data.peek[k] != v }


### PR DESCRIPTION
As it says on the tin. Individual resources with locales set as well as multi resources are now supported.

**Note:** there _may_ be remaining edge cases where generated pages are concerned, but if so I would consider those in the realm of a 2.x patch and not to hold up the initial 2.0 release.