### PR TITLE
Add no-op `roda_app` accessor to `GeneratedPage`

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/generated_page.rb
+++ b/bridgetown-core/lib/bridgetown-core/generated_page.rb
@@ -25,6 +25,13 @@ module Bridgetown
       .htm
     ).freeze
 
+    # NOTE: these are no-op methods, only here to provide "compatibility" with
+    # `Bridgetown::Resource::Base` in edge case rendering contexts. There's
+    # actually no case when a GeneratedPage will have a linkage with the Roda
+    # app because GeneratedPage instances are only used in static builds.
+    def roda_app=(*); end
+    def roda_app = nil
+
     # Initialize a new GeneratedPage
     #
     # @param site [Bridgetown::Site]


### PR DESCRIPTION
This is to address an obscure rendering edge case involving paginated pages and a layout / partial templates mismatch (aka ERB layout, Serbea partials). Came up while working on: https://codeberg.org/bridgetownrb/willamette/issues/15