### PR TITLE
Add mentions and links to Willamette in various docs locations

### DIFF
--- a/bridgetown-website/bridgetown.config.yml
+++ b/bridgetown-website/bridgetown.config.yml
@@ -10,7 +10,7 @@ collections:
     sort_by: order
     name: Documentation
   plugins:
-    output: true
+    output: false
 
 pagination:
   enabled: true

--- a/bridgetown-website/frontend/styles/theme-dark.css
+++ b/bridgetown-website/frontend/styles/theme-dark.css
@@ -200,11 +200,14 @@
   & sl-button[variant="primary"]::part(base) {
     color: var(--color-lighter-green);
     border-color: var(--color-lighter-green);
-    background-color: var(--sl-color-primary-500);
 
     &:hover {
       background-color: var(--sl-color-primary-600);
     }
+  }
+
+  & sl-button[variant="primary"]:not([outline])::part(base) {
+    background-color: var(--sl-color-primary-500);
   }
 
   & table.settings p.default code {

--- a/bridgetown-website/src/_docs/configuration/willamette.md
+++ b/bridgetown-website/src/_docs/configuration/willamette.md
@@ -1,0 +1,19 @@
+---
+title: Willamette, a First-Party Bridgetown Theme
+order: 0
+top_section: Configuration
+category: customize-your-site
+back_to: configuration
+---
+
+![Promotional graphic for Willamette theme showing a deep blue river, a while sailboat, and a row of green trees along the riverbank.](https://willamette.bridgetownrb.com/images/willamette-social-share.jpg)
+
+If you're searching for Bridgetown themes to help you get a leg up on your new website project, [Willamette might be what you're looking for!](https://willamette.bridgetownrb.com)
+
+Create blogs, portfolios, documentation sites, galleries, business dashboards, and more. **Willamette** is a new premier open source theme [by the makers of Bridgetown](https://willamette.bridgetownrb.com/2026/05/26/introducing-willamette-first-party-bridgetown-theme/), designed to serve the publishing needs of indie creators & developers.
+
+{: style="text-align: center"}
+<p><sl-button variant="primary" outline href="https://willamette.bridgetownrb.com" target="_blank">
+  Learn More
+  <sl-icon slot="suffix" library="remixicon" name="arrows/arrow-right-s-fill"></sl-icon>
+</sl-button></p>

--- a/bridgetown-website/src/_docs/themes.md
+++ b/bridgetown-website/src/_docs/themes.md
@@ -7,6 +7,10 @@ category: themes
 
 Themes are [plugins](/docs/plugins) you can add to your Bridgetown website which may provide layouts, content, components, and frontend assets, as well as perform other tasks to enhance the functionality of your site.
 
+{%@ Note do %}
+You may be interested in [Willamette, our first-party theme.](https://willamette.bridgetownrb.com) Create blogs, portfolios, documentation sites, galleries, business dashboards, and more!
+{% end %}
+
 You install a theme the same way you'd install any plugin, either by running a command such as:
 
 ```sh
@@ -24,9 +28,8 @@ The theme creator will typically provide instructions on how to use the provided
 Sometimes you might want to copy files out of a theme and into your site repo directly. The [`bridgetown plugins cd` command](/docs/commands/plugins#copying-files-out-of-plugin-source-folders) will help you do exactly that.
 
 {%@ Note do %}
-Looking for a theme to install on your site?
 [Check out our plugins directory](/plugins/) for a growing collection of themes
-and other useful plugins!
+and other useful plugins.
 {% end %}
 
 ## Creating a Theme
@@ -39,4 +42,6 @@ To provide frontend assets via esbuild, [follow these instructions](/docs/plugin
 
 To aid your users in installing your plugin and setting up configuration options and so forth, add a `bridgetown.automation.rb` [automation script](/docs/automations) to your theme repo.
 
-As always, if you have any questions or need support in creating your theme, [check out our community resources](/community).
+Our [Willamette theme](https://willamette.bridgetownrb.com) can help provide you a leg up…we're more than happy if you base parts of your new theme on how Willamette sets up things!
+
+And as always, if you have any questions or need support in creating your theme, [check out our community resources](/community).

--- a/bridgetown-website/src/_posts/2020/2020-04-18-whats-the-deal-with-themes.md
+++ b/bridgetown-website/src/_posts/2020/2020-04-18-whats-the-deal-with-themes.md
@@ -3,6 +3,7 @@ title: What's the Deal with Themes?
 subtitle: Why Bridgetown is making a clean break with the past and building an entirely new framework for creating and using themes.
 author: jared
 category: future
+exclude_from_search: true
 ---
 
 If you're familiar with Jekyll—or really any web publishing system out there—you're no doubt familiar with the idea of a _theme_. You browse a collection of themes, find one that looks good, go to your website tool and press a button/type a command/upload a package, and _presto change-o_! You've got yourself a shiny new website. Everybody loves themes, right?

--- a/bridgetown-website/src/_posts/2020/2020-05-07-postcss-tailwind-plugins-oh-my.md
+++ b/bridgetown-website/src/_posts/2020/2020-05-07-postcss-tailwind-plugins-oh-my.md
@@ -3,6 +3,7 @@ title: PostCSS, Tailwind, Plugins…Oh My!
 subtitle: For you diehard fans of Tailwind CSS out there, Andrew Mason has got you covered. Also, we now have a GitHub-sourced Plugins directory!
 author: jared
 category: news
+exclude_from_search: true
 ---
 
 {%@ Note type: :warning do %}

--- a/bridgetown-website/src/_posts/2020/2020-05-18-whats-new-in-0.14-hazelwood.md
+++ b/bridgetown-website/src/_posts/2020/2020-05-18-whats-new-in-0.14-hazelwood.md
@@ -3,6 +3,7 @@ title: "A Bridge to the Future: What’s New in Bridgetown 0.14 “Hazelwood”"
 subtitle: The biggest public release of Bridgetown since its inception, featuring the brand-new Unified Plugins API, Active Support, and a whole lot more.
 author: jared
 category: release
+exclude_from_search: true
 ---
 
 Bridgetown 0.14 "Hazelwood" is here! 🎉 And it's the biggest public release of Bridgetown since its inception.

--- a/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
+++ b/bridgetown-website/src/_posts/2020/2020-06-18-major-workflow-advances-in-0.15-overlook.md
@@ -3,6 +3,7 @@ title: "Huge Theme and Workflow Advances in Bridgetown 0.15 “Overlook”"
 subtitle: Introducing themes, automations, Liquid Components, testing strategies, and a new Thor-based CLI—all to make your experience building Bridgetown sites a true delight.
 author: jared
 category: release
+exclude_from_search: true
 ---
 
 Whew, a lot has happened since the release of Bridgetown 0.14 "Hazelwood". The community has been growing [on Twitter](https://twitter.com/bridgetownrb) and [in Discord](https://discord.gg/V56yUWR), we've gotten [new sponsors on GitHub](https://github.com/bridgetownrb/bridgetown#special-thanks-to-our-founding-members--), and a ton of work to move the ecosystem forward has been going on behind the scenes.

--- a/bridgetown-website/src/_posts/2020/2020-08-11-bulmatown-theme-and-snipcart.md
+++ b/bridgetown-website/src/_posts/2020/2020-08-11-bulmatown-theme-and-snipcart.md
@@ -3,6 +3,7 @@ title: E-commerce on the Jamstack with Bridgetown, Snipcart, and Bulma CSS
 subtitle: A journey into Sparkletown with a short stop for some shopping.
 author: margaret
 category: showcase
+exclude_from_search: true
 ---
 
 Hello! Guest author [Margaret](/authors/margaret/) here. This week I tried out the new [Bulmatown](https://github.com/whitefusionhq/bulmatown){:rel="noopener"} theme and experimented with adding products using [Snipcart](https://snipcart.com/){:rel="noopener"}. My test site is deployed **[here](https://vigorous-ritchie-f43dbd.netlify.app/){:rel="noopener"}** via Netlify, and you can take a closer look at the code **[here](https://github.com/codemargaret/sparkletown){:rel="noopener"}**.

--- a/bridgetown-website/src/_posts/2020/2020-08-25-midsummer-2020-plugin-roundup.md
+++ b/bridgetown-website/src/_posts/2020/2020-08-25-midsummer-2020-plugin-roundup.md
@@ -3,6 +3,7 @@ title: Midsummer 2020 Bridgetown Plugin Roundup
 subtitle: Bridgetown is amazingly useful right out of the box, but add a few plugins and an automation or two, and it sizzles!
 author: jared
 category: showcase
+exclude_from_search: true
 ---
 
 Over the past several months, Bridgetown enthusiasts and open source software developers have been writing plugins and automations to deck out your website with all sorts of new features and enhancements. I thought it was high time we highlight just a few of these in case you missed them previously. **Let's go!**

--- a/bridgetown-website/src/_posts/2021/2021-09-02-roadmap-to-1.0.md
+++ b/bridgetown-website/src/_posts/2021/2021-09-02-roadmap-to-1.0.md
@@ -3,6 +3,7 @@ title: Announcing Bridgetown’s Public Roadmap for 2021-2022
 subtitle: The road to 1.0, plus upcoming opportunities to contribute to that vision to make it a reality.
 author: jared
 category: future
+exclude_from_search: true
 ---
 
 When the Bridgetown project [first launched in April of 2020](https://www.bridgetownrb.com/news/time-to-visit-bridgetown/), the mission was clear: modernize and reimagine Jekyll as an exemplary Jamstack-style Ruby website framework which can compete favorably with the best options on the market.


### PR DESCRIPTION
Resolves #1109 

I set a number of older blog posts to be excluded from search. We may want to exclude anything older than N date in general, perhaps 2024?

Any other places in the documentation where we might want to add a link?