### PR TITLE
docs: updated information on adding Thor commands, Render hybrid deploys

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configurations/render.rb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/render.rb
@@ -3,4 +3,11 @@
 @render_service_name = ask "What would like to call your Render service?"
 template in_templates_dir("render.yaml.erb"), "render.yaml"
 
-say "All done. Just create a new blueprint from the Render dashboard and connect this repo."
+say_status :render, "Your render.yaml file is now configured!"
+say ""
+say "Verify its contents and once ready, create a new blueprint from the Render dashboard"
+say "and connect your repo."
+say ""
+say "Optionally, if you're setting up a backend API and database, create a environment group"
+say "on Render called [yourservicehere]-prod-envs for sharing environment variables between"
+say "multiple servers."

--- a/bridgetown-core/lib/bridgetown-core/configurations/render/render.yaml.erb
+++ b/bridgetown-core/lib/bridgetown-core/configurations/render/render.yaml.erb
@@ -1,13 +1,10 @@
 services:
   - type: web
     name: <%= @render_service_name %>
-    env: static
+    runtime: static
     buildCommand: bin/bridgetown deploy
     staticPublishPath: ./output
     pullRequestPreviewsEnabled: true
-    envVars:
-      - key: BRIDGETOWN_ENV
-        value: production
     headers:
       - path: /*
         name: X-Frame-Options
@@ -27,3 +24,42 @@ services:
       - path: /*
         name: Cache-Control
         value: "public, max-age=86400, s-max-age=86400"
+    envVars:
+      - key: BRIDGETOWN_ENV
+        value: production
+###########
+# Uncomment and modify the following for hybrid deployments, database support, etc.
+#   Use the `routes` rewrite feature to "poke holes" through your static CDN to specific
+#   route handlers in your Roda server application.
+###########
+#
+#       - key: DATABASE_URL
+#         fromDatabase:
+#           name: <%= @render_service_name %>_proddb
+#           property: connectionString
+#       - fromGroup: <%= @render_service_name %>-prod-envs
+#     routes:
+#       - type: rewrite
+#         source: /account/*
+#         destination: https://<%= @render_service_name %>-api.onrender.com/account/*
+#       - type: rewrite
+#         source: /auth/*
+#         destination: https://<%= @render_service_name %>-api.onrender.com/auth/*
+#   - type: web
+#     name: <%= @render_service_name %>-api
+#     plan: standard
+#     runtime: ruby
+#     buildCommand: bundle install && npm install && bin/bridgetown frontend:build
+#     startCommand: bin/bridgetown start
+#     envVars:
+#       - key: BRIDGETOWN_ENV
+#         value: production
+#       - key: DATABASE_URL
+#         fromDatabase:
+#           name: <%= @render_service_name %>_proddb
+#           property: connectionString
+#       - fromGroup: <%= @render_service_name %>-prod-envs
+# databases:
+#   - name: <%= @render_service_name %>_proddb
+#     plan: starter
+#     databaseName: <%= @render_service_name %>_production

--- a/bridgetown-core/lib/bridgetown-core/helpers.rb
+++ b/bridgetown-core/lib/bridgetown-core/helpers.rb
@@ -264,14 +264,19 @@ module Bridgetown
         end
       end
 
-      # TODO: docu
+      # Output a declarative shadow DOM tag to wrap the input argument or block
+      #
+      # @param input [String] content to wrap if block isn't provided
+      # @return [String]
       def dsd(input = nil, &block)
         tmpl_content = block.nil? ? input.to_s : view.capture(&block)
 
         Bridgetown::Utils.dsd_tag(tmpl_content)
       end
 
-      # TODO: docu
+      # Load a sidecar CSS file with a .dsd.css extension and output a style tag
+      #
+      # @return [String]
       def dsd_style
         tmpl_path = caller_locations(1, 2).find do |loc|
                       loc.label.include?("method_missing").!
@@ -292,7 +297,8 @@ module Bridgetown
         style_tag.html_safe
       end
 
-      # TODO: docu
+      # If you need to access signals without creating a tracking dependency, wrap a
+      # block of code in this helper
       def bypass_tracking(...) = Signalize.untracked(...)
     end
   end

--- a/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
+++ b/bridgetown-core/lib/bridgetown-core/plugin_manager.rb
@@ -102,7 +102,7 @@ module Bridgetown
 
     # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
-    # Iterates through loaded gems and finds npm-add gemspec metadata.
+    # Iterates through loaded gems and finds npm_add gemspec metadata.
     # If that exact package hasn't been installed, execute npm i
     #
     # @return [Bundler::SpecSet]
@@ -134,7 +134,7 @@ module Bridgetown
     end
 
     def self.find_npm_dependency(loaded_gem)
-      npm_metadata = loaded_gem.to_spec&.metadata&.dig("npm-add") ||
+      npm_metadata = loaded_gem.to_spec&.metadata&.dig("npm_add") ||
         loaded_gem.to_spec&.metadata&.dig("yarn-add")
       npm_dependency = npm_metadata&.match(NPM_DEPENDENCY_REGEXP)
       return nil if npm_dependency&.length != 3 || npm_dependency[2] == ""

--- a/bridgetown-core/test/test_plugin_manager.rb
+++ b/bridgetown-core/test/test_plugin_manager.rb
@@ -56,7 +56,7 @@ class TestPluginManager < BridgetownUnitTest
   context "find npm dependencies" do
     should "work if the metadata exists and is in the right format" do
       gem_mock = OpenStruct.new(to_spec: OpenStruct.new(metadata: {
-        "npm-add" => "my-plugin@0.1.0",
+        "npm_add" => "my-plugin@0.1.0",
       }))
       assert_equal ["my-plugin", "0.1.0"], Bridgetown::PluginManager.find_npm_dependency(gem_mock)
     end
@@ -75,12 +75,12 @@ class TestPluginManager < BridgetownUnitTest
 
     should "not work if the metadata isn't in the right format" do
       gem_mock = OpenStruct.new(to_spec: OpenStruct.new(metadata: {
-        "npm-add" => "gobbledeegook",
+        "npm_add" => "gobbledeegook",
       }))
       assert_equal nil, Bridgetown::PluginManager.find_npm_dependency(gem_mock)
 
       gem_mock2 = OpenStruct.new(to_spec: OpenStruct.new(metadata: {
-        "npm-add" => "gobbledee@gook@",
+        "npm_add" => "gobbledee@gook@",
       }))
       assert_equal nil, Bridgetown::PluginManager.find_npm_dependency(gem_mock2)
     end

--- a/bridgetown-website/src/_docs/plugins/commands.md
+++ b/bridgetown-website/src/_docs/plugins/commands.md
@@ -7,18 +7,19 @@ category: plugins
 
 Bridgetown plugins can provide commands for the `bridgetown` executable.
 
-Commands are built using the [Thor](https://github.com/erikhuda/thor) CLI
-toolkit, which powers many popular Ruby libraries and frameworks including
-Rails, Bundler, and Middleman.
+Commands are built using the [Thor](https://github.com/rails/thor) CLI toolkit, which also powers many popular Ruby libraries and frameworks.
 
-{%@ Note type: :warning do %}
-  In Bridgetown 1.2, plugin gems which provide new commands won't work unless they're required within a boot file (aka `config/boot.rb`). This is likely to change in a future version of Bridgetown. In the meantime, you'll want to clarify that fact in your plugin gem's README. [More information is available here.](/docs/configuration/initializers#low-level-boot-customization)
-{% end %}
+To provide a comment, add a folder within your gem's `lib` folder with the path `bridgetown/features` and inside save a Ruby file with your exact gem name. Within that file, subclass `Thor` and use a registration block to notify Bridgetown how to include your command (example below).
 
-Subclass `Thor` in your plugin and use a registration block to notify
-Bridgetown how to include your command. Commands are written in a `command [subcommand]`
-format, so if your base command is `river`, your logic will be contained
-within one or more subcommands:
+You will also need to add a clause in your `.gemspec` to notify Bridgetown a command-line feature should be loaded:
+
+```ruby
+spec.metadata = {
+  "bridgetown_features" => "true"
+}
+```
+
+Commands are written in a `command [subcommand]` format, so if your base command is `river`, your logic will be contained within one or more subcommands:
 
 ```
 bridgetown river # outputs a help message about the available subcommands
@@ -26,13 +27,13 @@ bridgetown river bank
 bridgetown river flows
 ```
 
-You can also use the `ConfigurationOverridable` concern to load the
-`bridgetown.config.yml` configuration and optionally override keys with
-command line options passed to your command.
+You can also use the `ConfigurationOverridable` concern to load the site configuration and optionally override keys with command line options passed to your command.
 
 Here's an example of how to write a `Thor` subclass:
 
 ```ruby
+# lib/bridgetown/features/my_example_plugin.rb
+
 require_all "bridgetown-core/commands/concerns"
 
 module MyPlugin
@@ -63,8 +64,7 @@ module MyPlugin
 end
 ```
 
-In addition, if you want full access to [automations](/docs/automations) from
-within your command, you can include the Thor and custom Bridgetown actions:
+In addition, if you want full access to [automations](/docs/automations) from within your command, you can include the Thor and custom Bridgetown actions:
 
 ```ruby
 include Thor::Actions

--- a/bridgetown-website/src/_docs/plugins/gems-and-frontend.md
+++ b/bridgetown-website/src/_docs/plugins/gems-and-frontend.md
@@ -13,11 +13,11 @@ do this is to set up a `package.json` manifest and [publish your frontend code a
 
 Let's assume you've been building an awesome plugin called, unsurprisingly,
 `MyAwesomePlugin`. In your `my-awesome-plugin.gemspec` file, all you need to do is
-add the `npm-add` metadata matching the NPM package name and keeping the version
+add the `npm_add` metadata matching the NPM package name and keeping the version
 the same as the Gem version:
 
 ```ruby
-  spec.metadata = { "npm-add" => "my-awesome-plugin@#{MyAwesomePlugin::VERSION}" }
+  spec.metadata = { "npm_add" => "my-awesome-plugin@#{MyAwesomePlugin::VERSION}" }
 ```
 
 With that bit of metadata, Bridgetown will know always to look for that package in


### PR DESCRIPTION
also fixed an issue for `npm_add` gemspec metadata (it was `npm-add` before but to keep in line with gem conventions, it should use an underscore).

Resolves #905 #990