### PR TITLE
fix: accept array arguments in config

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
+++ b/bridgetown-core/lib/bridgetown-core/configuration/configuration_dsl.rb
@@ -244,38 +244,41 @@ module Bridgetown
       #   Control the behavior of Bridgetown's live reload functionality in development
       #   @param bool [Boolean] - default: `true`
 
-      # @!method exclude(files_list)
-      #   Exclude source directories and/or files from the build conversion
-      #   @param files_list [Array<String>]
+      # Exclude source directories and/or files from the build conversion
+      # @param files_list [Array<String>] - you can pass multiple string arguments
+      #   in lieu of an array
       def exclude(*files_list)
+        files_list = Array(files_list[0]) if files_list.length == 1
         get("exclude").tap do |value|
-          files_list.each { value << _1 } if files_list.size.positive?
+          files_list.each { value << _1 }
         end
       end
 
-      # @!method include(files_list)
-      #   Force inclusion of directories and/or files in the conversion (e.g. starting with
-      #   underscores or dots)
-      #   @param files_list [Array<String>]
+      # Force inclusion of directories and/or files in the conversion (e.g. starting with
+      # underscores or dots)
+      # @param files_list [Array<String>] - you can pass multiple string arguments
+      #   in lieu of an array
       def include(*files_list)
+        files_list = Array(files_list[0]) if files_list.length == 1
         get("include").tap do |value|
-          files_list.each { value << _1 } if files_list.size.positive?
+          files_list.each { value << _1 }
         end
       end
 
-      # @!method keep_files(files_list)
-      #   Files to keep when clobbering the site destination (aka not generated in typical
-      #   Bridgetown builds)
-      #   @param files_list [Array<String>]
+      # Files to keep when clobbering the site destination (aka not generated in typical
+      # Bridgetown builds)
+      # @param files_list [Array<String>] - you can pass multiple string arguments
+      #   in lieu of an array
       def keep_files(*files_list)
+        files_list = Array(files_list[0]) if files_list.length == 1
         get("keep_files").tap do |value|
-          files_list.each { value << _1 } if files_list.size.positive?
+          files_list.each { value << _1 }
         end
       end
 
       # @!method autoload_paths
-      #   Add paths to the Zeitwerk autoloader. Use a `config.defaults << "..."` syntax or a more
-      #   advanced hash config
+      #   Add paths to the Zeitwerk autoloader. Use a `config.autoload_paths << "..."` syntax or
+      #   a more advanced hash config
       #   @example Add a new path for autoloading and eager load on boot
       #       config.autoload_paths << {
       #         path: "loadme",

--- a/bridgetown-core/test/test_configuration.rb
+++ b/bridgetown-core/test/test_configuration.rb
@@ -417,5 +417,31 @@ class TestConfiguration < BridgetownUnitTest
         assert_includes @config["exclude"], f
       end
     end
+
+    it "keep_files, include, exclude may accept array of files" do
+      dsl = Configuration::ConfigurationDSL.new(scope: @config, data: @config)
+
+      dsl.instance_variable_set(:@context, :testing)
+      dsl.instance_exec(dsl) do
+        keep_files ["some_file1.txt"]
+        keep_files ["some_file2.txt", "some_file3.txt"]
+
+        include ["some_file4.txt"]
+        include ["some_file5.txt", "some_file6.txt"]
+
+        exclude ["some_file7.txt"]
+        exclude ["some_file8.txt", "some_file9.txt"]
+      end
+
+      ["some_file1.txt", "some_file2.txt", "some_file3.txt"].each do |f|
+        assert_includes @config["keep_files"], f
+      end
+      ["some_file4.txt", "some_file5.txt", "some_file6.txt"].each do |f|
+        assert_includes @config["include"], f
+      end
+      ["some_file7.txt", "some_file8.txt", "some_file9.txt"].each do |f|
+        assert_includes @config["exclude"], f
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow input arrays for `keep_files`, `include`, `exclude`

Building upon the fix for #1079 in the #1081 PR, this allows the first argument to be an array, which means all three of these syntaxes are valid:

```ruby
config.keep_files << "keepme1.txt"; config.keep_files << "keepme2.txt"

config.keep_files "keepme1.txt", "keepme2.txt"

config.keep_files ["keepme1.txt", "keepme2.txt"]
```