### PR TITLE
Fix routing order dependency in bridgetown_server

### DIFF
--- a/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_server.rb
@@ -157,9 +157,15 @@ class Roda
           scope.initialize_bridgetown_root
 
           base_path = Bridgetown::Current.preloaded_configuration.base_path.delete_prefix("/")
-          on(base_path.empty? ? true : base_path) do
+
+          if base_path.empty?
             ssg # static file server
             Bridgetown::Rack::Routes.load_all scope
+          else
+            on(base_path) do
+              ssg # static file server
+              Bridgetown::Rack::Routes.load_all scope
+            end
           end
         end
       end

--- a/bridgetown-core/test/ssr/server/roda_app.rb
+++ b/bridgetown-core/test/ssr/server/roda_app.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class RodaApp < Roda
+  module OrderIndependenceExample
+    module RequestMethods
+      def order_independence
+        get "order-independence" do
+          { it: "works" }
+        end
+      end
+    end
+  end
+
   plugin :bridgetown_server
+  plugin OrderIndependenceExample
 
   # rubocop:disable Lint/EmptyBlock
   plugin(:common_logger, StringIO.new.tap do |io| # swallow logs in tests
@@ -11,5 +22,8 @@ class RodaApp < Roda
   end)
   # rubocop:enable Lint/EmptyBlock
 
-  route(&:bridgetown)
+  route do |r|
+    r.bridgetown
+    r.order_independence
+  end
 end

--- a/bridgetown-core/test/test_ssr.rb
+++ b/bridgetown-core/test/test_ssr.rb
@@ -115,5 +115,24 @@ class TestSSR < BridgetownUnitTest
       assert_includes last_response.body, "<ul>\n  <li>Port 80</li>\n</ul>"
       assert_includes last_response.body, "<p>Well that was 246!\n  <em>ya think?</em></p>"
     end
+
+    should "allow plugins to work without order dependence" do
+      get "/order-independence"
+
+      assert last_response.ok?
+      assert_equal({ it: "works" }.to_json, last_response.body)
+    end
+
+    should "allow plugins to work without order dependence with a base path" do
+      original_base_path = site.config.base_path
+      site.config.base_path = "/subpath"
+
+      get "/order-independence"
+
+      assert last_response.ok?
+      assert_equal({ it: "works" }.to_json, last_response.body)
+    ensure
+      site.config.base_path = original_base_path
+    end
   end
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

- I've added tests
- The test suite passes locally (run `script/cibuild` to verify this)

## Summary

The `bridgetown_server` plugin was consuming all routes when `base_path` was empty, preventing other Roda plugins from handling requests. This made plugin order critical and broke existing behavior that allowed plugin usage to be in any order.

This change updates the routing logic to avoid using the terminal `#on(true)` pattern, allowing multiple plugins to coexist regardless of load order.

It also adds regression tests to ensure plugins can handle routes independently.

## Context

#939 was an attempt to reduce duplication in the plugin by relying on the "always" matcher behavior `#on(true)`. This accidentally regressed behavior and made the plugin's method terminal by making the branch _always_ match when `base_path` is the default. In that case, when no sub-branch from either the `ssg` plugin or a `Bridgetown::Rack::Routes` descendant matches, the `#on(true)` form terminates and doesn't pass to the next line in the router.

This change doesn't need a documentation update because the terminal behavior of the plugin was surprising.

### Other possible solutions

I considered removing the fork here and updating the `ssg` plugin and the `Bridgetown::Rack::Routes` logic to include knowledge of `base_path` within them, but I think this solution is cleaner.

- The `ssg` plugin would be straightforward; we could pass the `base_path` in the plugin configuration.
- The `Bridgetown::Rack::Routes` would, I think, continue to have a fork in it because, without the fork, we would end up in the same place due to the reliance on Roda's routing tree logic. Since the fork has to live somewhere, it felt cleaner to have it in the Roda plugin that sets up the other two.