### PR TITLE
fix: multi-locale in front matter works with Fast Refresh

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/resource/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/resource/base.rb
@@ -364,7 +364,7 @@ module Bridgetown
         origin_data = model.origin.read
         correct_locale = origin_data["locale"] || origin_data[:locale] || data.locale
         model.attributes = origin_data
-        model.attributes.locale = correct_locale
+        model.attributes.locale = correct_locale.to_s == "multi" ? data.locale : correct_locale
         @relative_url = @absolute_url = nil # wipe memoizations
         read!
         tax_diff = past_values.any? { |k, v| @data.peek[k] != v }


### PR DESCRIPTION
Resolves #977 

The problem is the data originally read into each locale's resources was getting overridden by newly-loaded front matter from the origin model. This now ensures if the model's locale is `multi` we preserve the actual locale of the derived resource.