### PR TITLE
Fix: Don't take all arguments to create a new site (#1006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed new command not to use all params to create a path #1006 
+  (@mlitwiniuk)
 
 ## [2.0.0.beta6] - 2025-04-16
 

--- a/bridgetown-core/lib/bridgetown-core/commands/new.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/new.rb
@@ -16,6 +16,11 @@ module Bridgetown
       end
       summary "Creates a new Bridgetown site scaffold in PATH"
 
+      argument :path,
+               type: :string,
+               required: false, # we're changing for path in new_site method
+               desc: "PATH where new Bridgetown site will be created"
+
       class_option :apply,
                    aliases: "-a",
                    banner: "PATH|URL",
@@ -60,9 +65,9 @@ module Bridgetown
       end
 
       def new_site
-        raise ArgumentError, "You must specify a path." if args.empty?
+        raise ArgumentError, "You must specify a path." if path.nil? || path.empty?
 
-        new_site_path = File.expand_path(args.join(" "), Dir.pwd)
+        new_site_path = File.expand_path(path, Dir.pwd)
         @site_name = new_site_path.split(File::SEPARATOR).last
 
         if preserve_source_location?(new_site_path, options)
@@ -77,7 +82,7 @@ module Bridgetown
 
         say_status :create, new_site_path
         create_site new_site_path
-        after_install new_site_path, args.join(" "), options
+        after_install new_site_path, path, options
       rescue ArgumentError => e
         say_status :alert, e.message, :red
       ensure

--- a/bridgetown-core/test/test_new_command.rb
+++ b/bridgetown-core/test/test_new_command.rb
@@ -191,7 +191,14 @@ class TestNewCommand < BridgetownUnitTest
 
     should "create a new directory" do
       refute_exist @site_name_with_spaces
-      invocation = argumentize("new #{@site_name_with_spaces}")
+      invocation = ["new", @site_name_with_spaces]
+      capture_output { Bridgetown::Commands::Base.start(invocation) }
+      assert_exist @site_name_with_spaces
+    end
+
+    should "create a new directory and ignore additoinal options" do
+      refute_exist @site_name_with_spaces
+      invocation = ["new", @site_name_with_spaces, "--help"]
       capture_output { Bridgetown::Commands::Base.start(invocation) }
       assert_exist @site_name_with_spaces
     end


### PR DESCRIPTION
This is a 🐛 bug fix. 

## Summary

This fixes #1006 - invoking `new` command with additional parameters won't use them to create a folder. Additionally this makes `new` command more consistent with regular shell usage, where parameters containing spaces should be wrapped with double quotes.

## Context

Fixes #1006 
