### PR TITLE
Refactor live reload into class

### DIFF
--- a/bridgetown-core/lib/bridgetown-core/rack/live_reload.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/live_reload.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/RedundantBegin, Style/RedundantSelf
+module Bridgetown
+  module Rack
+    class LiveReload
+      SLEEP_INTERVAL = 0.5
+
+      def initialize(file_to_check:, errors_file:)
+        @file_to_check = file_to_check
+        @errors_file = errors_file
+
+        @last_modified = self.current_modified
+      end
+
+      def event_stream
+        proc do |stream|
+          begin
+            run_loop(stream)
+          ensure
+            stream.close
+          end
+        end
+      end
+
+      def threaded_event_stream
+        proc do |stream|
+          Thread.new do
+            run_loop(stream)
+          ensure
+            stream.close
+          end
+        end
+      end
+
+      private
+
+      def run_loop(stream)
+        loop do
+          latest_modified = current_modified
+
+          if @last_modified < latest_modified
+            stream.write "data: reloaded!\n\n"
+            break
+          elsif File.exist?(@errors_file)
+            stream.write "event: builderror\ndata: #{File.read(@errors_file).to_json}\n\n"
+          else
+            stream.write "data: #{latest_modified}\n\n"
+          end
+
+          sleep SLEEP_INTERVAL
+        rescue Errno::EPIPE # User refreshed the page
+          break
+        end
+      end
+
+      def current_modified
+        File.exist?(@file_to_check) ? File.stat(@file_to_check).mtime.to_i : 0
+      end
+    end
+  end
+end
+# rubocop:enable Style/RedundantBegin, Style/RedundantSelf

--- a/bridgetown-core/lib/bridgetown-core/rack/routes.rb
+++ b/bridgetown-core/lib/bridgetown-core/rack/routes.rb
@@ -109,52 +109,29 @@ module Bridgetown
         end
 
         # @param app [Roda]
-        def setup_live_reload(app) # rubocop:disable Metrics
-          sleep_interval = 0.5
+        def setup_live_reload(app)
+          require_relative "live_reload"
+
           file_to_check = Bridgetown.live_reload_path
           errors_file = Bridgetown.build_errors_path
+          live_reload = Bridgetown::Rack::LiveReload.new(
+            file_to_check: file_to_check,
+            errors_file: errors_file
+          )
 
-          # rubocop:disable Metrics/BlockLength
           app.request.get "_bridgetown/live_reload" do
-            @_mod = File.exist?(file_to_check) ? File.stat(file_to_check).mtime.to_i : 0
-            event_stream = proc do |stream|
-              # We don't need to do this when using Falcon.
-              # Puma hangs with Ctrl+C without this manual interruption.
-              # Very very hacky, but it's only in dev.
-              # https://github.com/puma/puma/issues/3569
-              unless defined? Falcon
-                trap(:INT) do
-                  stream.close
-                  raise Interrupt
-                end
+            event_stream =
+              if defined? Falcon
+                live_reload.event_stream
+              else
+                live_reload.threaded_event_stream
               end
-
-              loop do
-                new_mod = File.exist?(file_to_check) ? File.stat(file_to_check).mtime.to_i : 0
-
-                if @_mod < new_mod
-                  stream.write "data: reloaded!\n\n"
-                  break
-                elsif File.exist?(errors_file)
-                  stream.write "event: builderror\ndata: #{File.read(errors_file).to_json}\n\n"
-                else
-                  stream.write "data: #{new_mod}\n\n"
-                end
-
-                sleep sleep_interval
-              rescue Errno::EPIPE # User refreshed the page
-                break
-              end
-            ensure
-              stream.close
-            end
 
             app.request.halt [200, {
               "Content-Type"  => "text/event-stream",
               "cache-control" => "no-cache",
             }, event_stream,]
           end
-          # rubocop:enable Metrics/BlockLength
         end
       end
 


### PR DESCRIPTION
This fixes the error message when terminating a Puma server in v2.2.

> Error reached top of thread-pool: Socket timeout writing data (Puma::ConnectionError)

This error is logged directly to STDERR by Puma. The old technique of spawning a new thread for live reloads worked without logging this error. A new thread isn't needed for Falcon so I'm reluctant to have it work that way across the board. However, refactoring the live reload logic into its own class allows us to cleaning run it in more than one execution paradigm.

I've set it up to spawn a new thread for all servers except Falcon. If we ever wanted to add more paradigms like Fibers or Ractors, this structure allows us to do that.