### PR TITLE
Switch to `.bridgetown-cache/live_reload.txt` for live reload

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -365,11 +365,18 @@ module Bridgetown
     #
     # @return [String] the path to the cached errors file
     def build_errors_path
-      File.join(
-        (Bridgetown::Current.site&.config || Bridgetown::Current.preloaded_configuration).root_dir,
-        ".bridgetown-cache",
-        "build_errors.txt"
-      )
+      site_config = Bridgetown::Current.site&.config || Bridgetown::Current.preloaded_configuration
+      File.join(site_config.root_dir, site_config.cache_dir, "build_errors.txt")
+    end
+
+    # This file gets touched each time there's a new build, which then triggers live reload
+    # in the browser.
+    #
+    # @see Bridgetown::Rack::Routes.setup_live_reload
+    # @return [String] the path to the empty file being watched
+    def live_reload_path
+      site_config = Bridgetown::Current.site&.config || Bridgetown::Current.preloaded_configuration
+      File.join(site_config.root_dir, site_config.cache_dir, "live_reload.txt")
     end
   end
 

--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -378,6 +378,11 @@ module Bridgetown
       site_config = Bridgetown::Current.site&.config || Bridgetown::Current.preloaded_configuration
       File.join(site_config.root_dir, site_config.cache_dir, "live_reload.txt")
     end
+
+    def touch_live_reload_file(path = live_reload_path)
+      FileUtils.mkdir_p File.dirname(path)
+      FileUtils.touch path
+    end
   end
 
   module Model; end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/fast_refreshable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/fast_refreshable.rb
@@ -76,7 +76,7 @@ class Bridgetown::Site
       end
 
       Bridgetown::Hooks.trigger :site, :post_write, self
-      touch_live_reload_file
+      Bridgetown.touch_live_reload_file
     end
 
     private

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
@@ -70,6 +70,4 @@ class Bridgetown::Site
       File.write(in_dest_dir("index.html"), index_html, mode: "wb")
     end
   end
-
-
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
@@ -17,7 +17,7 @@ class Bridgetown::Site
       write_redirecting_index if config.prefix_default_locale
 
       Bridgetown::Hooks.trigger :site, :post_write, self
-      touch_live_reload_file unless config.disable_disk_cache
+      Bridgetown.touch_live_reload_file unless config.disable_disk_cache
     end
 
     # Yields all content objects while looping through {#generated_pages},
@@ -71,8 +71,5 @@ class Bridgetown::Site
     end
   end
 
-  def touch_live_reload_file
-    FileUtils.mkdir_p File.dirname(Bridgetown.live_reload_path)
-    FileUtils.touch Bridgetown.live_reload_path
-  end
+
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
@@ -17,6 +17,7 @@ class Bridgetown::Site
       write_redirecting_index if config.prefix_default_locale
 
       Bridgetown::Hooks.trigger :site, :post_write, self
+      touch_live_reload_file
     end
 
     # Yields all content objects while looping through {#generated_pages},
@@ -68,5 +69,10 @@ class Bridgetown::Site
 
       File.write(in_dest_dir("index.html"), index_html, mode: "wb")
     end
+  end
+
+  def touch_live_reload_file
+    FileUtils.mkdir_p File.dirname(Bridgetown.live_reload_path)
+    FileUtils.touch Bridgetown.live_reload_path
   end
 end

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/writable.rb
@@ -17,7 +17,7 @@ class Bridgetown::Site
       write_redirecting_index if config.prefix_default_locale
 
       Bridgetown::Hooks.trigger :site, :post_write, self
-      touch_live_reload_file
+      touch_live_reload_file unless config.disable_disk_cache
     end
 
     # Yields all content objects while looping through {#generated_pages},

--- a/bridgetown-core/lib/bridgetown-core/rack/boot.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/boot.rb
@@ -39,6 +39,7 @@ module Bridgetown
       root: Bridgetown::Current.preloaded_configuration.root_dir
     )
       server_folder = File.join(root, "server")
+      cached_reload_file = Bridgetown.live_reload_path
 
       Bridgetown::Hooks.register_one(
         :loader, :post_setup, reloadable: false
@@ -62,7 +63,7 @@ module Bridgetown
             end
 
             loader.reload
-            loader.eager_load
+            Bridgetown::Hooks.trigger :loader, :post_reload, loader, server_folder
           rescue SyntaxError => e
             Bridgetown::Errors.print_build_error(e)
           end.start
@@ -75,6 +76,7 @@ module Bridgetown
         next unless load_path == server_folder
 
         loader.eager_load
+        Bridgetown.touch_live_reload_file(cached_reload_file)
       end
 
       loaders_manager.setup_loaders([server_folder])

--- a/bridgetown-core/lib/bridgetown-core/rack/routes.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/routes.rb
@@ -108,8 +108,7 @@ module Bridgetown
         # @param app [Roda]
         def setup_live_reload(app) # rubocop:disable Metrics
           sleep_interval = 0.5
-          file_to_check = File.join(Bridgetown::Current.preloaded_configuration.destination,
-                                    "index.html")
+          file_to_check = Bridgetown.live_reload_path
           errors_file = Bridgetown.build_errors_path
 
           app.request.get "_bridgetown/live_reload" do

--- a/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
+++ b/bridgetown-routes/lib/roda/plugins/bridgetown_routes.rb
@@ -130,10 +130,14 @@ class Roda
       module RequestMethods
         # This runs through all of the routes in the manifest, setting up Roda blocks for execution
         def file_routes
+          base_path = Bridgetown::Current.preloaded_configuration.base_path.delete_prefix("/")
+
           scope.routes_manifest.routes.each do |route|
             file, localized_file_slugs, segment_keys = route
 
             localized_file_slugs.each do |slug|
+              on("") { scope.run_file_route(file, slug:) } if slug == "index" && !base_path.empty?
+
               # This sets up an initial Roda route block at the slug, and handles segments as params
               #
               # _routes/nested/[slug].erb -> "nested/:slug"


### PR DESCRIPTION
This uses a special hidden file for watching for live reload.

Also includes some Routes plugin-related fixes as well as making those go on the Fast Refresh track

Fixes #940
