### PR TITLE
Avoid duplication in r.bridgetown implementation

### DIFF
--- a/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
@@ -158,20 +158,11 @@ class Roda
           scope.initialize_bridgetown_context
           scope.initialize_bridgetown_root
 
-          # There are two different code paths depending on if there's a site `base_path` configured
-          if Bridgetown::Current.preloaded_configuration.base_path == "/"
-            ssg # static file server
-            Bridgetown::Rack::Routes.load_all scope
-            return
-          end
-
-          # Support custom base_path configurations
-          on(Bridgetown::Current.preloaded_configuration.base_path.delete_prefix("/")) do
+          base_path = Bridgetown::Current.preloaded_configuration.base_path.delete_prefix("/")
+          on(base_path.empty? ? true : base_path) do
             ssg # static file server
             Bridgetown::Rack::Routes.load_all scope
           end
-
-          nil
         end
       end
     end


### PR DESCRIPTION
I apologize that I have not read the project goals, future roadmap, or code of conduct.  If for any reason I'm violating something, please feel free to close.

This is a 🙋 feature or enhancement. It's actually a refactoring, but I think of removing duplication as an enhancement.

- I've **not** added tests (if it's a bug, feature or enhancement).  This is a refactoring and should not affect behavior.
- I've **not** adjusted the documentation (if it's a feature or enhancement). This is a refactoring and should not affect behavior.
- I've **not** run the test suite locally (I've forked the repo, but not even cloned it locally). However, I enabled GitHub Actions in my fork, and CI passed on my fork.

## Summary

By choosing an appropriate argument to `on`, based on the base path, we don't need a separate if statement block and manual return.

Additionally, the nil at the end is not needed, as `on` will either throw if it handles the request, or return nil if it does not.

## Context

I was reviewing the code as I'll be discussing it in an upcoming presentation, and came across this method, and saw an easy way to improve it.