### PR TITLE
Pass options to roda sessions plugin

### DIFF
--- a/bridgetown-core/lib/roda/plugins/bridgetown_ssr.rb
+++ b/bridgetown-core/lib/roda/plugins/bridgetown_ssr.rb
@@ -36,7 +36,7 @@ class Roda
                 "RODA_SECRET_KEY variable"
         end
 
-        app.plugin :sessions, secret: secret_key
+        app.plugin :sessions, secret: secret_key, **sessions_options(opts)
         app.plugin :flashier
       end
 
@@ -44,6 +44,24 @@ class Roda
         app.include Bridgetown::Filters::URLFilters
         app.opts[:bridgetown_site] =
           Bridgetown::Site.start_ssr!(loaders_manager: Bridgetown::Rack.loaders_manager, &)
+      end
+
+      # Transforms opts[:sessions] into a hash that can be passed into the
+      # sessions plugin as keyword args.
+      #
+      # @param opts [Hash] argument of .load_dependencies
+      # @return [Hash{Symbol => Object}]
+      private_class_method def self.sessions_options(opts)
+        if opts[:sessions].is_a?(Hash)
+          # Roda expects symbol keys, even for a nested hash such as :cookie_options
+          opts[:sessions]
+            .transform_keys(&:to_sym)
+            .transform_values do |value|
+              value.is_a?(Hash) ? value.transform_keys(&:to_sym) : value
+            end
+        else # i.e. opts[:sessions] == true
+          {}
+        end
       end
     end
 

--- a/bridgetown-core/lib/site_template/config/initializers.rb
+++ b/bridgetown-core/lib/site_template/config/initializers.rb
@@ -68,7 +68,8 @@ Bridgetown.configure do |config|
   #
   # init :ssr
   #
-  # Add `sessions: true` if you need to use session data, flash, etc.
+  # Add `sessions: true` if you need to use session data, flash, etc. Pass a
+  # hash instead of `true` if you need to set options for the Roda sessions plugin.
   #
 
   # Uncomment to use file-based dynamic template routing via Roda (make sure you

--- a/bridgetown-core/test/ssr/config/local_ssr_init.rb
+++ b/bridgetown-core/test/ssr/config/local_ssr_init.rb
@@ -2,7 +2,7 @@
 
 Bridgetown.initializer :local_ssr_init do |config|
   config.init :ssr do
-    sessions true
+    sessions cookie_options: { same_site: :strict }
     setup -> site do # rubocop:disable Layout/SpaceInLambdaLiteral, Style/StabbyLambdaParentheses
       site.data.iterations ||= 0
       site.data.iterations += 1

--- a/bridgetown-core/test/test_ssr.rb
+++ b/bridgetown-core/test/test_ssr.rb
@@ -141,5 +141,9 @@ class TestSSR < BridgetownUnitTest
     ensure
       site.config.base_path = original_base_path
     end
+
+    it "applies custom session options passed as a hash" do
+      expect(app.opts.dig(:sessions, :cookie_options, :same_site)) == :strict
+    end
   end
 end

--- a/bridgetown-website/src/_docs/configuration/initializers.md
+++ b/bridgetown-website/src/_docs/configuration/initializers.md
@@ -252,6 +252,8 @@ The SSR features of Bridgetown, along with its companion file-based routing feat
 
 ```rb
 init :ssr, sessions: true # the dotenv initializer is also recommended, more on that below
+# or if you need to set options on the sessions plugin, pass a hash:
+# init :ssr, sessions: { key: "my_app.session", cookie_options: { same_site: :strict } }
 
 # optional:
 init :"bridgetown-routes"

--- a/bridgetown-website/src/_docs/roda.md
+++ b/bridgetown-website/src/_docs/roda.md
@@ -47,7 +47,7 @@ If you add `init :ssr` to your [Initializers](/docs/configuration/initializers) 
 * [custom_block_results](https://roda.jeremyevans.net/rdoc/classes/Roda/RodaPlugins/CustomBlockResults.html) - lets Roda route blocks return arbitrary objects which can be processed with custom handlers. We use this to enable our [RodaCallable](/docs/routes#callable-objects-for-rendering-within-blocks) functionality
 * `method_override` - this Bridgetown-supplied plugin looks for the presence of a `_method` form param and will use that to override the incoming HTTP request method. Thus even if a form comes in as POST, if `_method` equals `PUT` the request method will be `PUT`.
 
-If you pass `sessions: true` to the `ssr` initializer in your config, you'll get these plugins added:
+If you pass `sessions: true` to the `ssr` initializer in your config, you'll get the below plugins added. Pass a hash instead of `true` if you need to set options for the sessions plugin.
 
 * [sessions](https://roda.jeremyevans.net/rdoc/classes/Roda/RodaPlugins/Sessions.html) - adds support for cookie-based session storage (aka a small amount of key-val data storage which persists across requests for a single client). You'll need to have `RODA_SECRET_KEY` defined in your environment. To make this easy in local development, you should set up the [Dotenv gem](/docs/configuration/initializers#dotenv). Setting up a secret key is a matter of running `bin/bridgetown secret` and then copying the key to `RODA_SECRET_KEY`.
 * [flash](https://roda.jeremyevans.net/rdoc/classes/Roda/RodaPlugins/Flash.html) - provides a `flash` object you can access from both routes and view templates.

--- a/bridgetown-website/src/_docs/routes.md
+++ b/bridgetown-website/src/_docs/routes.md
@@ -15,6 +15,7 @@ However, to take full advantage of all the Bridgetown has to offer, we recommend
 
 ```rb
 init :ssr # add `sessions: true` if you want to save session data, use flash, etc.
+# (pass a hash instead of `true` if you need to set options for the sessions plugin)
 # or:
 init :"bridgetown-routes" # inits ssr automatically
 ```
@@ -256,7 +257,7 @@ See [Ruby Front Matter](/docs/front-matter#the-power-of-ruby-in-front-matter) fo
 The Roda block also excepts a couple of different styles of specifying front matter. You can use `render_with do ... end` as in the examples above, but you can also use a data hash instead:
 
 ```ruby
-hsh = { layout: :page, title: "I'm a Page!" } 
+hsh = { layout: :page, title: "I'm a Page!" }
 
 render_with(data: hsh)
 ```
@@ -323,7 +324,7 @@ class MyRssFeed
 
     response["Content-Type"] = "application/rss+xml" # set the correct content type
     feed_xml # return XML string
-  end  
+  end
 end
 ```
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've read our Contributing Guide, including the section regarding
  AI-generated code. (TL;DR: we do not accept AI-generated code. ☺️)

  https://github.com/bridgetownrb/bridgetown/blob/main/CONTRIBUTING.md
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Allows options to be passed to the Roda sessions plugin.

Currently, the sessions plugin can be included like this:

```ruby
init :ssr, sessions: true
```

This PR allows a hash to be passed instead of `true`, containing options for the sessions plugin:

```ruby
init :ssr, sessions: { key: "my_app.session", cookie_options: { same_site: :strict } }
```

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Resolves #1115
