### PR TITLE
Pass options hash as keyword arguments to the `partial` method

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/component.rb
+++ b/bridgetown-core/lib/bridgetown-core/component.rb
@@ -169,7 +169,7 @@ module Bridgetown
         end
         result&.html_safe
       else
-        partial(item, options, &block)&.html_safe
+        partial(item, **options, &block)&.html_safe
       end
     end
 

--- a/bridgetown-foundation/lib/bridgetown/foundation/questionable_string.rb
+++ b/bridgetown-foundation/lib/bridgetown/foundation/questionable_string.rb
@@ -4,9 +4,7 @@ module Bridgetown::Foundation
   class QuestionableString < ::String
     def method_missing(method_name, *args)
       value = method_name.to_s
-      if value.end_with?("?")
-        return self == value.chop
-      end
+      return self == value.chop if value.end_with?("?")
 
       super
     end


### PR DESCRIPTION
Fixes #986
