### PR TITLE
Update Lit configuration files to use ESM syntax

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/lit.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit.rb
@@ -11,19 +11,19 @@ end
 
 say_status :lit, "Installing Lit + SSR Plugin..."
 
-add_gem "bridgetown-lit-renderer", version: "2.1.0.beta2"
+add_gem "bridgetown-lit-renderer", version: "3.0.0"
 
-add_npm_package "lit esbuild-plugin-lit-css bridgetown-lit-renderer@2.1.0-beta2"
+add_npm_package "lit esbuild-plugin-lit-css bridgetown-lit-renderer@3.0.0"
 
 copy_file in_templates_dir("lit-ssr.config.js"), "config/lit-ssr.config.js"
 copy_file in_templates_dir("lit-components-entry.js"), "config/lit-components-entry.js"
 copy_file in_templates_dir("esbuild-plugins.js"), "config/esbuild-plugins.js"
 
 insert_into_file "esbuild.config.js",
-                 after: 'const build = require("./config/esbuild.defaults.js")' do
+                 after: 'import build from "./config/esbuild.defaults.js"' do
   <<~JS
 
-    const { plugins } = require("./config/esbuild-plugins.js")
+    import { plugins } from "./config/esbuild-plugins.js"
   JS
 end
 

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/esbuild-plugins.js
@@ -4,21 +4,21 @@
 
 // This plugin will let you import `.lit.css` files as sidecar stylesheets.
 // Read https://www.bridgetownrb.com/docs/components/lit#sidecar-css-files for documentation.
-const { litCssPlugin } = require("esbuild-plugin-lit-css")
-const postcssrc = require("postcss-load-config")
-const postcss = require("postcss")
+import { litCssPlugin } from "esbuild-plugin-lit-css"
 
-module.exports = {
-  plugins: [
-    litCssPlugin({
-      filter: /\.lit\.css$/,
-      transform: async (css, { filePath }) => {
-        const postCssConfig = await postcssrc()
-        const postCssProcessor = postcss([...postCssConfig.plugins])
+import postcss from "postcss"
 
-        const results = await postCssProcessor.process(css, { ...postCssConfig.options, from: filePath })
-        return results.css
-      }
-    }),
-  ]
-}
+const postcssrc = (await import("postcss-load-config")).default
+
+export const plugins = [
+  litCssPlugin({
+    filter: /\.lit\.css$/,
+    transform: async (css, { filePath }) => {
+      const postCssConfig = await postcssrc()
+      const postCssProcessor = postcss([...postCssConfig.plugins])
+
+      const results = await postCssProcessor.process(css, { ...postCssConfig.options, from: filePath })
+      return results.css
+    }
+  }),
+]

--- a/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-ssr.config.js
+++ b/bridgetown-core/lib/bridgetown-core/configurations/lit/lit-ssr.config.js
@@ -1,5 +1,5 @@
-const build = require("bridgetown-lit-renderer/build")
-const { plugins } = require("./esbuild-plugins.js")
+import build from "bridgetown-lit-renderer/build"
+import { plugins } from "./esbuild-plugins.js"
 
 const esbuildOptions = { plugins }
 


### PR DESCRIPTION
Resolves #955

> [!WARNING]
> **Don't** merge this in until the 3.0 release of the Lit plugin! See: https://github.com/bridgetownrb/bridgetown-lit-renderer/pull/3