### PR TITLE
doc/variables differences for config and env between liquid and ruby.

### DIFF
--- a/bridgetown-website/src/_data/bridgetown_variables/global.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables/global.yml
@@ -14,3 +14,6 @@
   description: >-
     In layout files, the rendered content of the resource being wrapped.
     Not defined in resource files themselves.
+- name: environment, env
+  description: >-
+    The environment is obtained from the Bridgetown instance <code>Bridgetown.environment</code> in Ruby templating and <code>bridgetown.environment</code> in Liquid. In Ruby templates you can also use <code>Bridgetown.env</code>.

--- a/bridgetown-website/src/_data/bridgetown_variables/site.yml
+++ b/bridgetown-website/src/_data/bridgetown_variables/site.yml
@@ -23,7 +23,7 @@
 - name: site.tags.TAG
   description: >-
     The list of all resources with tag <code>TAG</code>.
-- name: site.url
+- name: site.url, site.config.url
   description: >-
     Contains the url of your site as it is configured in the <code>bridgetown.config.yml</code>.
     For example, if you have <code>url: http://mysite.com</code> in your configuration file,
@@ -31,6 +31,7 @@
     environment there is an
     exception: <code>site.url</code> will be set to the value of <code>host</code>, <code>port</code>,
     and SSL-related options. This defaults to <code>url: http://localhost:4000</code>.
+    site.url is only available in liquid, but site.config.url is available in all templates.
 - name: "site.metadata"
   description: >-
     You can put metadata variables in <code>_data/site_metadata.yml</code> so
@@ -38,10 +39,10 @@
     good place to put <code>&lt;head&gt;</code> content like site title,
     description, icon, social media handles, etc. Then you can reference
     {{ site.metadata.title }}, etc. in your Liquid templates.
-- name: "site.[CONFIGURATION_DATA]"
+- name: "site.[CONFIGURATION_DATA], site.config[CONFIGURATION_DATA]"
   description: >-
     All the variables set via the command line and your <code>bridgetown.config.yml</code> are available
     through the <code>site</code> variable. For example, if you have <code>foo: bar</code> in
-    your configuration file, then it will be accessible in Liquid as <code>site.foo</code>.
+    your configuration file, then it will be accessible in Liquid as <code>site.foo</code>. In Ruby templating the values are available only through site.config.
     Bridgetown does not parse changes to <code>bridgetown.config.yml</code> in
     <code>watch</code> mode, you must restart Bridgetown to see changes to variables.

--- a/bridgetown-website/src/_docs/variables.md
+++ b/bridgetown-website/src/_docs/variables.md
@@ -7,7 +7,7 @@ category: variables
 
 Bridgetown traverses your site looking for files to process. Any files with
 [front matter](/docs/front-matter/) are subject to processing. For each of these
-files, Bridgetown makes a variety of data available via the [Liquid](/docs/template-engines/liquid/) template language.
+files, Bridgetown makes a variety of data available in templates.
 The following is a reference of the available data.
 
 ## Global Variables


### PR DESCRIPTION
This is a 🔦 documentation change.

## Update variables doc page

noted differences I'm aware of between liquid and ruby templating

## Context

For ##992