### PR TITLE
Dup `ARGV` passed to Bridgetown CLI so later access to ARGV gets complete data

### DIFF
--- a/bridgetown-core/bin/bridgetown
+++ b/bridgetown-core/bin/bridgetown
@@ -31,7 +31,7 @@ custom_commands_file = File.expand_path("config/custom_commands.rb", Dir.pwd)
 require custom_commands_file if File.exist?(custom_commands_file)
 
 begin
-  Bridgetown::Commands::Application.parse(ARGV).call
+  Bridgetown::Commands::Application.parse(ARGV.dup).call
 rescue Samovar::MissingValueError => e
   puts "#{"Command error:".bold.red} #{e.message.to_s.yellow}\n\n"
   e.command.print_usage

--- a/bridgetown-core/lib/bridgetown-core/commands/help.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/help.rb
@@ -5,7 +5,7 @@ module Bridgetown
     class Help < Bridgetown::Command
       self.description = "Show detailed command usage information and exit"
 
-      one :command, "The name of a Bridgetown command", required: true
+      one :command, "The name of a Bridgetown command", required: false
 
       def call
         found_command = parent.class.table[:command].commands[command]
@@ -14,7 +14,7 @@ module Bridgetown
 
         return if found_command
 
-        puts "Unknown command: #{command}\n\n"
+        puts "Unknown command: #{command}\n\n" if command
         parent.print_usage
       end
     end


### PR DESCRIPTION
Fixes #1100

Also make the `help` command just print help without a specific command passed in