### PR TITLE
Add `bridgetown-sitemap` to website

### DIFF
--- a/bridgetown-website/Gemfile
+++ b/bridgetown-website/Gemfile
@@ -14,6 +14,7 @@ gem "puma", "< 7"
 gem "bridgetown-feed", "~> 4"
 gem "bridgetown-quick-search", "~> 3.0"
 gem "bridgetown-seo-tag", "~> 7.0"
+gem "bridgetown-sitemap", "~> 3.0"
 gem "bridgetown-svg-inliner", "~> 2.1"
 
 gem "gems", "~> 1.2"

--- a/bridgetown-website/Gemfile.lock
+++ b/bridgetown-website/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       bridgetown (>= 1.2.0.beta2, < 3.0)
     bridgetown-seo-tag (7.0.1)
       bridgetown (>= 1.3)
+    bridgetown-sitemap (3.0.3)
+      bridgetown (>= 1.3.0, < 3.0)
     bridgetown-svg-inliner (2.1.1)
       bridgetown (>= 1.2.0, < 3.0)
       csv
@@ -191,6 +193,7 @@ DEPENDENCIES
   bridgetown-paginate!
   bridgetown-quick-search (~> 3.0)
   bridgetown-seo-tag (~> 7.0)
+  bridgetown-sitemap (~> 3.0)
   bridgetown-svg-inliner (~> 2.1)
   gems (~> 1.2)
   nokolexbor (~> 0.4)

--- a/bridgetown-website/config/initializers.rb
+++ b/bridgetown-website/config/initializers.rb
@@ -6,6 +6,7 @@ Bridgetown.configure do |config|
   init :"bridgetown-feed"
   init :"bridgetown-quick-search"
   init :"bridgetown-svg-inliner"
+  init :"bridgetown-sitemap"
 
   config.inflector.configure do |inflections|
     inflections.acronym "W3C"


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've read our Contributing Guide, including the section regarding
  AI-generated code. (TL;DR: we do not accept AI-generated code. ☺️)

  https://github.com/bridgetownrb/bridgetown/blob/main/CONTRIBUTING.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Adds the `bridgetown-sitemap` gem to the Bridgetown website.

<img width="1356" height="723" alt="Screen Shot 2026-06-04 at 7 43 12 AM" src="https://github.com/user-attachments/assets/a93451d8-b94a-4c30-a83c-511913a10cf5" />

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Resolves #1106 
