### PR TITLE
Allow `sort_by` and `sort_direction` to accept symbols in collection metadata

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/collection.rb
+++ b/bridgetown-core/lib/bridgetown-core/collection.rb
@@ -325,12 +325,13 @@ module Bridgetown
     alias_method :add_model_resource, :add_resource_from_model
 
     def sort_resources!
-      if metadata["sort_by"].is_a?(String)
+      sort_by_value = metadata["sort_by"]
+      if sort_by_value.is_a?(String) || sort_by_value.is_a?(Symbol)
         sort_resources_by_key!
       else
         resources.sort!
       end
-      resources.reverse! if metadata.sort_direction == "descending"
+      resources.reverse! if metadata.sort_direction.to_s == "descending"
     end
 
     private
@@ -342,7 +343,7 @@ module Bridgetown
     # A custom sort function based on Schwartzian transform
     # Refer https://byparker.com/blog/2017/schwartzian-transform-faster-sorting/ for details
     def sort_resources_by_key!
-      meta_key = metadata["sort_by"]
+      meta_key = metadata["sort_by"].to_s
       # Modify array to cache property along with the Resource instance
       resources.map! { |r| [r.data[meta_key], r] }.sort! do |apples, olives|
         order = determine_sort_order(meta_key, apples, olives)

--- a/bridgetown-core/test/test_collections.rb
+++ b/bridgetown-core/test/test_collections.rb
@@ -208,6 +208,87 @@ class TestCollections < BridgetownUnitTest
     end
   end
 
+  context "with a collection with symbol sort_by in config/initializers.rb" do
+    setup do
+      @site = fixture_site(
+        "collections" => {
+          "tutorials" => {
+            "output"  => true,
+            "sort_by" => :lesson,
+          },
+        }
+      )
+      @site.process
+      @tutorials_collection = @site.collections["tutorials"]
+
+      @actual_array = @tutorials_collection.resources.map { _1.relative_path.to_s }
+    end
+
+    should "sort documents in a collection with 'sort_by' metadata set to a " \
+           "FrontMatter key symbol :lesson" do
+      default_tutorials_array = %w(
+        _tutorials/dive-in-and-publish-already.md
+        _tutorials/extending-with-plugins.md
+        _tutorials/getting-started.md
+        _tutorials/graduation-day.md
+        _tutorials/lets-roll.md
+        _tutorials/tip-of-the-iceberg.md
+      )
+      tutorials_sorted_by_lesson_array = %w(
+        _tutorials/getting-started.md
+        _tutorials/lets-roll.md
+        _tutorials/dive-in-and-publish-already.md
+        _tutorials/tip-of-the-iceberg.md
+        _tutorials/extending-with-plugins.md
+        _tutorials/graduation-day.md
+      )
+
+      refute_equal default_tutorials_array, @actual_array
+      assert_equal tutorials_sorted_by_lesson_array, @actual_array
+    end
+  end
+
+  context "with a collection with symbol sort_direction in config/initializers.rb" do
+    setup do
+      @site = fixture_site(
+        "collections" => {
+          "tutorials" => {
+            "output"         => true,
+            "sort_by"        => :lesson,
+            "sort_direction" => :descending,
+          },
+        }
+      )
+      @site.process
+      @tutorials_collection = @site.collections["tutorials"]
+
+      @actual_array = @tutorials_collection.resources.map { _1.relative_path.to_s }
+    end
+
+    should "sort documents in a collection with 'sort_direction' metadata set to a " \
+           "symbol :descending" do
+      default_tutorials_array = %w(
+        _tutorials/dive-in-and-publish-already.md
+        _tutorials/extending-with-plugins.md
+        _tutorials/getting-started.md
+        _tutorials/graduation-day.md
+        _tutorials/lets-roll.md
+        _tutorials/tip-of-the-iceberg.md
+      )
+      tutorials_sorted_by_lesson_desc_array = %w(
+        _tutorials/graduation-day.md
+        _tutorials/extending-with-plugins.md
+        _tutorials/tip-of-the-iceberg.md
+        _tutorials/dive-in-and-publish-already.md
+        _tutorials/lets-roll.md
+        _tutorials/getting-started.md
+      )
+
+      refute_equal default_tutorials_array, @actual_array
+      assert_equal tutorials_sorted_by_lesson_desc_array, @actual_array
+    end
+  end
+
   context "with dots in the filenames" do
     setup do
       @site = fixture_site(


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the Project Goals and Future Roadmap pages at: https://bridgetownrb.com/docs/philosophy/
  - I read the Code of Conduct: https://github.com/bridgetownrb/bridgetown/blob/main/CODE_OF_CONDUCT.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Before the fix, this would not work:

```ruby
Bridgetown.configure do |config|
  config.collections = {
    "docs" => {
      "output" => true,
      "sort_by" => :order,          # ❌ This would fail
      "sort_direction" => :descending # ❌ This would fail
    }
  }
end
```

After the fix, both strings and symbols work:
```ruby
Bridgetown.configure do |config|
  config.collections = {
    "docs" => {
      "output" => true,
      "sort_by" => :order,          # ✅ Now works
      "sort_direction" => :descending # ✅ Now works
    }
  }
end
```

Or using strings (this always worked)

## Context

Fixes #975 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
