### PR TITLE
Require bridgetown when booting from Rack

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -133,10 +133,16 @@ module Bridgetown
 
     # Set up the Bridgetown execution environment before attempting to load any
     # plugins or gems prior to a site build
-    def begin!
+    def begin!(with_config: :preflight)
       ENV["RACK_ENV"] ||= environment
 
-      Bridgetown::Current.preloaded_configuration = Bridgetown::Configuration::Preflight.new
+      if with_config == :preflight
+        Bridgetown::Current.preloaded_configuration ||= Bridgetown::Configuration::Preflight.new
+      elsif with_config == :initializers &&
+          !Bridgetown::Current.preloaded_configuration.is_a?(Bridgetown::Configuration)
+        Bridgetown::Current.preloaded_configuration = Bridgetown.configuration
+      end
+
       Bridgetown::PluginManager.setup_bundler
     end
 

--- a/bridgetown-core/lib/bridgetown-core/rack/boot.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/boot.rb
@@ -3,8 +3,7 @@
 require "zeitwerk"
 require "roda"
 require "json"
-
-Bridgetown::Current.preloaded_configuration ||= Bridgetown.configuration
+require "bridgetown"
 
 require_relative "loader_hooks"
 require_relative "logger"
@@ -12,6 +11,8 @@ require_relative "routes"
 
 module Bridgetown
   module Rack
+    Bridgetown.begin!(with_config: :initializers)
+
     class << self
       # @return [Bridgetown::Utils::LoadersManager]
       attr_accessor :loaders_manager


### PR DESCRIPTION
In order to start Bridgetown by running the web server directly (`bundle exec puma`), we need to `require "bridgetown"` in the boot file.

Without it, we get all sorts of uninitialized constant errors.  

This is one of those fixes where I'm not sure what I'm doing, and whether it'll have any bad consequences. I just hammered it until it worked and seems to be working fine in my tests. 

@jaredcwhite is this a valid fix? Please don't merge it until we know for sure it's not gonna make things catch fire haha.

Part of https://github.com/bridgetownrb/bridgetown/issues/946