### PR TITLE
fix: start/build command and SSR hooks bugs

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/commands/build.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/build.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "bridgetown-core/commands/start"
+
 module Bridgetown
   module Commands
     class Build < Bridgetown::Command
@@ -9,6 +11,7 @@ module Bridgetown
 
       options do
         BuildOptions.include_options(self)
+        Start::StartOptions.include_options(self) if ARGV[0] == "start"
         option "-w/--watch", "Watch for changes and rebuild"
       end
 

--- a/bridgetown-core/lib/bridgetown-core/commands/start.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/start.rb
@@ -28,12 +28,13 @@ module Bridgetown
       module StartOptions
         def self.include_options(klass)
           klass.option "-P/--port <NUM>",
-                 "Serve your site on the specified port. Defaults to 4000",
-                 type: Integer
+                       "Serve your site on the specified port. Defaults to 4000",
+                       type: Integer
           klass.option "-B/--bind <IP>", "IP address for the server to bind to", default: "0.0.0.0"
-          klass.option "--skip-frontend", "Don't load the frontend bundler (always true for production)"
+          klass.option "--skip-frontend",
+                       "Don't load the frontend bundler (always true for production)"
           klass.option "--skip-live-reload",
-                 "Don't use the live reload functionality (always true for production)"
+                       "Don't use the live reload functionality (always true for production)"
         end
       end
 

--- a/bridgetown-core/lib/bridgetown-core/commands/start.rb
+++ b/bridgetown-core/lib/bridgetown-core/commands/start.rb
@@ -25,6 +25,18 @@ module Bridgetown
 
   module Commands
     class Start < Bridgetown::Command
+      module StartOptions
+        def self.include_options(klass)
+          klass.option "-P/--port <NUM>",
+                 "Serve your site on the specified port. Defaults to 4000",
+                 type: Integer
+          klass.option "-B/--bind <IP>", "IP address for the server to bind to", default: "0.0.0.0"
+          klass.option "--skip-frontend", "Don't load the frontend bundler (always true for production)"
+          klass.option "--skip-live-reload",
+                 "Don't use the live reload functionality (always true for production)"
+        end
+      end
+
       include ConfigurationOverridable
       include Freyia::Setup
       include Inclusive
@@ -33,13 +45,7 @@ module Bridgetown
 
       options do
         BuildOptions.include_options(self)
-        option "-P/--port <NUM>",
-               "Serve your site on the specified port. Defaults to 4000",
-               type: Integer
-        option "-B/--bind <IP>", "IP address for the server to bind to", default: "0.0.0.0"
-        option "--skip-frontend", "Don't load the frontend bundler (always true for production)"
-        option "--skip-live-reload",
-               "Don't use the live reload functionality (always true for production)"
+        StartOptions.include_options(self)
       end
 
       def call # rubocop:disable Metrics

--- a/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
+++ b/bridgetown-core/lib/bridgetown-core/concerns/site/ssr.rb
@@ -45,7 +45,6 @@ class Bridgetown::Site
     end
 
     def ssr_first_read
-      Bridgetown::Hooks.trigger :site, :pre_read, self
       defaults_reader.tap do |d|
         d.path_defaults.clear
         d.read


### PR DESCRIPTION
Due to a recent refactor (in prep for 2.2 release), there was bug where start command-only arguments would crash the build command. A different but related bug was actually present in 2.1, which was that build command arguments were being swallowed entirely. The refactor revealed the issue with an overt error. The underlying problem is now fixed in this PR.

----

In addition, there has accidentally been a duplication of the `pre_read` hook for SSR mode in Bridgetown 2.0+. This resulted in Builders being run through twice, which in turn would result in hooks being defined twice…like HTML Inspectors. That's how I noticed it: I had deployed a site to production with an HTML inspector, and was puzzled to see on an SSR route that the logic of the inspector had run a second time (thus a second added DOM node when only one DOM node was supposed to have been added).

**This problem was obscured** due to a Ruby execution quirk "in development" I had absolutely no success in tracking down ☹️ —apparently when setting up the sidecar frontend Rake task, it somehow made it so some/all duplicated hooks weren't in action, and thus the SSR route looked correct. Avoid running the Rake task, and the problem comes back. _wuuuuuut_

I was afraid my fix might result in _no_ hook being run at all! But instead both scenarios seem to work as advertised. Spooky.