### PR TITLE
feat: add support for wikilinks in Markdown via initializer

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration.rb
@@ -6,7 +6,7 @@ module Bridgetown
     using Bridgetown::Refinements
 
     # Built-in initializer list which isn't Gem-backed:
-    REQUIRE_DENYLIST = %i(external_sources parse_routes ssr) # rubocop:disable Style/MutableConstant
+    REQUIRE_DENYLIST = %i(external_sources parse_routes ssr wikilinks) # rubocop:disable Style/MutableConstant
 
     Initializer = Struct.new(:name, :block, :completed) do
       def to_s

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -9,6 +9,7 @@ module Bridgetown
     autoload :RequireGems, "bridgetown-core/utils/require_gems"
     autoload :RubyExec, "bridgetown-core/utils/ruby_exec"
     autoload :SmartyPantsConverter, "bridgetown-core/utils/smarty_pants_converter"
+    autoload :Wikilinks, "bridgetown-core/utils/wikilinks"
 
     # Constants for use in #slugify
     SLUGIFY_MODES = %w(raw default pretty simple ascii latin).freeze

--- a/bridgetown-core/lib/bridgetown-core/utils/initializers.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/initializers.rb
@@ -80,3 +80,7 @@ Bridgetown.initializer :parse_routes do |config|
 
   File.write(File.join(config.root_dir, ".routes.json"), routing_tree.to_json(json_gen_opts))
 end
+
+Bridgetown.initializer :wikilinks do |config|
+  Bridgetown::Utils::Wikilinks.setup_parsing_hook config
+end

--- a/bridgetown-core/lib/bridgetown-core/utils/wikilinks.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils/wikilinks.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module Utils
+    class Wikilinks
+      # @param config [Bridgetown::Configuration::ConfigurationDSL]
+      def self.setup_parsing_hook(config)
+        markdown_exts = config.markdown_ext.split(",").map { ".#{_1}" }
+
+        config.hook :resources, :pre_render, priority: :low do |resource|
+          next unless markdown_exts.include?(resource.relative_path.extname)
+          next if resource.data.bypass_wikilinks
+
+          Wikilinks.new(resource:).convert
+        end
+      end
+
+      # @param resource [Bridgetown::Resource::Base]
+      def initialize(resource:)
+        @resource = resource
+        @site = resource.site
+      end
+
+      # Sets the resource's new content to the parsed string where `[[Wiki-style Links]]` are
+      # turned into `[Wiki-style Links](...)`
+      def convert
+        @resource.content = parse_content(@resource.content)
+      end
+
+      # Parse all `[[wiki links]]` unless they're escaped, e.g. `\[[don't parse me bro]]`.
+      # You can use a pipe character to control the displayed text of the link:
+      # `[[Actual page title|Link text here]]`, and you can also add an anchor for the link:
+      # `[[Page Title#page_section_anchor]]`
+      # @param input [String]
+      # @return String
+      def parse_content(input)
+        input.gsub %r!(\\?)\[\[(.+?)\]\]! do
+          next "[[#{Regexp.last_match[2]}]]" if Regexp.last_match[1] == "\\"
+
+          search_title, printed_title =
+            Regexp.last_match[2].split("|").map(&:strip)
+          search_title, anchor = search_title.split("#")
+          anchor = "##{anchor}" if anchor
+          title = printed_title || search_title
+          found = @site.resources.find { _1.data.title == search_title }
+          if found
+            "[#{title}](#{found.relative_url}#{anchor}){:.wikilink}"
+          else
+            missing_title_strategy(title)
+          end
+        end
+      end
+
+      def missing_title_strategy(title)
+        # TODO: this should be configurable
+        "<u>#{title} (missing)</u>"
+      end
+    end
+  end
+end

--- a/bridgetown-core/test/features/test_wikilinks.rb
+++ b/bridgetown-core/test/features/test_wikilinks.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "features/feature_helper"
+
+# Wiki-style links should be converted to regular Markdown (and then anchor tags)
+class TestWikilinks < BridgetownFeatureTest
+  describe "wikilinks initializer" do
+    it "converts wikilinks to Markdown" do
+      create_directory "config"
+      create_file "config/initializers.rb", <<~RUBY
+        Bridgetown.configure do |config|
+          init :wikilinks
+        end
+      RUBY
+
+      create_directory "_posts"
+      create_page "_posts/link-all-things.md",
+                  "This should render [[Additional Page|a page]] and [[Also This Page#section-title]] but \\[[Additional Page]] should remain plain.",
+                  date: "2026-04-26"
+
+      create_page "_posts/one-additional-page.md",
+                  "Content",
+                  title: "Additional Page",
+                  date: "2026-04-25"
+      create_page "also-page.md", "Content", title: "Also This Page"
+
+      run_bridgetown "build"
+
+      assert_file_contains "<p>This should render <a href=\"/2026/04/25/one-additional-page/\" class=\"wikilink\">a page</a> and <a href=\"/also-page/#section-title\" class=\"wikilink\">Also This Page</a> but [[Additional Page]] should remain plain.</p>\n",
+                           "output/2026/04/26/link-all-things/index.html"
+    end
+  end
+end

--- a/bridgetown-website/Gemfile.lock
+++ b/bridgetown-website/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: ../bridgetown-builder
   specs:
-    bridgetown-builder (2.1.1)
-      bridgetown-core (= 2.1.1)
+    bridgetown-builder (2.1.2)
+      bridgetown-core (= 2.1.2)
 
 PATH
   remote: ../bridgetown-core
   specs:
-    bridgetown-core (2.1.1)
+    bridgetown-core (2.1.2)
       addressable (~> 2.4)
       amazing_print (~> 1.2)
       base64 (>= 0.3)
       bigdecimal (>= 3.2)
-      bridgetown-foundation (= 2.1.1)
+      bridgetown-foundation (= 2.1.2)
       csv (~> 3.2)
       erubi (~> 1.9)
       faraday (~> 2.0)
@@ -40,7 +40,7 @@ PATH
 PATH
   remote: ../bridgetown-foundation
   specs:
-    bridgetown-foundation (2.1.1)
+    bridgetown-foundation (2.1.2)
       dry-inflector (>= 1.0)
       hash_with_dot_access (~> 2.0)
       inclusive (~> 1.0)
@@ -49,17 +49,17 @@ PATH
 PATH
   remote: ../bridgetown-paginate
   specs:
-    bridgetown-paginate (2.1.1)
-      bridgetown-core (= 2.1.1)
+    bridgetown-paginate (2.1.2)
+      bridgetown-core (= 2.1.2)
 
 PATH
   remote: ../bridgetown
   specs:
-    bridgetown (2.1.1)
-      bridgetown-builder (= 2.1.1)
-      bridgetown-core (= 2.1.1)
-      bridgetown-foundation (= 2.1.1)
-      bridgetown-paginate (= 2.1.1)
+    bridgetown (2.1.2)
+      bridgetown-builder (= 2.1.2)
+      bridgetown-core (= 2.1.2)
+      bridgetown-foundation (= 2.1.2)
+      bridgetown-paginate (= 2.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/bridgetown-website/config/initializers.rb
+++ b/bridgetown-website/config/initializers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Bridgetown.configure do |config|
+  init :wikilinks
   init :"bridgetown-seo-tag"
   init :"bridgetown-feed"
   init :"bridgetown-quick-search"

--- a/bridgetown-website/src/_docs/automations.md
+++ b/bridgetown-website/src/_docs/automations.md
@@ -10,7 +10,7 @@ tasks such as adding gems, updating configuration, inserting code, copying
 files, and much more.
 
 Automations are similar in concept to Gatsby Recipes or Rails App Templates.
-They're uniquely powerful when combined with [plugins](/docs/plugins), as an
+They're uniquely powerful when combined with [[Extend with Plugins|plugins]], as an
 automation can install and configure one or more plugins from a single script.
 
 You could also write an automation to run multiple additional automations, and
@@ -18,7 +18,7 @@ apply that to a brand-new site to set everything up exactly how you want it in a
 repeatable and automatic fashion.
 
 Automations can be loaded from a local path, or they can be loaded from remote
-URLs including repositories. You can also run automation scripts [from within Rake tasks](/docs/command-line-usage#rakefile-and-rake-tasks), and the exact same automation DSL can be used directly within [custom commands](/docs/plugins/commands).
+URLs including repositories. You can also run automation scripts [[Command Line Usage#rakefile-and-rake-tasks|from within Rake tasks]], and the exact same automation DSL can be used directly within [[Commands|custom commands]].
 
 {%@ Note type: :warning do %}
 As with any other case where you are executing code downloaded from the Internet, **this is a potential security risk!** Make sure you apply automations from only those sources you are able to trust (and verify)!

--- a/bridgetown-website/src/_docs/configuration/initializers.md
+++ b/bridgetown-website/src/_docs/configuration/initializers.md
@@ -342,6 +342,10 @@ Now anywhere in your Ruby plugins, templates, etc., you can access environment v
 
 You can load in additional content, such as Markdown files and associated images, from folders outside of a Bridgetown site project. [Read this documentation to learn more.](/docs/content/external-sources)
 
+### Wikilinks
+
+You can enable `\[[wikilinks]]` style links within your Markdown content. [[Resources#wikilinks|Read this documentation to learn more]].
+
 ### Inflector
 
 You can configure the inflector used by Zeitwerk and models. A few acronyms are provided by default like HTML, CSS, and JS, so a file like `html_processor.rb` could be defined by `HTMLProcessor`. You can add more inflection rules like so:

--- a/bridgetown-website/src/_docs/resources.md
+++ b/bridgetown-website/src/_docs/resources.md
@@ -275,7 +275,7 @@ By default, Bridgetown will search all of your resources and find the first matc
 
 You can also use a custom display title for your link, for example `\[[I am a Resource|here's a resource]]` would render "here's a resource" as the link text.
 
-If you need to link to a specific section within a resource (aka anchor), use a `#` symbol: `\[[Another Page#the_best_section]]`. You may need to inspect the HTML of a resource to ensure you're linking to the correct anchor within the content.
+If you need to link to a specific section within a resource (aka anchor), use a `#` symbol: `\[[Another Page#the-best-section]]`. You may need to inspect the HTML of a resource to ensure you're linking to the correct anchor within the content.
 
 If you'd like to opt-out any resource from being processed for wikilinks, add `bypass_wikilinks: true` to its front matter. To disable multiple resources at once, you can use [[Front Matter Defaults]].
 

--- a/bridgetown-website/src/_docs/resources.md
+++ b/bridgetown-website/src/_docs/resources.md
@@ -263,6 +263,22 @@ The inflections between the various singular and plural relation names are handl
 
 You can also load resources for your project, such as Markdown files and associated images, from folders outside of a Bridgetown site project. This is ideal for content authored using third-party applications such as Obsidian. [Read this documentation to learn more.](/docs/content/external-sources)
 
+## Wikilinks
+
+You can add support for `\[[wikilinks]]` style links within your Markdown content. This isn't enabled by default, so you'll need to update your `config/initializers.rb` file and add:
+
+```ruby
+init :wikilinks
+```
+
+By default, Bridgetown will search all of your resources and find the first matching title. So if you have a resource with `title: I am a Resource` in its front matter, you can write `\[[I am a Resource]]` to link to it.
+
+You can also use a custom display title for your link, for example `\[[I am a Resource|here's a resource]]` would render "here's a resource" as the link text.
+
+If you need to link to a specific section within a resource (aka anchor), use a `#` symbol: `\[[Another Page#the_best_section]]`. You may need to inspect the HTML of a resource to ensure you're linking to the correct anchor within the content.
+
+If you'd like to opt-out any resource from being processed for wikilinks, add `bypass_wikilinks: true` to its front matter. To disable multiple resources at once, you can use [[Front Matter Defaults]].
+
 ## Configuring Permalinks
 
 Bridgetown uses permalink "templates" to determine the default permalink to use for resource destination URLs. You can override a resource permalink on a case-by-case basis by using the `permalink` front matter key. Otherwise, the permalink is determined as follows (unless you change the site config):


### PR DESCRIPTION
Closes #1027 

This PR adds support for wikilinks in Markdown files when the `wikilinks` initializer is added to a project, aka `[[Link to a Page]]` will be turned into `[Link to a Page](/page-url/)`. It supports a pipe for using arbitrary display text of the link, as well as an anchor for linking to a specific section.

In the issue I speculated that there might be a more sophisticated approach than regex, but in the end it seemed like the simplest solution (especially since there's an easy way to add an escape backslash). Plus, you can opt out certain pages via `bypass_wikilinks: true` in front matter.

# TODO

- [x] Tests
- [x] Documentation