### PR TITLE
Normalize resource dates as Time objects

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/concerns/publishable.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/publishable.rb
@@ -14,9 +14,7 @@ module Bridgetown
       return false unless published? || @site.config.unpublished
 
       future_allowed = collection.metadata.future || @site.config.future
-      this_time = date.is_a?(Date) ? date.to_time.to_i : date.to_i
-
-      future_allowed || this_time <= @site.time.to_i
+      future_allowed || date <= @site.time
     end
   end
 end

--- a/bridgetown-paginate/lib/bridgetown-paginate/utils.rb
+++ b/bridgetown-paginate/lib/bridgetown-paginate/utils.rb
@@ -79,10 +79,7 @@ module Bridgetown
         return -1 if a.nil? && !b.nil?
         return 1 if !a.nil? && b.nil?
         return a.downcase <=> b.downcase if a.is_a?(String)
-
-        if a.respond_to?(:to_datetime) && b.respond_to?(:to_datetime)
-          return a.to_datetime <=> b.to_datetime
-        end
+        return a.to_time <=> b.to_time if a.respond_to?(:to_time) && b.respond_to?(:to_time)
 
         # By default use the built in sorting for the data type
         a <=> b


### PR DESCRIPTION
In a confusing manner, the YAML importer was interpreting a variable like `date: 2025-10-25` as a `Date` object, whereas `date: 2025-10-25 10:11:12` would be interpreted as a `Time` object. This resulted in resources in a collection having a mixture of Date and Time objects. Apparently some of the Active Support infrastructure loaded in under the hood was obfuscating these differences in terms of sort comparisons, but now as we migrate off of that it's revealing the gaps.

This PR normalizes resource dates so that they're _always_ `Time` objects (the time of the date would be `00:00:00` aka 12:00AM). While that's a little confusing that the front matter key is `date` but the value is a Time object, I think it would be more confusing if we had used `time` in front matter (in the vernacular, people don't really think of times as having a date component).

**BREAKING CHANGE**: this _might_ impact anyone who's written code dealing with Date objects specifically.
