### PR TITLE
Update Pagination Documentation

### DIFF
--- a/bridgetown-website/src/_data/bridgetown_variables/paginator.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables/paginator.yml
@@ -8,15 +8,26 @@
   description: Total number of resources
 - name: total_pages
   description: Total number of paginated pages
+- name: first_page_path
+  description: >-
+    Returns the path to the first page, or <code>nil</code> if none
+- name: last_page
+  description: >-
+    The number of the last page, or <code>nil</code> if none
+- name: last_page_path
+  description: >-
+    Returns the path to the last page, or <code>nil</code> if none
+- name: next_page
+  description: >-
+    The number of the next page, or <code>nil</code> if no subsequent page exists
+- name: next_page_path
+  description: >-
+    The path to the next page, or <code>nil</code> if no previous page exists
 - name: previous_page
   description: >-
     The number of the previous page, or <code>nil</code> if no previous page exists
 - name: previous_page_path
   description: >-
     The path to the previous page, or <code>nil</code> if no previous page exists
-- name: next_page
-  description: >-
-    The number of the next page, or <code>nil</code> if no subsequent page exists
-- name: next_page_path
-  description: >-
-    The path to the next page, or <code>nil</code> if no subsequent page exists
+
+

--- a/bridgetown-website/src/_data/bridgetown_variables/paginator_attr.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables/paginator_attr.yml
@@ -1,0 +1,27 @@
+- name: collection
+  description: >-
+    <code>Required</code> The collection to paginate
+- name: offset
+  description: >-
+    <code>Default: 0</code> Supports skipping x number of posts from the beginning of the post list
+- name: per_page
+  description: >-
+    <code>Default 10</code> Number of resources per page
+- name: permalink
+  description: >-
+    <code>Default: "/page/:num/"</code> Supports :num as customizable elements
+- name: title
+  description: >-
+    <code>Default: ":title (Page :num)"</code> Supports :num customizable elements
+- name: sort_reverse
+  description: >-
+    <code>Default: true</code> Sorts the posts in reverse order
+- name: sort_field
+  description: >-
+    <code>Default: "date"</code> Sorts the posts by the specified field
+- name: limit
+  description: >-
+    <code>Default: 0</code> Limits how many content objects to paginate (default: 0, means all)
+- name: debug
+  description: >-
+    <code>Default: false</code> Turns on debug output for the gem

--- a/bridgetown-website/src/_docs/content/pagination.md
+++ b/bridgetown-website/src/_docs/content/pagination.md
@@ -5,8 +5,6 @@ top_section: Writing Content
 category: resources
 ---
 
-{%@ "docs/help_needed", resource: resource %}
-
 Pagination support is built-in to Bridgetown, but it is not enabled by default. You can enable it in the config file using:
 
 ```yml
@@ -16,7 +14,7 @@ pagination:
 
 ## Page Configuration
 
-To facilitate pagination on any given page (like `index.html`, `blog.md`, etc.) then include configuration in the resource's front matter to specify which collection you'd like to paginate through:
+To facilitate pagination on any given page (like `index.html`, `blog.md`, etc.) include configuration in the resource's front matter to specify which collection you'd like to paginate through:
 
 ``` yml
 ---
@@ -52,6 +50,10 @@ paginate:
   sort_field: rating
   sort_reverse: true
 ```
+
+## Attributes for Defining Pagination
+
+{%@ Documentation::VariablesTable data: site.data, scope: :paginator_attr, description_size: :bigger %}
 
 ## Excluding a Resource from the Paginator
 
@@ -89,3 +91,4 @@ To display pagination links, use the `paginator` Liquid object as follows:
 The `paginator` Liquid object provides the following attributes:
 
 {%@ Documentation::VariablesTable data: site.data, scope: :paginator, description_size: :bigger %}
+


### PR DESCRIPTION
Add most of the paginator methods, for both paginating a collection and using the paginator in templates. 

There were a few attributes I skipped because they did not appear to be things an end user would want to touch, these include:  documents (is this redundant with collections/resources?), page_trail/trail (is this a feature that isn't documented or not fully implemented?), indexpage (setting this to any other page broke the page), extension (ignored if indexpage is nil), debug (not sure this is useful outside of plugin development)

 This is a 🔦 documentation change.

## Summary

Review 

## Context

No Github issues. 

I had to look at the source when figuring out how to use the paginator, and am responding to the call for documentation review in the doc.