### PR TITLE
fixed frozen string warning for ruby 3.4

### DIFF
--- a/bridgetown-foundation/lib/bridgetown/foundation/questionable_string.rb
+++ b/bridgetown-foundation/lib/bridgetown/foundation/questionable_string.rb
@@ -5,8 +5,7 @@ module Bridgetown::Foundation
     def method_missing(method_name, *args)
       value = method_name.to_s
       if value.end_with?("?")
-        value.chop!
-        return self == value
+        return self == value.chop
       end
 
       super


### PR DESCRIPTION
This is a bug fix.

## Summary

When using rake with Ruby 3.4 I get a warning:

> ~/.gems/gems/bridgetown-foundation-2.0.0.beta4/lib/bridgetown/foundation/questionable_string.rb:8: warning: string returned by :production?.to_s will be frozen in the future

**To reproduce**

```bash
# rbenv install 3.4.2
# rbenv global 3.4.2
bridgetown plugins new XYZ
cd XYZ
rake
```
