### PR TITLE
Load dotenv before booting Puma if it will be initialized

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/build.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/build.rb
@@ -97,7 +97,7 @@ module Bridgetown
             ai.ipv4? && !ai.ipv4_loopback?
           end&.ip_address
           scheme = config_options.bind&.split("://")&.first == "ssl" ? "https" : "http"
-          port = ENV.fetch("BRIDGETOWN_PORT", config_options.port)
+          port = config_options.port
           Bridgetown.logger.info ""
           Bridgetown.logger.info "Now serving at:", "#{scheme}://localhost:#{port}".magenta
           Bridgetown.logger.info "", "#{scheme}://#{external_ip}:#{port}".magenta if external_ip

--- a/bridgetown-core/lib/site_template/config/puma.rb
+++ b/bridgetown-core/lib/site_template/config/puma.rb
@@ -2,9 +2,10 @@
 #
 # Learn more at: https://puma.io
 # Bridgetown configuration documentation:
-# https://edge.bridgetownrb.com/docs/configuration/puma
+# https://www.bridgetownrb.com/docs/configuration/puma
 
-# This port number can be overriden by a bind configuration option
+# This port number typically gets overridden by Bridgetown's boot & config loader
+# so you probably don't want to touch the number here
 #
 port ENV.fetch("BRIDGETOWN_PORT") { 4000 }
 


### PR DESCRIPTION
Fixes #996 (sort of)

I simply couldn't come up with a clean way to honor the port number that's directly in `config/puma.rb`, so I updated our template file for that to indicate that's not the place to be changing the number.

Beyond that, I'm doing the funky-but-it-works method of checking if the initializers config _will_ init `dotenv` via. regex — if so, it will preemptively load dotenv before determining the port value. In addition, I've clarifed the load order of the port config value so it works like so:

1. CLI
2. BRIDGETOWN_PORT env var
3. YAML config (if present)
4. 4000

Alas, we also have the issue where we can't get the port number from the initializers config as that config is loaded _after_ Puma boots because the server and the static build process are two separate init contexts. (geeeez) So we'll probably need to document somewhere that only the YAML-based config can specifically set a port number.

Honestly just using dotenv and setting `BRIDGETOWN_PORT` is by far the cleanest way to go since that closely mirrors how a production server works.