### PR TITLE
Remove explicit require of `puma` in the console command

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/console.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/console.rb
@@ -80,7 +80,6 @@ module Bridgetown
 
         config_options = configuration_with_overrides(options)
         if options[:"server-config"]
-          require "puma"
           require "bridgetown-core/rack/boot"
           Bridgetown::Rack.boot
         else


### PR DESCRIPTION
Not sure why we need to `require "puma` in the console, even when starting it in the server context. Nothing blows up after removing it. The server classes are still all available.

Part of https://github.com/bridgetownrb/bridgetown/issues/946.