### PR TITLE
Use Net::HTTP instead of Faraday

### DIFF
--- a/bridgetown-core/lib/bridgetown-core.rb
+++ b/bridgetown-core/lib/bridgetown-core.rb
@@ -29,6 +29,7 @@ require "logger"
 require "csv"
 require "json"
 require "yaml"
+require "net/http"
 
 # Pull in Foundation gem
 require "bridgetown-foundation"

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -400,7 +400,7 @@ module Bridgetown
     def default_github_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::GITHUB_REPO_REGEX.match(repo_url)
       api_endpoint = "https://api.github.com/repos/#{repo_match[1]}"
-      JSON.parse(Faraday.get(api_endpoint).body)["default_branch"] || "main"
+      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to GitHub API: #{e.message}")
       "main"
@@ -409,7 +409,7 @@ module Bridgetown
     def default_gitlab_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::GITLAB_REPO_REGEX.match(repo_url)
       api_endpoint = "https://gitlab.com/api/v4/projects/#{repo_match[1].sub("/", "%2F")}"
-      JSON.parse(Faraday.get(api_endpoint).body)["default_branch"] || "main"
+      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to GitLab API: #{e.message}")
       "main"
@@ -418,7 +418,7 @@ module Bridgetown
     def default_codeberg_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::CODEBERG_REPO_REGEX.match(repo_url)
       api_endpoint = "https://codeberg.org/api/v1/repos/#{repo_match[1]}"
-      JSON.parse(Faraday.get(api_endpoint).body)["default_branch"] || "main"
+      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to Codeberg API: #{e.message}")
       "main"

--- a/bridgetown-core/lib/bridgetown-core/utils.rb
+++ b/bridgetown-core/lib/bridgetown-core/utils.rb
@@ -399,8 +399,8 @@ module Bridgetown
 
     def default_github_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::GITHUB_REPO_REGEX.match(repo_url)
-      api_endpoint = "https://api.github.com/repos/#{repo_match[1]}"
-      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
+      api_endpoint = URI("https://api.github.com/repos/#{repo_match[1]}")
+      JSON.parse(Net::HTTP.get(api_endpoint))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to GitHub API: #{e.message}")
       "main"
@@ -408,8 +408,8 @@ module Bridgetown
 
     def default_gitlab_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::GITLAB_REPO_REGEX.match(repo_url)
-      api_endpoint = "https://gitlab.com/api/v4/projects/#{repo_match[1].sub("/", "%2F")}"
-      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
+      api_endpoint = URI("https://gitlab.com/api/v4/projects/#{repo_match[1].sub("/", "%2F")}")
+      JSON.parse(Net::HTTP.get(api_endpoint))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to GitLab API: #{e.message}")
       "main"
@@ -417,8 +417,8 @@ module Bridgetown
 
     def default_codeberg_branch_name(repo_url)
       repo_match = Bridgetown::Commands::Automations::CODEBERG_REPO_REGEX.match(repo_url)
-      api_endpoint = "https://codeberg.org/api/v1/repos/#{repo_match[1]}"
-      JSON.parse(Net::HTTP.get(URI(api_endpoint)))["default_branch"] || "main"
+      api_endpoint = URI("https://codeberg.org/api/v1/repos/#{repo_match[1]}")
+      JSON.parse(Net::HTTP.get(api_endpoint))["default_branch"] || "main"
     rescue StandardError => e
       Bridgetown.logger.warn("Unable to connect to Codeberg API: #{e.message}")
       "main"

--- a/bridgetown-core/test/test_utils.rb
+++ b/bridgetown-core/test/test_utils.rb
@@ -406,6 +406,34 @@ class TestUtils < BridgetownUnitTest
     end
   end
 
+  describe "The `Utils.default_gitlab_branch_name` method" do
+    it "returns the correct default branch name" do
+      Net::HTTP.stub :get, JSON.generate({ "default_branch" => "my_default_branch" }) do
+        assert_equal "my_default_branch", Utils.default_gitlab_branch_name("https://gitlab.com/whitefusionhq/phaedra/abc/12344")
+      end
+    end
+
+    it "returns main if all else fails" do
+      Net::HTTP.stub :get, proc { raise("nope") } do
+        assert_equal "main", Utils.default_gitlab_branch_name("https://gitlab.com/thisorgdoesntexist/thisrepoistotallybogus")
+      end
+    end
+  end
+
+  describe "The `Utils.default_codeberg_branch_name` method" do
+    it "returns the correct default branch name" do
+      Net::HTTP.stub :get, JSON.generate({ "default_branch" => "my_default_branch" }) do
+        assert_equal "my_default_branch", Utils.default_codeberg_branch_name("https://codeberg.org/whitefusionhq/phaedra/abc/12344")
+      end
+    end
+
+    it "returns main if all else fails" do
+      Net::HTTP.stub :get, proc { raise("nope") } do
+        assert_equal "main", Utils.default_codeberg_branch_name("https://codeberg.org/thisorgdoesntexist/thisrepoistotallybogus")
+      end
+    end
+  end
+
   describe "The `Utils.helper_code_for_template_extname` method" do
     it "returns content within delimiters for the supplied file extname" do
       assert_equal "{% content %}", Utils.helper_code_for_template_extname(".liquid", "content")

--- a/bridgetown-core/test/test_utils.rb
+++ b/bridgetown-core/test/test_utils.rb
@@ -394,13 +394,13 @@ class TestUtils < BridgetownUnitTest
 
   describe "The `Utils.default_github_branch_name` method" do
     it "returns the correct default branch name" do
-      Faraday.stub :get, HashWithDotAccess::Hash.new(body: JSON.generate({ "default_branch" => "my_default_branch" })) do
+      Net::HTTP.stub :get, JSON.generate({ "default_branch" => "my_default_branch" }) do
         assert_equal "my_default_branch", Utils.default_github_branch_name("https://github.com/whitefusionhq/phaedra/abc/12344")
       end
     end
 
     it "returns main if all else fails" do
-      Faraday.stub :get, proc { raise("nope") } do
+      Net::HTTP.stub :get, proc { raise("nope") } do
         assert_equal "main", Utils.default_github_branch_name("https://github.com/thisorgdoesntexist/thisrepoistotallybogus")
       end
     end

--- a/bridgetown-website/src/_pages/plugins.serb
+++ b/bridgetown-website/src/_pages/plugins.serb
@@ -6,21 +6,19 @@
     ::Builders::Versions.cache.getset("plugins") do
       endpoint = "https://api.github.com/search/repositories?q=topic:bridgetown-plugin%20archived:false&per_page=100"
 
-      conn = Faraday.new(
-        url: endpoint,
-        headers: {"Accept" => "application/vnd.github.v3+json"}
-      ) do |faraday|
-        if ENV["BRIDGETOWN_GITHUB_TOKEN"]
-          username, token = ENV["BRIDGETOWN_GITHUB_TOKEN"].split(":")
-          faraday.request :authorization, :basic, username, token
-        end
+      headers = {"Accept" => "application/vnd.github.v3+json"}
+      request = Net::HTTP::Get.new(URI(endpoint), headers)
+      if ENV["BRIDGETOWN_GITHUB_TOKEN"]
+        username, token = ENV["BRIDGETOWN_GITHUB_TOKEN"].split(":")
+        request.basic_auth(username, token)
       end
-      items = JSON.parse(conn.get.body)["items"].sort_by {|item| item["name"]}
+      result = Net::HTTP.get(URI(endpoint), headers)
+      items = JSON.parse(result)["items"].sort_by {|item| item["name"]}
 
       items.each do |item|
         branchname = item.fetch("default_branch", "master")
         gem_url = "https://raw.githubusercontent.com/#{item["full_name"]}/#{branchname}/lib/#{item["name"]}/version.rb"
-        result = Faraday.get(gem_url).body
+        result = Net::HTTP.get(URI(gem_url))
         begin
           item["gem_version"] = result.match(/VERSION = "(.*?)"/)[1]
         rescue NoMethodError

--- a/bridgetown-website/src/_pages/plugins.serb
+++ b/bridgetown-website/src/_pages/plugins.serb
@@ -4,21 +4,21 @@
   exclude_from_search: true,
   plugins: -> do
     ::Builders::Versions.cache.getset("plugins") do
-      endpoint = "https://api.github.com/search/repositories?q=topic:bridgetown-plugin%20archived:false&per_page=100"
+      endpoint = URI("https://api.github.com/search/repositories?q=topic:bridgetown-plugin%20archived:false&per_page=100")
 
       headers = {"Accept" => "application/vnd.github.v3+json"}
-      request = Net::HTTP::Get.new(URI(endpoint), headers)
+      request = Net::HTTP::Get.new(endpoint, headers)
       if ENV["BRIDGETOWN_GITHUB_TOKEN"]
         username, token = ENV["BRIDGETOWN_GITHUB_TOKEN"].split(":")
         request.basic_auth(username, token)
       end
-      result = Net::HTTP.get(URI(endpoint), headers)
+      result = Net::HTTP.get(endpoint, headers)
       items = JSON.parse(result)["items"].sort_by {|item| item["name"]}
 
       items.each do |item|
         branchname = item.fetch("default_branch", "master")
-        gem_url = "https://raw.githubusercontent.com/#{item["full_name"]}/#{branchname}/lib/#{item["name"]}/version.rb"
-        result = Net::HTTP.get(URI(gem_url))
+        gem_url = URI("https://raw.githubusercontent.com/#{item["full_name"]}/#{branchname}/lib/#{item["name"]}/version.rb")
+        result = Net::HTTP.get(gem_url)
         begin
           item["gem_version"] = result.match(/VERSION = "(.*?)"/)[1]
         rescue NoMethodError


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've read our Contributing Guide, including the section regarding
  AI-generated code. (TL;DR: we do not accept AI-generated code. ☺️)

  https://github.com/bridgetownrb/bridgetown/blob/main/CONTRIBUTING.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Replaces uses of Faraday with Net::HTTP.

As far as I can tell, [the features that Net::HTTP lacks](https://honeyryderchuck.gitlab.io/2023/10/15/state-of-ruby-http-clients-use-httpx.html#features) compared to Faraday don't matter for the two uses that are being replaced in this PR.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Partially addresses #1089. That issue will be fully resolved at Bridgetown 3.0, when we remove the Faraday dependencies from `bridgetown-core`.

## Manual tests

Of an automation that uses the changed `default_github_branch_name` method:

<img width="1472" height="182" alt="Screen Shot 2026-04-27 at 6 36 37 AM" src="https://github.com/user-attachments/assets/7ec7b732-e4b7-4ce7-ac6f-65505e65e8d8" />

<br>
