### PR TITLE
Load Dotenv configuration before starting the server to catch additional configuration

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/start.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/start.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require "rackup/server"
+begin
+  require 'dotenv'
+rescue LoadError
+  # Since it's a plugin, we don't want to fail if it's not installed
+end
 
 module Bridgetown
   class Server < Rackup::Server
@@ -72,6 +77,9 @@ module Bridgetown
 
         # Load Bridgetown configuration into thread memory
         bt_options = configuration_with_overrides(options)
+
+        Bridgetown.load_dotenv(root: bt_options.root_dir) if defined?(Dotenv)
+
         port = ENV.fetch("BRIDGETOWN_PORT", bt_options.port)
         # TODO: support Puma serving HTTPS directly?
         bt_bound_url = "http://#{bt_options.bind}:#{port}"


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary


The `BRIDGETOWN_PORT` was not being honored because `Dotenv` hasn't loaded when the `Bridgetown::Commands::Start#start` is being ran and therefore any additional configuration in the `.env` file is being ignored.

This PR requires `dotenv` at the beginning of the file, and loads it before the `ENV["BRIDGETOWN_PORT"]` is fetched. That way, it becomes available and it is taken into account before passing in the configuration to start the serve

## Context

Fixes #996

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
