### PR TITLE
propose cookbook with pagination alternative example

### DIFF
--- a/bridgetown-website/src/_docs/cookbook.md
+++ b/bridgetown-website/src/_docs/cookbook.md
@@ -1,0 +1,21 @@
+---
+order: 2500
+title: Cookbook
+#top_section: Introduction
+category: cookbook
+next_page_order: 2501
+layout: docs
+---
+
+## Pagination
+
+### Pagination Needs to be in a Collection
+
+Pagination pages don't appear in collections. If you need your pagination page to be in a collection (like you have a menu that iterates a collection), have two pages. The first page can show the same number of entries and have a link for the other archive page in place of pagination.
+
+### Organize a Collection by Years
+
+The built in paginator can't do this, but it's fairly easy to do as long as you don't need a restful url for each year.
+
+[collection_by_years recipe]('cookbook/collection_by_years')
+

--- a/bridgetown-website/src/_docs/cookbook.md
+++ b/bridgetown-website/src/_docs/cookbook.md
@@ -7,15 +7,32 @@ next_page_order: 2501
 layout: docs
 ---
 
+## Helpers
+
+### General Helpers
+
+The **cache_busting_url** from the doc using the configured url of the project, and the **multiply_and_optionally_add** example, in a single file.
+
+[helpers_example recipe](cookbook/helpers_example)
+
+### Date Helpers
+
+In your project you might for example have a frequently used strftime format. Or you may run into issues with ruby having Time, Date and DateTime classes, as well as strings containing date/time values. This helper provides two methods: **standardize_date** to convert to date objects and **date_format** to format the date.
+
+[helpers_date recipe](cookbook/helpers_date)
+
 ## Pagination
 
-### Pagination Needs to be in a Collection
+### Keeping a Pagination Page in a Collection
 
 Pagination pages don't appear in collections. If you need your pagination page to be in a collection (like you have a menu that iterates a collection), have two pages. The first page can show the same number of entries and have a link for the other archive page in place of pagination.
 
-### Organize a Collection by Years
+### Archives by Date Period
 
-The built in paginator can't do this, but it's fairly easy to do as long as you don't need a restful url for each year.
+**collection_by_years** does not use pagination at all to create a time period grouped index. Using this approach avoids the paginator.
 
-[collection_by_years recipe]('cookbook/collection_by_years')
+[collection_by_years recipe](cookbook/collection_by_years)
 
+**monthly_archives** uses prototypes, which rely on the paginator.
+
+[monthly_archives recipe](cookbook/monthly_archives)

--- a/bridgetown-website/src/_docs/cookbook/collection_by_years.md
+++ b/bridgetown-website/src/_docs/cookbook/collection_by_years.md
@@ -1,0 +1,84 @@
+---
+order: 2501
+title: Cookbook Collection By Years
+#top_section: Introduction
+category: cookbook
+#next_page_order: 30
+---
+
+### _components/years.rb
+
+```ruby
+class Years < Bridgetown::Component
+  def initialize(collection:)
+    @archive = []
+    current_year = nil
+    current_year_data = []
+
+    collection.resources.each do |resource|
+      year = resource.date.year
+      if year != current_year
+        # Save the previous year's data if it exists
+        @archive << { year: current_year, pages: current_year_data } if current_year
+        # Start a new year
+        current_year = year
+        current_year_data = [resource]
+      else
+        current_year_data << resource
+      end
+    end
+
+    # Don't forget to add the last year's data
+    return unless current_year
+
+    @archive << { year: current_year, pages: current_year_data }
+  end
+end
+```
+
+### _components/years.erb
+
+```erb
+<!-- If you're not using Bootstrap define the d-none style or
+switch to your framework's equivalent class.
+<style>
+.d-none { display: none; }
+</style>
+-->
+<% classlist = '' %>
+<% @archive.each do |yeargroup| %>
+  <h2 ><%= yeargroup[:year] %> </h2>
+  <div <%= raw classlist %> >
+  <% classlist = 'class="d-none"' %>
+  <% pages = yeargroup[:pages] %>
+
+  <ul>
+  <% pages.each do |page| %>
+    <li><%= page.data.date.strftime('%B %e') %>
+      <a href="<%= page.relative_url %>"><%= page.data.title %></a></li>
+  <% end %>
+  </ul>
+  </div>
+<% end %>
+
+<!-- make sure jquery loads before this script -->
+<script>
+$(document).ready(function() {
+  $('h2').css('cursor', 'pointer');
+  $('h2').on('click', function() {
+    $('h2').not(this).next('div').addClass('d-none');
+    $(this).next('div').removeClass('d-none');
+  });
+});
+</script>
+```
+
+### years.md in one of your collections
+
+```erb
+---
+title: Collection Pages Grouped by Year
+# Do not paginate this page.
+---
+<%= render Years.new(collection: collections.posts ) %>
+```

--- a/bridgetown-website/src/_docs/cookbook/collection_by_years.md
+++ b/bridgetown-website/src/_docs/cookbook/collection_by_years.md
@@ -1,6 +1,6 @@
 ---
 order: 2501
-title: Cookbook Collection By Years
+title: 'Cookbook: Collection By Years'
 #top_section: Introduction
 category: cookbook
 #next_page_order: 30

--- a/bridgetown-website/src/_docs/cookbook/helpers_date.md
+++ b/bridgetown-website/src/_docs/cookbook/helpers_date.md
@@ -1,0 +1,42 @@
+---
+order: 2503
+title: 'Cookbook: Date Helpers'
+#top_section: Introduction
+category: cookbook
+#next_page_order: 30
+---
+
+### plugins/builders/datehelpers.rb
+```
+require_relative '../../lib/date_helpers'
+
+class Builders::Datehelpers < SiteBuilder
+  def build
+    helper :standardize_date do |dt|
+      DateHelpers.standardize_date(dt)
+    end
+    helper :display_date do |dt|
+      DateHelpers.standardize_date(dt).strftime('%A %e %B %Y')
+    end
+  end
+end
+```
+### lib/date_helpers.rb
+```
+module DateHelpers
+  def self.standardize_date(date)
+    case date
+    when String
+      begin
+        Date.parse(date)
+      rescue ArgumentError
+        nil
+      end
+    when Date, Time, DateTime
+      date.to_date
+    else
+      nil
+    end
+  end
+end
+```

--- a/bridgetown-website/src/_docs/cookbook/helpers_example.md
+++ b/bridgetown-website/src/_docs/cookbook/helpers_example.md
@@ -1,0 +1,43 @@
+---
+order: 2503
+title: 'Cookbook: Helpers Example'
+#top_section: Introduction
+category: cookbook
+#next_page_order: 30
+---
+
+### plugins/builders/helpers.rb
+```
+class Builders::Helpers < SiteBuilder
+  def build
+    helper :cache_busting_url do |path|
+      "#{Bridgetown::Current.site.config.url}/#{path}?#{Time.now.to_i}"
+    end
+    helper :multiply_and_optionally_add do |input, multiply_by, add_by = nil|
+      value = input * multiply_by
+      add_by ? value + add_by : value
+    end
+  end
+end
+
+```
+### config/initializers.rb
+```
+Bridgetown.configure do |config|
+# ...
+  if Bridgetown.env.production?
+    url 'https://bridgtownrb.org'
+  end
+
+  if Bridgetown.env.development?
+    url 'http://localhost:4000'
+    unpublished true
+    future true
+  end
+
+  if Bridgetown.env.stage?
+    url https://stage.bridgtownrb.org'
+  end
+# ...
+end
+```

--- a/bridgetown-website/src/_docs/cookbook/monthly_archives.md
+++ b/bridgetown-website/src/_docs/cookbook/monthly_archives.md
@@ -1,0 +1,49 @@
+---
+order: 2502
+title: 'Cookbook: Monthly Archive'
+#top_section: Introduction
+category: cookbook
+#next_page_order: 30
+---
+### plugins/builders/monthly_archives.rb
+
+```ruby
+class Builders::MonthlyArchives < SiteBuilder
+  using Bridgetown::Refinements
+
+  priority :high
+
+  COLLECTIONS = %w(posts)
+
+  def build
+    hook :resources, :post_read do |resource|
+      add_monthly_data(resource) if resource.collection.label.within?(COLLECTIONS)
+    end
+
+    helper :monthly_archive_list do
+      site.data
+        .monthly_archives
+        .map { _1.split("|") } # split 2010-05|May 2010
+        .sort_by { _1[0] }
+        .map { _1[1] }
+        .reverse
+    end
+  end
+
+  def add_monthly_data(resource)
+    resource.data.monthly = resource.date.strftime("%B %Y") # May 2010
+    site.data.monthly_archives ||= Set.new
+    site.data.monthly_archives << "#{resource.date.strftime("%Y-%m")}|#{resource.data.monthly}"
+  end
+end
+```
+
+### your pagination page front matter
+
+```yaml
+title: ":prototype-term-titleize Archive"
+exclude_from_search: true
+prototype:
+  collection: posts
+  term: monthly
+```


### PR DESCRIPTION
 This is a 🔦 documentation enhancement. 

## Summary

This provides an example of an alternative approach to pagination. 

It proposes a new documentation section: cookbook for code examples.

## Context

The technique could be considered a workaround for #807.
