### PR TITLE
Handle Symbol#to_s returning chilled strings

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/model/base.rb
+++ b/bridgetown-core/lib/bridgetown-core/model/base.rb
@@ -145,11 +145,7 @@ module Bridgetown
         return attributes[method_name] if attributes.key?(method_name)
 
         key = method_name.to_s
-        if key.end_with?("=")
-          key.chop!
-          attributes[key] = args.first
-          return attributes[key]
-        end
+        return attributes[key.chop] = args.first if key.end_with?("=")
 
         Bridgetown.logger.warn "key `#{method_name}' not found in attributes for " \
                                "#{attributes[:id].presence || "new #{self.class}"}"

--- a/bridgetown-core/lib/bridgetown-core/signals.rb
+++ b/bridgetown-core/lib/bridgetown-core/signals.rb
@@ -55,10 +55,7 @@ class Bridgetown::Signals < Signalize::Struct
     return nil if value.empty? && block.nil?
 
     key = key.to_s
-    if key.end_with?("=")
-      key.chop!
-      return self[key] = value[0]
-    end
+    return self[key.chop] = value[0] if key.end_with?("=")
 
     super(key.to_sym)
   end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

In [a change to Ruby 3.4][1], the core team made it so `Symbol#to_s` returns a "chilled" string, which is a String that will be frozen in future releases of Ruby.

This change makes two cases that were raising warnings for me on Ruby 3.4.5 use a dup-and-modify approach for handling assignment calls within `method_missing` implementations.

[1]: https://bugs.ruby-lang.org/issues/20350

## Context

See ruby/ruby#12065
