### PR TITLE
Preserve the `_bridgetown` default value in `keep_files` config

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -122,7 +122,7 @@ module Bridgetown
           .setup_load_paths!
           .setup_locales
           .add_default_collections
-          .add_default_excludes
+          .add_destination_paths
           .check_include_exclude
       end
     end
@@ -148,9 +148,13 @@ module Bridgetown
       dsl._run_builtins!
       self.url = cached_url if cached_url # restore local development URL if need be
 
-      setup_load_paths! appending: true
+      setup_post_init!
 
       self
+    end
+
+    def setup_post_init!
+      add_destination_paths.setup_load_paths! appending: true
     end
 
     # @return [Set<SourceManifest>]
@@ -357,12 +361,17 @@ module Bridgetown
       vendor/bundle/ vendor/cache/ vendor/gems/ vendor/ruby/
     ).freeze
 
-    def add_default_excludes
+    def add_destination_paths
+      self["keep_files"] << "_bridgetown" unless
+        self["keep_files"].nil?.! && self["keep_files"].include?("_bridgetown")
+
       return self if self["exclude"].nil?
 
       self["exclude"].concat(DEFAULT_EXCLUDES).uniq!
       self
     end
+
+    alias_method :add_default_excludes, :add_destination_paths
 
     def should_execute_inline_ruby?
       ENV["BRIDGETOWN_RUBY_IN_FRONT_MATTER"] != "false" &&

--- a/bridgetown-core/test/test_site.rb
+++ b/bridgetown-core/test/test_site.rb
@@ -267,6 +267,8 @@ class TestSite < BridgetownUnitTest
         FileUtils.touch(dest_dir(".git/HEAD"))
         FileUtils.touch(dest_dir(".svn/HEAD"))
         FileUtils.touch(dest_dir(".hg/HEAD"))
+        FileUtils.mkdir(dest_dir("_bridgetown"))
+        FileUtils.touch(dest_dir("_bridgetown/static"))
       end
 
       teardown do
@@ -276,6 +278,7 @@ class TestSite < BridgetownUnitTest
         FileUtils.rm_rf(dest_dir(".git"))
         FileUtils.rm_rf(dest_dir(".svn"))
         FileUtils.rm_rf(dest_dir(".hg"))
+        FileUtils.rm_rf(dest_dir("_bridgetown"))
       end
 
       should "remove orphaned files in destination" do
@@ -285,6 +288,7 @@ class TestSite < BridgetownUnitTest
         refute_exist dest_dir("quux")
         assert_exist dest_dir(".git")
         assert_exist dest_dir(".git", "HEAD")
+        assert_exist dest_dir("_bridgetown", "static")
       end
 
       should "remove orphaned files in destination - keep_files .svn" do
@@ -299,6 +303,7 @@ class TestSite < BridgetownUnitTest
         refute_exist dest_dir(".git", "HEAD")
         assert_exist dest_dir(".svn")
         assert_exist dest_dir(".svn", "HEAD")
+        assert_exist dest_dir("_bridgetown", "static")
       end
     end
 


### PR DESCRIPTION
Fixes #624 

Also ensures when setting `exclude` via initializer config, we'll preserve our default excludes as well.