### PR TITLE
fix: defer to the Streamlined render method for blocks

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/build.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/build.rb
@@ -29,7 +29,7 @@ module Bridgetown
       # Build your bridgetown site
       # Continuously watch if `watch` is set to true in the config.
       def build
-        Bridgetown.logger.adjust_verbosity(options)
+        Bridgetown.logger.adjust_verbosity(**options)
 
         # @type [Bridgetown::Configuration]
         config_options = configuration_with_overrides(

--- a/bridgetown-core/lib/bridgetown-core/commands/console.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/console.rb
@@ -71,7 +71,7 @@ module Bridgetown
         end
         require "amazing_print" unless options[:"bypass-ap"]
 
-        Bridgetown.logger.adjust_verbosity(options)
+        Bridgetown.logger.adjust_verbosity(**options)
 
         Bridgetown.logger.info "Starting:", "Bridgetown v#{Bridgetown::VERSION.magenta} " \
                                             "(codename \"#{Bridgetown::CODE_NAME.yellow}\") " \

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -174,7 +174,7 @@ module Bridgetown
       # unless the user opts to skip 'bundle install'.
       # rubocop:todo Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
-      def after_install(path, cli_path, options = {})
+      def after_install(path, cli_path, options)
         git_init path
 
         @skipped_bundle = true # is set to false if bundle install worked

--- a/bridgetown-core/lib/bridgetown-core/component.rb
+++ b/bridgetown-core/lib/bridgetown-core/component.rb
@@ -158,10 +158,15 @@ module Bridgetown
 
     # Provide a render helper for evaluation within the component context.
     #
-    # @param item [Object] a component supporting `render_in` or a partial name
-    # @param options [Hash] passed to the `partial` helper if needed
+    # @param item [Object] a component supporting `render_in`, a Streamlined proc, or a partial name
+    # @param options [Hash] keyword arguments passed to the `partial` helper if needed
     # @return [String]
-    def render(item, options = {}, &block)
+    def render(item = nil, **options, &block) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      return @_rbout if !block && options.empty? && item.nil?
+
+      # Defer to Streamline's rendering logic in this case
+      return super if item.is_a?(Proc) || (block && item.nil?)
+
       if item.respond_to?(:render_in)
         result = ""
         capture do # this ensures no leaky interactions between BT<=>VC blocks

--- a/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
+++ b/bridgetown-core/lib/bridgetown-core/converters/markdown/kramdown_parser.rb
@@ -45,6 +45,8 @@ module Kramdown
     end
 
     def initialize(source, options = {}) # rubocop:disable Lint/MissingSuper
+      # NOTE: keep `options = {}` instead of the newer `**options` for Kramdown compatibility
+
       BridgetownDocument.setup(options)
 
       @options = BridgetownDocument.options

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -109,12 +109,11 @@ module Bridgetown
       # @param text [String] the content inside the anchor tag
       # @param relative_path [String, Object] source file path, e.g.
       #   "_posts/2020-10-20-my-post.md", or object that responds to `url`
-      # @param options [Hash] key-value pairs of HTML attributes to add to the tag
+      # @param options [Hash] pass keyword arguments to add HTML attributes
       # @return [String] the anchor tag HTML
       # @raise [ArgumentError] if the file cannot be found
-      def link_to(text, relative_path = nil, options = {}, &block)
+      def link_to(text, relative_path = nil, **options, &block)
         if block.present?
-          options = relative_path || {}
           relative_path = text
           text = view.respond_to?(:capture) ? view.capture(&block) : yield
         elsif relative_path.nil?

--- a/bridgetown-core/lib/bridgetown-core/log_adapter.rb
+++ b/bridgetown-core/lib/bridgetown-core/log_adapter.rb
@@ -31,7 +31,7 @@ module Bridgetown
       @level = level
     end
 
-    def adjust_verbosity(options = {})
+    def adjust_verbosity(**options)
       # Quiet always wins.
       if options[:quiet]
         self.log_level = :error

--- a/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
+++ b/bridgetown-core/lib/bridgetown-core/ruby_template_view.rb
@@ -59,7 +59,7 @@ module Bridgetown
       end
     end
 
-    def liquid_render(component, options = {}, &block)
+    def liquid_render(component, **options, &block)
       options[:_block_content] = capture(&block) if block && respond_to?(:capture)
       render_statement = _render_statement(component, options)
 


### PR DESCRIPTION
Plus additional work to migrate from `options = {}` to `**options`

Resolves #1002 & #581